### PR TITLE
feat(settings): functional account/team management + critical FK fix

### DIFF
--- a/frontend/app/api/contact/calendar/client-events/route.ts
+++ b/frontend/app/api/contact/calendar/client-events/route.ts
@@ -77,10 +77,13 @@ export async function GET(req: Request) {
       return NextResponse.json({ error: directorsErr.message }, { status: 500 });
     }
 
-    // 4) Also get the client/owner email for attendee filtering
+    // 4) Also get the client/owner email for attendee filtering.
+    // Disambiguate the join: project_members has two FKs to profiles
+    // (profile_id and assigned_by); without the explicit constraint name
+    // PostgREST refuses the embed.
     const { data: ownerMember } = await supabaseAdmin
       .from("project_members")
-      .select("profile_id, profiles(email)")
+      .select("profile_id, profiles!project_members_profile_id_fkey(email)")
       .eq("project_id", projectId)
       .eq("role", "owner")
       .single();

--- a/frontend/app/dashboard/files/DragOverlay.tsx
+++ b/frontend/app/dashboard/files/DragOverlay.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { motion } from "motion/react";
+import { File as FileIcon, Folder } from "lucide-react";
+
+export interface DragOverlayCardProps {
+    name: string;
+    kind: "file" | "folder";
+}
+
+/**
+ * Ghost card rendered inside @dnd-kit's <DragOverlay> while an item is being
+ * dragged. Matches the FolderCard/FileCard shell so the dragged item reads as
+ * "lifted": same border/padding, plus a slight scale, stronger shadow and a
+ * faint green ring.
+ */
+export default function DragOverlayCard({ name, kind }: DragOverlayCardProps) {
+    const Icon = kind === "folder" ? Folder : FileIcon;
+
+    return (
+        <motion.div
+            initial={{ scale: 1 }}
+            animate={{ scale: 1.03 }}
+            transition={{ type: "spring", stiffness: 420, damping: 28 }}
+            className="flex min-h-[3.75rem] w-[220px] cursor-grabbing items-center gap-3 overflow-hidden rounded-lg border border-sbi-dark-border/50 bg-sbi-dark-card/90 px-4 py-3 opacity-90 scale-[1.03] shadow-2xl ring-1 ring-sbi-green/30 backdrop-blur-sm"
+        >
+            <Icon className="h-4 w-4 shrink-0 text-sbi-green/70" />
+            <span
+                className="truncate text-sm font-medium leading-none text-white"
+                title={name}
+            >
+                {name}
+            </span>
+        </motion.div>
+    );
+}

--- a/frontend/app/dashboard/files/FileCard.tsx
+++ b/frontend/app/dashboard/files/FileCard.tsx
@@ -1,50 +1,146 @@
-import { createClient } from "@supabase/supabase-js";
+"use client";
+
+import { useState } from "react";
+import { useDraggable } from "@dnd-kit/core";
+import {
+    FileText,
+    FileImage,
+    FileSpreadsheet,
+    FileCode2,
+    FileArchive,
+    FileVideo,
+    FileAudio,
+    File as FileIcon,
+    Eye,
+    Download,
+    ExternalLink,
+    Pencil,
+    Trash2,
+    type LucideIcon,
+} from "lucide-react";
+import { createClient } from "@/lib/supabase/client";
+import { toastError } from "@/lib/notifications";
+import { Modal } from "@/components/dashboard/common/Modal";
 
 interface FileCardProps {
     name: string;
     folderPath: string;
+    draggableId: string;
     updatedAt?: string | null;
+    canManage?: boolean;
+    onRename?: () => void;
+    onDelete?: () => void;
 }
 
-const supabase = createClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!,
-);
+type PreviewKind = "image" | "pdf" | "video" | "audio" | "other";
 
-export default function FileCard({ name, folderPath, updatedAt }: FileCardProps) {
-    const getSignedUrl = async () => {
+const supabase = createClient();
+
+function extOf(name: string): string {
+    return name.split(".").pop()?.toLowerCase() ?? "";
+}
+
+function iconForExtension(name: string): LucideIcon {
+    const ext = extOf(name);
+    if (["png", "jpg", "jpeg", "gif", "webp", "svg", "heic", "avif"].includes(ext)) return FileImage;
+    if (["pdf", "doc", "docx", "rtf", "txt", "md"].includes(ext)) return FileText;
+    if (["xls", "xlsx", "csv", "numbers"].includes(ext)) return FileSpreadsheet;
+    if (["js", "ts", "tsx", "jsx", "json", "yml", "yaml", "html", "css"].includes(ext)) return FileCode2;
+    if (["zip", "rar", "7z", "tar", "gz"].includes(ext)) return FileArchive;
+    if (["mp4", "mov", "avi", "mkv", "webm"].includes(ext)) return FileVideo;
+    if (["mp3", "wav", "ogg", "m4a", "flac"].includes(ext)) return FileAudio;
+    return FileIcon;
+}
+
+// What can render inline in a browser, vs. needs a download/new-tab fallback.
+function previewKind(name: string): PreviewKind {
+    const ext = extOf(name);
+    if (["png", "jpg", "jpeg", "gif", "webp", "svg", "avif"].includes(ext)) return "image";
+    if (ext === "pdf") return "pdf";
+    if (["mp4", "webm", "ogg", "mov"].includes(ext)) return "video";
+    if (["mp3", "wav", "m4a", "flac"].includes(ext)) return "audio";
+    return "other";
+}
+
+export default function FileCard({
+    name,
+    folderPath,
+    draggableId,
+    updatedAt,
+    canManage = false,
+    onRename,
+    onDelete,
+}: FileCardProps) {
+    const Icon = iconForExtension(name);
+    const kind = previewKind(name);
+
+    const {
+        attributes,
+        listeners,
+        setNodeRef: setDragRef,
+        isDragging,
+    } = useDraggable({
+        id: `drag:file:${draggableId}`,
+        data: { kind: "file", name, path: draggableId },
+        disabled: !canManage,
+    });
+
+    const [previewOpen, setPreviewOpen] = useState(false);
+    const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+    const [loadingPreview, setLoadingPreview] = useState(false);
+
+    // Longer TTL so a preview (esp. video) doesn't expire mid-view.
+    // `download` makes Supabase set Content-Disposition: attachment via the
+    // signed URL itself — never string-append `?download`, the URL already
+    // carries a `?token=` query and a second `?` corrupts the JWT.
+    const getSignedUrl = async (
+        opts?: { download?: string },
+        expiresIn = 3600,
+    ): Promise<string | null> => {
         const fullPath = folderPath ? `${folderPath}/${name}` : name;
-        const { data, error } = await supabase.storage
-            .from("Files")
-            .createSignedUrl(fullPath, 60);
-
-        if (error) {
-            console.error("File URL error:", error);
+        try {
+            const { data, error } = await supabase.storage
+                .from("Files")
+                .createSignedUrl(
+                    fullPath,
+                    expiresIn,
+                    opts?.download ? { download: opts.download } : undefined,
+                );
+            if (error) {
+                console.error("File URL error:", error);
+                toastError(`Couldn't open ${name}. ${error.message ?? "Please try again."}`);
+                return null;
+            }
+            return data.signedUrl;
+        } catch (err) {
+            console.error("Unexpected file URL error:", err);
+            toastError(`Couldn't open ${name}.`);
             return null;
         }
-
-        return data.signedUrl;
     };
 
     const handlePreview = async () => {
+        if (loadingPreview) return;
+        setLoadingPreview(true);
         const signedUrl = await getSignedUrl();
-        if (!signedUrl) {
-            return;
-        }
+        setLoadingPreview(false);
+        if (!signedUrl) return;
+        setPreviewUrl(signedUrl);
+        setPreviewOpen(true);
+    };
 
-        window.open(signedUrl, "_blank", "noopener,noreferrer");
+    const handleOpenInNewTab = () => {
+        if (previewUrl) window.open(previewUrl, "_blank", "noopener,noreferrer");
     };
 
     const handleDownload = async () => {
-        const signedUrl = await getSignedUrl();
-        if (!signedUrl) {
-            return;
-        }
-        // Append the download parameter to the signed URL
-        const downloadUrl = `${signedUrl}?download`;
-        
+        // Always mint a fresh signed URL with the download disposition — the
+        // inline previewUrl renders in-tab and has no attachment header.
+        const signedUrl = await getSignedUrl({ download: name });
+        if (!signedUrl) return;
+
         const link = document.createElement("a");
-        link.href = downloadUrl;
+        link.href = signedUrl;
         link.download = name;
         document.body.appendChild(link);
         link.click();
@@ -60,27 +156,149 @@ export default function FileCard({ name, folderPath, updatedAt }: FileCardProps)
         : "Unknown";
 
     return (
-        <div className="border border-sbi-dark-border rounded-lg p-6 hover:border-sbi-green transition bg-sbi-dark-secondary">
-            <div className="text-sm font-medium mb-2 truncate">{name}</div>
-            <div className="text-xs text-sbi-muted-dark mb-5">
-                Last modified: {formattedDate}
-            </div>
-            <div className="flex items-center gap-3">
-                <button
-                    type="button"
-                    onClick={handlePreview}
-                    className="px-3 py-1.5 text-xs rounded border border-sbi-dark-border hover:border-sbi-green hover:text-sbi-green transition"
+        <>
+            <div
+                ref={setDragRef}
+                {...(canManage ? listeners : {})}
+                className={`group relative flex min-h-[3.75rem] items-center gap-3 overflow-hidden border border-sbi-dark-border/50 rounded-lg px-4 py-3 hover:border-sbi-green/40 transition-colors bg-sbi-dark-card/40 ${
+                    canManage
+                        ? isDragging
+                            ? "opacity-40 cursor-grabbing"
+                            : "cursor-grab"
+                        : ""
+                }`}
+            >
+                <Icon className="h-4 w-4 text-sbi-muted shrink-0" />
+                <div
+                    className="min-w-0 flex-1"
+                    {...(canManage ? attributes : {})}
                 >
-                    Preview
-                </button>
-                <button
-                    type="button"
-                    onClick={handleDownload}
-                    className="px-3 py-1.5 text-xs rounded border border-sbi-dark-border hover:border-sbi-green hover:text-sbi-green transition"
-                >
-                    Download
-                </button>
+                    <div className="text-sm font-medium text-white truncate" title={name}>
+                        {name}
+                    </div>
+                    <div className="text-xs text-sbi-muted">{formattedDate}</div>
+                </div>
+                {/* Actions sit over the row's right edge on an opaque fade so
+                    the filename stays crisp (never blurred) and just runs
+                    under them when long. Single opacity reveal — no scale,
+                    no stagger, no layout animation. */}
+                <div className="pointer-events-none absolute inset-y-0 right-0 z-10 flex items-center gap-1 pl-8 pr-3 bg-gradient-to-l from-sbi-dark-card via-sbi-dark-card to-transparent opacity-0 transition-opacity duration-150 group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:opacity-100">
+                    <button
+                        type="button"
+                        onClick={handlePreview}
+                        disabled={loadingPreview}
+                        aria-label={`Preview ${name}`}
+                        title="Preview"
+                        className="cursor-pointer p-1.5 rounded-md text-sbi-muted hover:text-white hover:bg-white/5 disabled:opacity-50 disabled:cursor-default transition-colors"
+                    >
+                        {loadingPreview ? (
+                            <span className="block h-4 w-4 rounded-full border-2 border-sbi-muted border-t-transparent animate-spin" />
+                        ) : (
+                            <Eye className="h-4 w-4" />
+                        )}
+                    </button>
+                    <button
+                        type="button"
+                        onClick={handleDownload}
+                        aria-label={`Download ${name}`}
+                        title="Download"
+                        className="cursor-pointer p-1.5 rounded-md text-sbi-muted hover:text-white hover:bg-white/5 transition-colors"
+                    >
+                        <Download className="h-4 w-4" />
+                    </button>
+                    {canManage ? (
+                        <>
+                            <button
+                                type="button"
+                                onClick={onRename}
+                                aria-label={`Rename ${name}`}
+                                title="Rename"
+                                className="cursor-pointer p-1.5 rounded-md text-sbi-muted hover:text-white hover:bg-white/5 transition-colors"
+                            >
+                                <Pencil className="h-4 w-4" />
+                            </button>
+                            <button
+                                type="button"
+                                onClick={onDelete}
+                                aria-label={`Delete ${name}`}
+                                title="Delete"
+                                className="cursor-pointer p-1.5 rounded-md text-sbi-muted hover:text-red-400 hover:bg-red-500/10 transition-colors"
+                            >
+                                <Trash2 className="h-4 w-4" />
+                            </button>
+                        </>
+                    ) : null}
+                </div>
             </div>
-        </div>
+
+            <Modal
+                opened={previewOpen}
+                onClose={() => setPreviewOpen(false)}
+                title={name}
+                uppercaseTitle={false}
+                size="xl"
+                padded={false}
+                headerActions={
+                    <>
+                        <button
+                            type="button"
+                            onClick={handleOpenInNewTab}
+                            className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs rounded-md text-sbi-muted hover:text-white hover:bg-white/5 transition-colors"
+                        >
+                            <ExternalLink className="h-3.5 w-3.5" /> Open in new tab
+                        </button>
+                        <button
+                            type="button"
+                            onClick={handleDownload}
+                            className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs rounded-md border border-sbi-green/30 bg-sbi-green/10 text-sbi-green hover:bg-sbi-green hover:text-sbi-dark transition-colors"
+                        >
+                            <Download className="h-3.5 w-3.5" /> Download
+                        </button>
+                    </>
+                }
+            >
+                <div className="p-4">
+                    {previewUrl && kind === "image" && (
+                        // eslint-disable-next-line @next/next/no-img-element
+                        <img
+                            src={previewUrl}
+                            alt={name}
+                            className="mx-auto max-h-[75vh] w-auto object-contain"
+                        />
+                    )}
+                    {previewUrl && kind === "pdf" && (
+                        <iframe
+                            src={previewUrl}
+                            title={name}
+                            className="w-full h-[78vh] rounded-md bg-white"
+                        />
+                    )}
+                    {previewUrl && kind === "video" && (
+                        <video
+                            src={previewUrl}
+                            controls
+                            autoPlay
+                            className="mx-auto max-h-[78vh] w-full rounded-md bg-sbi-dark"
+                        />
+                    )}
+                    {previewUrl && kind === "audio" && (
+                        <div className="py-16">
+                            <audio src={previewUrl} controls className="w-full" />
+                        </div>
+                    )}
+                    {kind === "other" && (
+                        <div className="flex flex-col items-center justify-center gap-3 py-20 text-center">
+                            <FileIcon className="h-10 w-10 text-sbi-muted-dark" />
+                            <p className="text-sm text-white">
+                                This file type can&apos;t be previewed here.
+                            </p>
+                            <p className="text-xs text-sbi-muted max-w-sm">
+                                Use Download or Open in new tab to view it.
+                            </p>
+                        </div>
+                    )}
+                </div>
+            </Modal>
+        </>
     );
 }

--- a/frontend/app/dashboard/files/FolderCard.tsx
+++ b/frontend/app/dashboard/files/FolderCard.tsx
@@ -1,17 +1,116 @@
+"use client";
+
+import { useDraggable, useDroppable } from "@dnd-kit/core";
+import { Folder, Pencil, Trash2 } from "lucide-react";
+import { isInvalidMoveTarget } from "./storage";
+
 interface FolderCardProps {
     name: string;
+    draggableId: string;
+    droppableId: string;
     onOpen: () => void;
+    canManage?: boolean;
+    onRename?: () => void;
+    onDelete?: () => void;
 }
 
-export default function FolderCard({ name, onOpen }: FolderCardProps) {
+export default function FolderCard({
+    name,
+    draggableId,
+    droppableId,
+    onOpen,
+    canManage = false,
+    onRename,
+    onDelete,
+}: FolderCardProps) {
+    const {
+        attributes,
+        listeners,
+        setNodeRef: setDragRef,
+        isDragging,
+    } = useDraggable({
+        id: `drag:folder:${draggableId}`,
+        data: { kind: "folder", name, path: draggableId },
+        disabled: !canManage,
+    });
+
+    const { setNodeRef: setDropRef, isOver, active } = useDroppable({
+        id: `drop:grid:${droppableId}`,
+        data: { kind: "folder", name, path: droppableId },
+    });
+
+    // Only highlight as a drop target when a drop here would actually move
+    // something — not onto itself, its own subtree, or its current parent.
+    const activeData = active?.data.current as
+        | { kind?: "file" | "folder"; path?: string }
+        | undefined;
+    const showDropRing =
+        isOver &&
+        !!activeData?.path &&
+        !!activeData.kind &&
+        !isInvalidMoveTarget(activeData.path, activeData.kind, droppableId);
+
+    const setNodeRef = (el: HTMLElement | null) => {
+        setDragRef(el);
+        setDropRef(el);
+    };
+
     return (
-        <button
-            type="button"
-            onClick={onOpen}
-            className="w-full text-left border border-sbi-dark-border rounded-lg p-6 hover:border-sbi-green transition bg-sbi-dark-secondary"
+        <div
+            ref={setNodeRef}
+            {...(canManage ? listeners : {})}
+            className={`group relative flex min-h-[3.75rem] items-center gap-3 overflow-hidden border rounded-lg px-4 py-3 transition-colors ${
+                canManage
+                    ? isDragging
+                        ? "opacity-40 cursor-grabbing"
+                        : "cursor-grab"
+                    : ""
+            } ${
+                showDropRing
+                    ? "ring-1 ring-inset ring-sbi-green/40 border-sbi-green/40 bg-sbi-dark-card/70"
+                    : "border-sbi-dark-border/50 hover:border-sbi-green/40 bg-sbi-dark-card/40 hover:bg-sbi-dark-card/60"
+            }`}
         >
-            <div className="text-sm font-medium mb-2 truncate">{name}</div>
-            <div className="text-xs text-sbi-muted-dark">Folder</div>
-        </button>
+            <button
+                type="button"
+                onClick={onOpen}
+                title={name}
+                className={`flex min-w-0 flex-1 items-center gap-3 text-left ${
+                    canManage
+                        ? isDragging
+                            ? "cursor-grabbing"
+                            : "cursor-grab"
+                        : "cursor-pointer"
+                }`}
+                {...(canManage ? attributes : {})}
+            >
+                <Folder className="h-4 w-4 text-sbi-muted shrink-0" />
+                <span className="text-sm font-medium text-white truncate leading-none">
+                    {name}
+                </span>
+            </button>
+            {canManage ? (
+                <div className="pointer-events-none absolute inset-y-0 right-0 z-10 flex items-center gap-1 pl-8 pr-3 bg-gradient-to-l from-sbi-dark-card via-sbi-dark-card to-transparent opacity-0 transition-opacity duration-150 group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:opacity-100">
+                    <button
+                        type="button"
+                        onClick={onRename}
+                        aria-label={`Rename ${name}`}
+                        title="Rename"
+                        className="cursor-pointer p-1.5 rounded-md text-sbi-muted hover:text-white hover:bg-white/5 transition-colors"
+                    >
+                        <Pencil className="h-4 w-4" />
+                    </button>
+                    <button
+                        type="button"
+                        onClick={onDelete}
+                        aria-label={`Delete ${name}`}
+                        title="Delete"
+                        className="cursor-pointer p-1.5 rounded-md text-sbi-muted hover:text-red-400 hover:bg-red-500/10 transition-colors"
+                    >
+                        <Trash2 className="h-4 w-4" />
+                    </button>
+                </div>
+            ) : null}
+        </div>
     );
 }

--- a/frontend/app/dashboard/files/TreeNode.tsx
+++ b/frontend/app/dashboard/files/TreeNode.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useDroppable } from "@dnd-kit/core";
+import { AnimatePresence, motion } from "motion/react";
+import { ChevronRight, Folder, FolderOpen } from "lucide-react";
+import { isInvalidMoveTarget } from "./storage";
+
+export interface FolderNode {
+    name: string;
+    path: string;
+    // Tri-state: undefined = unknown (lazy, show chevron until proven empty),
+    // true = has child folders, false = confirmed leaf (hide chevron).
+    hasSubfolders?: boolean;
+    children?: FolderNode[];
+}
+
+interface TreeNodeProps {
+    node: FolderNode;
+    level: number;
+    expandedPaths: Set<string>;
+    selectedFolderPath: string;
+    onNodeClick: (node: FolderNode) => void;
+}
+
+/**
+ * One tree row + its (animated) child subtree. Extracted verbatim from the
+ * former inline `renderTree`, with a @dnd-kit drop target wired to the folder's
+ * full path. While a dragged item hovers, the row highlights and — if the
+ * folder is collapsed and may have children — a 600ms spring-expand timer
+ * opens it (Google-Drive style).
+ */
+export default function TreeNode({
+    node,
+    level,
+    expandedPaths,
+    selectedFolderPath,
+    onNodeClick,
+}: TreeNodeProps) {
+    const isExpanded = expandedPaths.has(node.path);
+    const isSelected = selectedFolderPath === node.path;
+    // Chevron only for folders confirmed to have subfolders.
+    const canExpand = node.hasSubfolders === true;
+
+    const open = isExpanded || isSelected;
+    const FolderGlyph = open ? FolderOpen : Folder;
+
+    const { setNodeRef, isOver, active } = useDroppable({
+        id: `drop:tree:${node.path}`,
+        data: { kind: "folder", name: node.name, path: node.path },
+    });
+
+    // Only treat this row as a live drop target when the drop would actually
+    // move something (not onto itself / its own subtree / its current parent).
+    const activeData = active?.data.current as
+        | { kind?: "file" | "folder"; path?: string }
+        | undefined;
+    const isValidTarget =
+        isOver &&
+        !!activeData?.path &&
+        !!activeData.kind &&
+        !isInvalidMoveTarget(activeData.path, activeData.kind, node.path);
+
+    // v2: spring-expand on hover-while-collapsed. `onNodeClick` and `node`
+    // get new identities on every parent re-render / tree refresh; keep
+    // them in refs so the effect (and its 600ms timer) only re-subscribes
+    // on the values that actually matter, instead of resetting mid-hover.
+    const onNodeClickRef = useRef(onNodeClick);
+    onNodeClickRef.current = onNodeClick;
+    const nodeRef = useRef(node);
+    nodeRef.current = node;
+
+    const expandTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+    useEffect(() => {
+        if (
+            isValidTarget &&
+            !isExpanded &&
+            node.hasSubfolders !== false &&
+            expandTimer.current === null
+        ) {
+            expandTimer.current = setTimeout(() => {
+                expandTimer.current = null;
+                onNodeClickRef.current(nodeRef.current);
+            }, 600);
+        }
+        if ((!isValidTarget || isExpanded) && expandTimer.current !== null) {
+            clearTimeout(expandTimer.current);
+            expandTimer.current = null;
+        }
+        return () => {
+            if (expandTimer.current !== null) {
+                clearTimeout(expandTimer.current);
+                expandTimer.current = null;
+            }
+        };
+    }, [isValidTarget, isExpanded, node.path, node.hasSubfolders]);
+
+    return (
+        <li>
+            <button
+                ref={setNodeRef}
+                type="button"
+                onClick={() => onNodeClick(node)}
+                aria-expanded={canExpand ? isExpanded : undefined}
+                className={`group flex w-full cursor-pointer items-center gap-1.5 rounded-md px-2 py-1.5 text-left transition-colors duration-150 ${
+                    isValidTarget
+                        ? "border border-sbi-green/40 bg-sbi-green/10 [animation:sbiDragPulse_1.1s_ease-in-out_infinite]"
+                        : "border border-transparent"
+                } ${
+                    isSelected
+                        ? "bg-sbi-green/10 text-sbi-green"
+                        : "text-sbi-muted hover:text-white hover:bg-white/[0.03]"
+                }`}
+            >
+                {canExpand ? (
+                    <ChevronRight
+                        className={`size-3.5 shrink-0 text-sbi-muted-dark group-hover:text-current transition-transform duration-200 ${
+                            isExpanded ? "rotate-90" : ""
+                        }`}
+                    />
+                ) : (
+                    <span className="size-3.5 shrink-0" />
+                )}
+                <FolderGlyph
+                    className={`size-4 shrink-0 transition-colors ${
+                        isSelected
+                            ? "text-sbi-green"
+                            : "text-sbi-muted group-hover:text-white"
+                    }`}
+                />
+                <span className="flex-1 truncate leading-none">
+                    {node.name}
+                </span>
+            </button>
+            <AnimatePresence initial={false}>
+                {canExpand &&
+                isExpanded &&
+                node.children &&
+                node.children.length > 0 ? (
+                    <motion.div
+                        key="children"
+                        initial={{ height: 0, opacity: 0 }}
+                        animate={{ height: "auto", opacity: 1 }}
+                        exit={{ height: 0, opacity: 0 }}
+                        transition={{ duration: 0.2, ease: [0.22, 1, 0.36, 1] }}
+                        className="overflow-x-visible overflow-y-clip ml-[1.05rem] border-l border-sbi-dark-border/70 pl-2"
+                    >
+                        <ul className="space-y-1 mt-1">
+                            {node.children.map((child) => (
+                                <TreeNode
+                                    key={child.path}
+                                    node={child}
+                                    level={level + 1}
+                                    expandedPaths={expandedPaths}
+                                    selectedFolderPath={selectedFolderPath}
+                                    onNodeClick={onNodeClick}
+                                />
+                            ))}
+                        </ul>
+                    </motion.div>
+                ) : null}
+            </AnimatePresence>
+        </li>
+    );
+}

--- a/frontend/app/dashboard/files/page.tsx
+++ b/frontend/app/dashboard/files/page.tsx
@@ -1,110 +1,197 @@
 "use client";
 
 import { StorageError } from "@supabase/storage-js";
-import { createClient } from "@supabase/supabase-js";
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+    DndContext,
+    DragOverlay,
+    KeyboardSensor,
+    PointerSensor,
+    pointerWithin,
+    useDroppable,
+    useSensor,
+    useSensors,
+} from "@dnd-kit/core";
+import { FolderOpen, FolderPlus, Home, Upload } from "lucide-react";
 import FileCard from "./FileCard";
 import FolderCard from "./FolderCard";
+import TreeNode, { type FolderNode } from "./TreeNode";
+import DragOverlayCard from "./DragOverlay";
+import { useDragMove } from "./useDragMove";
+import {
+    type StorageEntry,
+    deleteFolder,
+    humanizeStorageError,
+    invalidatePath,
+    invalidatePrefix,
+    isFolder,
+    isInvalidMoveTarget,
+    isSentinel,
+    listFolder,
+    moveFolder,
+    moveObject,
+    parentOf,
+    removePaths,
+    uploadFile,
+} from "./storage";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+import { toastError, toastSuccess } from "@/lib/notifications";
+import { useProject } from "@/lib/project/project-context";
+import {
+    DashboardShell,
+    PageHeader,
+    Panel,
+    SectionLabel,
+    EmptyState,
+    Modal,
+    TextField,
+    btnPrimary,
+    btnGhost,
+} from "@/components/dashboard/common/ui";
 
-interface StorageEntry {
-    id: string | null;
-    name: string;
-    updated_at?: string;
+function SkeletonTile() {
+    return (
+        <div className="flex min-h-[3.75rem] items-center gap-3 border border-sbi-dark-border/50 rounded-lg px-4 py-3 bg-sbi-dark-card/30 animate-pulse">
+            <div className="h-4 w-4 bg-white/5 rounded shrink-0" />
+            <div className="min-w-0 flex-1">
+                <div className="h-4 w-3/5 bg-white/5 rounded mb-1.5" />
+                <div className="h-3 w-2/5 bg-white/5 rounded" />
+            </div>
+        </div>
+    );
 }
 
-interface FolderNode {
-    name: string;
-    path: string;
-    hasSubfolders: boolean;
-    children?: FolderNode[];
-}
-
-const supabase = createClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!,
-);
-
-function isFolder(entry: StorageEntry) {
-    return entry.id === null;
+function FolderSkeletonRow() {
+    return (
+        <li>
+            <div className="flex items-center gap-2 px-2 py-1 animate-pulse">
+                <span className="w-4" />
+                <div className="h-3 w-32 bg-white/5 rounded" />
+            </div>
+        </li>
+    );
 }
 
 export default function FilesPage() {
+    const { user } = useProject();
+    const isDirector = user?.role === "director";
+
     const [files, setFiles] = useState<StorageEntry[]>([]);
     const [subfolders, setSubfolders] = useState<FolderNode[]>([]);
     const [folderTree, setFolderTree] = useState<FolderNode[]>([]);
     const [selectedFolderPath, setSelectedFolderPath] = useState<string>("Media");
     const [expandedPaths, setExpandedPaths] = useState<Set<string>>(new Set(["Media"]));
     const [error, setError] = useState<StorageError | null>(null);
+    const [isLoadingTree, setIsLoadingTree] = useState(true);
+    const [isLoadingContents, setIsLoadingContents] = useState(true);
 
-    const folderHasSubfolders = async (folderPath: string): Promise<boolean> => {
-        const { data, error: fetchError } = await supabase.storage
-            .from("Files")
-            .list(folderPath, { limit: 200 });
+    // Write-op UI state
+    const fileInputRef = useRef<HTMLInputElement>(null);
+    const [isUploading, setIsUploading] = useState(false);
+    const [uploadCount, setUploadCount] = useState(0);
+    const [isDragging, setIsDragging] = useState(false);
+    const dragDepth = useRef(0);
 
+    const [newFolderOpen, setNewFolderOpen] = useState(false);
+    const [newFolderName, setNewFolderName] = useState("");
+    const [creatingFolder, setCreatingFolder] = useState(false);
+
+    const [renameTarget, setRenameTarget] = useState<{
+        kind: "file" | "folder";
+        name: string;
+        path: string;
+    } | null>(null);
+    const [renameValue, setRenameValue] = useState("");
+    const [renaming, setRenaming] = useState(false);
+
+    const [deleteTarget, setDeleteTarget] = useState<{
+        kind: "file" | "folder";
+        name: string;
+        path: string;
+    } | null>(null);
+
+    // ---------------------------------------------------------------------
+    // Listing — cache-aware. Tree nodes resolve `hasSubfolders` up front by
+    // probing each child (cached via listFolder, so revisits are free) so the
+    // chevron is accurate immediately and never appears-then-disappears. This
+    // probe is TREE-ONLY; the grid (fetchFolderContents) stays probe-free.
+    // ---------------------------------------------------------------------
+
+    const fetchFolderNodes = async (
+        folderPath: string,
+        force = false,
+    ): Promise<FolderNode[]> => {
+        const { data, error: fetchError } = await listFolder(folderPath, { force });
         if (fetchError) {
-            setError(fetchError);
-            return false;
-        }
-
-        return (data ?? []).some((entry) => isFolder(entry as StorageEntry));
-    };
-
-    const fetchFolderNodes = async (folderPath: string): Promise<FolderNode[]> => {
-        const { data, error: fetchError } = await supabase.storage
-            .from("Files")
-            .list(folderPath, { limit: 100 });
-
-        if (fetchError) {
-            setError(fetchError);
+            setError(new StorageError(fetchError.message));
             return [];
         }
-
-        const folderEntries = (data ?? [])
-            .filter((entry) => isFolder(entry as StorageEntry))
-            .map((folder) => {
-                const path = folderPath ? `${folderPath}/${folder.name}` : folder.name;
-                return { name: folder.name, path };
-            })
+        const folders = data
+            .filter((entry) => isFolder(entry))
+            .map((folder) => ({
+                name: folder.name,
+                path: folderPath ? `${folderPath}/${folder.name}` : folder.name,
+            }))
             .sort((a, b) => a.name.localeCompare(b.name));
 
-        const hasSubfolderChecks = await Promise.all(
-            folderEntries.map(async (folder) => {
-                const hasSubfolders = await folderHasSubfolders(folder.path);
+        return Promise.all(
+            folders.map(async (f) => {
+                const { data: childData } = await listFolder(f.path);
                 return {
-                    name: folder.name,
-                    path: folder.path,
-                    hasSubfolders,
+                    ...f,
+                    hasSubfolders: (childData ?? []).some((e) => isFolder(e)),
                 };
             }),
         );
+    };
 
-        return hasSubfolderChecks;
+    const fetchFolderContents = async (path: string, force = false) => {
+        setIsLoadingContents(true);
+        const { data, error: fetchError } = await listFolder(path, { force });
+
+        if (fetchError) {
+            setError(new StorageError(fetchError.message));
+            setIsLoadingContents(false);
+            return;
+        }
+        setError(null);
+
+        const folderEntries = data.filter((entry) => isFolder(entry));
+        const fileEntries = data.filter(
+            (entry) => !isFolder(entry) && !isSentinel(entry),
+        );
+
+        // No per-subfolder probe — the grid FolderCard never used it.
+        const childFolders: FolderNode[] = folderEntries
+            .map((folder) => ({
+                name: folder.name,
+                path: path ? `${path}/${folder.name}` : folder.name,
+            }))
+            .sort((a, b) => a.name.localeCompare(b.name));
+
+        setSubfolders(childFolders);
+        setFiles(fileEntries);
+        setIsLoadingContents(false);
     };
 
     useEffect(() => {
         const bootstrapFolders = async () => {
+            setIsLoadingTree(true);
             const rootNodes = await fetchFolderNodes("");
             setFolderTree(rootNodes);
+            setIsLoadingTree(false);
 
             const mediaFolder = rootNodes.find(
                 (node) => node.name.toLowerCase() === "media",
             );
-            if (mediaFolder) {
-                setSelectedFolderPath(mediaFolder.path);
-                setExpandedPaths(new Set([mediaFolder.path]));
-                const mediaChildren = await fetchFolderNodes(mediaFolder.path);
+            const target = mediaFolder ?? rootNodes[0];
+            if (target) {
+                setSelectedFolderPath(target.path);
+                setExpandedPaths(new Set([target.path]));
+                const children = await fetchFolderNodes(target.path);
                 setFolderTree((prev) =>
-                    updateNodeChildren(prev, mediaFolder.path, mediaChildren),
+                    markChildrenLoaded(prev, target.path, children),
                 );
-            } else if (rootNodes.length > 0) {
-                setSelectedFolderPath(rootNodes[0].path);
-                setExpandedPaths(new Set([rootNodes[0].path]));
-                if (rootNodes[0].hasSubfolders) {
-                    const firstChildren = await fetchFolderNodes(rootNodes[0].path);
-                    setFolderTree((prev) =>
-                        updateNodeChildren(prev, rootNodes[0].path, firstChildren),
-                    );
-                }
             }
         };
 
@@ -112,49 +199,12 @@ export default function FilesPage() {
     }, []);
 
     useEffect(() => {
-        const fetchFolderContents = async () => {
-            if (!selectedFolderPath) {
-                setFiles([]);
-                setSubfolders([]);
-                return;
-            }
-
-            const { data, error: fetchError } = await supabase.storage
-                .from("Files")
-                .list(selectedFolderPath, { limit: 200 });
-
-            if (fetchError) {
-                setError(fetchError);
-                return;
-            }
-
-            const entries = (data ?? []) as StorageEntry[];
-            const folderEntries = entries.filter((entry) => isFolder(entry));
-            const fileEntries = entries.filter((entry) => !isFolder(entry));
-
-            const childFolders = await Promise.all(
-                folderEntries.map(async (folder) => {
-                    const path = `${selectedFolderPath}/${folder.name}`;
-                    const hasSubfolders = await folderHasSubfolders(path);
-                    return {
-                        name: folder.name,
-                        path,
-                        hasSubfolders,
-                    };
-                }),
-            );
-
-            setSubfolders(childFolders.sort((a, b) => a.name.localeCompare(b.name)));
-            setFiles(fileEntries);
-        };
-
-        void fetchFolderContents();
+        void fetchFolderContents(selectedFolderPath);
     }, [selectedFolderPath]);
 
-    const handleSelectFolder = (folderPath: string) => {
-        setSelectedFolderPath(folderPath);
-        setExpandedPaths((prev) => new Set(prev).add(folderPath));
-    };
+    // ---------------------------------------------------------------------
+    // Tree node helpers
+    // ---------------------------------------------------------------------
 
     const updateNodeChildren = (
         nodes: FolderNode[],
@@ -165,9 +215,7 @@ export default function FilesPage() {
             if (node.path === targetPath) {
                 return { ...node, children };
             }
-            if (!node.children) {
-                return node;
-            }
+            if (!node.children) return node;
             return {
                 ...node,
                 children: updateNodeChildren(node.children, targetPath, children),
@@ -175,153 +223,808 @@ export default function FilesPage() {
         });
     };
 
-    const findNodeByPath = (nodes: FolderNode[], targetPath: string): FolderNode | null => {
-        for (const node of nodes) {
+    // Attach loaded children AND resolve the parent's lazy hasSubfolders:
+    // empty => false (hides the chevron), non-empty => true.
+    const markChildrenLoaded = (
+        nodes: FolderNode[],
+        targetPath: string,
+        children: FolderNode[],
+    ): FolderNode[] => {
+        return nodes.map((node) => {
             if (node.path === targetPath) {
-                return node;
+                return {
+                    ...node,
+                    children,
+                    hasSubfolders: children.length > 0,
+                };
             }
+            if (!node.children) return node;
+            return {
+                ...node,
+                children: markChildrenLoaded(node.children, targetPath, children),
+            };
+        });
+    };
+
+    const findNodeByPath = (
+        nodes: FolderNode[],
+        targetPath: string,
+    ): FolderNode | null => {
+        for (const node of nodes) {
+            if (node.path === targetPath) return node;
             if (node.children) {
                 const match = findNodeByPath(node.children, targetPath);
-                if (match) {
-                    return match;
-                }
+                if (match) return match;
             }
         }
         return null;
     };
 
-    const ensureNodeLoaded = async (nodePath: string) => {
+    const ensureNodeLoaded = async (nodePath: string, force = false) => {
         const node = findNodeByPath(folderTree, nodePath);
-        if (!node?.hasSubfolders) {
-            return;
-        }
-        if (node?.children) {
-            return;
-        }
-
-        const children = await fetchFolderNodes(nodePath);
-        setFolderTree((prev) => updateNodeChildren(prev, nodePath, children));
+        if (!force && node?.children) return;
+        const children = await fetchFolderNodes(nodePath, force);
+        setFolderTree((prev) => markChildrenLoaded(prev, nodePath, children));
     };
 
-    const handleToggleExpand = async (nodePath: string) => {
-        await ensureNodeLoaded(nodePath);
+    const handleSelectFolder = async (folderPath: string) => {
+        setSelectedFolderPath(folderPath);
+        await ensureNodeLoaded(folderPath);
         setExpandedPaths((prev) => {
             const next = new Set(prev);
-            if (next.has(nodePath)) {
-                next.delete(nodePath);
-            } else {
-                next.add(nodePath);
-            }
+            next.add(folderPath);
             return next;
         });
     };
 
-    const renderTree = (nodes: FolderNode[], level = 0) => {
-        return (
-            <ul className={level === 0 ? "space-y-2 text-sm" : "space-y-1 mt-1"}>
-                {nodes.map((node) => {
-                    const isExpanded = expandedPaths.has(node.path);
-                    const isSelected = selectedFolderPath === node.path;
-                    const canExpand = node.hasSubfolders;
+    // Whole tree row click. Explorer semantics:
+    //  - collapsed folder        -> select + expand
+    //  - expanded, NOT selected  -> just select (do NOT collapse — clicking a
+    //                               sibling then back must not fold it)
+    //  - expanded AND selected   -> collapse (only the already-active folder
+    //                               toggles shut on re-click)
+    const handleTreeNodeClick = useCallback(
+        async (node: FolderNode) => {
+            const wasSelected = selectedFolderPath === node.path;
+            setSelectedFolderPath(node.path);
 
-                    return (
-                        <li key={node.path}>
-                            <div
-                                className={`flex items-center gap-2 rounded px-2 py-1 transition ${
-                                    isSelected
-                                        ? "bg-sbi-dark-secondary text-sbi-green"
-                                        : "hover:text-sbi-green"
-                                }`}
-                            >
-                                {canExpand ? (
-                                    <button
-                                        type="button"
-                                        className="w-4 text-xs text-sbi-muted-dark hover:text-white"
-                                        onClick={() => void handleToggleExpand(node.path)}
-                                        aria-label={
-                                            isExpanded ? "Collapse folder" : "Expand folder"
-                                        }
-                                    >
-                                        {isExpanded ? "▾" : "▸"}
-                                    </button>
-                                ) : (
-                                    <span className="w-4" />
-                                )}
-                                <button
-                                    type="button"
-                                    className="text-left flex-1 truncate"
-                                    onClick={() => handleSelectFolder(node.path)}
-                                >
-                                    {node.name}
-                                </button>
-                            </div>
-                            {canExpand && isExpanded && node.children && node.children.length > 0 ? (
-                                <div className="ml-4 border-l border-sbi-dark-border pl-2">
-                                    {renderTree(node.children, level + 1)}
-                                </div>
-                            ) : null}
-                        </li>
-                    );
-                })}
-            </ul>
-        );
-    };
+            // Confirmed-leaf nodes can't expand; unknown nodes still try.
+            if (node.hasSubfolders === false) return;
 
-    const breadcrumb = useMemo(() => {
-        if (!selectedFolderPath) {
-            return "Home /";
+            const isExpanded = expandedPaths.has(node.path);
+
+            if (!isExpanded) {
+                await ensureNodeLoaded(node.path);
+                setExpandedPaths((prev) => new Set(prev).add(node.path));
+                return;
+            }
+
+            // Already expanded: only fold shut when it was the active
+            // selection.
+            if (wasSelected) {
+                setExpandedPaths((prev) => {
+                    const next = new Set(prev);
+                    next.delete(node.path);
+                    return next;
+                });
+            }
+        },
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        [selectedFolderPath, expandedPaths, folderTree],
+    );
+
+    // Droppable "Home / Root" zone in the tree sidebar header — lets items be
+    // moved to storage root (id = "").
+    const {
+        setNodeRef: setRootDropRef,
+        isOver: isRootOver,
+        active: rootActive,
+    } = useDroppable({
+        id: "drop:root",
+        data: { kind: "folder", name: "Home", path: "" },
+    });
+
+    // Highlight "Home" only when dropping there is a real move — i.e. the
+    // dragged item isn't already a top-level entry.
+    const rootActiveData = rootActive?.data.current as
+        | { kind?: "file" | "folder"; path?: string }
+        | undefined;
+    const showRootDropRing =
+        isRootOver &&
+        !!rootActiveData?.path &&
+        !!rootActiveData.kind &&
+        !isInvalidMoveTarget(rootActiveData.path, rootActiveData.kind, "");
+
+    const breadcrumbSegments = useMemo(() => {
+        const parts = selectedFolderPath
+            ? selectedFolderPath.split("/").filter(Boolean)
+            : [];
+        const segments: { label: string; path: string }[] = [
+            { label: "Home", path: "" },
+        ];
+        let accumulated = "";
+        for (const part of parts) {
+            accumulated = accumulated ? `${accumulated}/${part}` : part;
+            segments.push({ label: part, path: accumulated });
         }
-        const pathParts = selectedFolderPath.split("/").filter(Boolean);
-        return ["Home", ...pathParts].join(" / ");
+        return segments;
     }, [selectedFolderPath]);
 
+    const isEmpty =
+        !isLoadingContents && subfolders.length === 0 && files.length === 0;
+
+    // ---------------------------------------------------------------------
+    // Write ops (directors only). All invalidate cache before re-listing.
+    // ---------------------------------------------------------------------
+
+    // Refresh current folder + its parent tree node so changes show up.
+    const refreshAfterWrite = async () => {
+        invalidatePath(selectedFolderPath);
+        invalidatePath(parentOf(selectedFolderPath));
+        await fetchFolderContents(selectedFolderPath, true);
+        await ensureNodeLoaded(selectedFolderPath, true);
+        // Refresh parent tree node so new/removed folders appear in the tree.
+        const parent = parentOf(selectedFolderPath);
+        if (parent !== selectedFolderPath) {
+            const parentChildren = await fetchFolderNodes(parent, true);
+            setFolderTree((prev) =>
+                markChildrenLoaded(prev, parent, parentChildren),
+            );
+        }
+    };
+
+    // Force-relist both sides of a move (grid + tree) so the UI converges
+    // after a drag-drop. `srcParent`/`destPath` are folder prefixes ("" =
+    // root).
+    const refreshAfterMove = useCallback(
+        async (srcParent: string, destPath: string) => {
+            invalidatePath(srcParent);
+            invalidatePath(destPath);
+
+            // Refresh the currently-viewed grid if it's one of the two sides.
+            if (
+                selectedFolderPath === srcParent ||
+                selectedFolderPath === destPath
+            ) {
+                await fetchFolderContents(selectedFolderPath, true);
+            }
+
+            // Refresh the affected tree nodes so folders move in the tree too.
+            const sides = Array.from(new Set([srcParent, destPath]));
+            for (const side of sides) {
+                const children = await fetchFolderNodes(side, true);
+                if (side === "") {
+                    setFolderTree(children);
+                } else {
+                    setFolderTree((prev) =>
+                        markChildrenLoaded(prev, side, children),
+                    );
+                }
+            }
+        },
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        [selectedFolderPath],
+    );
+
+    // Optimistically drop a moved item out of the current grid; returns a
+    // rollback that restores the prior grid state if the move fails.
+    const removeFromGrid = useCallback(
+        (srcPath: string, kind: "file" | "folder") => {
+            const prevFolders = subfolders;
+            const prevFiles = files;
+            const srcName = srcPath.split("/").pop() as string;
+            if (kind === "folder") {
+                setSubfolders((prev) =>
+                    prev.filter((f) => f.path !== srcPath),
+                );
+            } else {
+                setFiles((prev) => prev.filter((f) => f.name !== srcName));
+            }
+            return () => {
+                setSubfolders(prevFolders);
+                setFiles(prevFiles);
+            };
+        },
+        [subfolders, files],
+    );
+
+    const { activeDragItem, handleDragStart, handleDragEnd } = useDragMove({
+        isDirector,
+        removeFromGrid,
+        refreshAfterMove,
+    });
+
+    const sensors = useSensors(
+        useSensor(PointerSensor, {
+            activationConstraint: { distance: 8 },
+        }),
+        useSensor(KeyboardSensor),
+    );
+
+    const handleUploadFiles = async (fileList: FileList | File[]) => {
+        const arr = Array.from(fileList);
+        if (arr.length === 0) return;
+        setIsUploading(true);
+        setUploadCount(arr.length);
+
+        let okCount = 0;
+        const failures: string[] = [];
+        for (const file of arr) {
+            const targetPath = selectedFolderPath
+                ? `${selectedFolderPath}/${file.name}`
+                : file.name;
+            const { error: upErr } = await uploadFile(targetPath, file);
+            if (upErr) {
+                failures.push(
+                    `${file.name}: ${humanizeStorageError(upErr.message, "upload")}`,
+                );
+            } else {
+                okCount += 1;
+            }
+        }
+
+        setIsUploading(false);
+        setUploadCount(0);
+
+        if (okCount > 0) {
+            toastSuccess(
+                `${okCount} file${okCount === 1 ? "" : "s"} uploaded.`,
+                "Upload complete",
+            );
+        }
+        if (failures.length > 0) {
+            toastError(failures.join(" • "), "Some uploads failed");
+        }
+        await refreshAfterWrite();
+    };
+
+    const onFileInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        if (e.target.files && e.target.files.length > 0) {
+            void handleUploadFiles(e.target.files);
+        }
+        e.target.value = "";
+    };
+
+    // Drag & drop onto the grid area. Only react to genuine OS file drags
+    // (dragging an in-page image/text is NOT a "Files" drag), and never while
+    // a modal/preview is open (its Radix dialog is mounted with role=dialog).
+    const dragHasFiles = (e: React.DragEvent) =>
+        Array.from(e.dataTransfer?.types ?? []).includes("Files");
+    const aModalIsOpen = () =>
+        typeof document !== "undefined" &&
+        !!document.querySelector('[role="dialog"]');
+
+    const onDragEnter = (e: React.DragEvent) => {
+        if (!isDirector || aModalIsOpen() || !dragHasFiles(e)) return;
+        e.preventDefault();
+        dragDepth.current += 1;
+        setIsDragging(true);
+    };
+    const onDragLeave = (e: React.DragEvent) => {
+        if (!isDirector || !isDragging) return;
+        e.preventDefault();
+        dragDepth.current -= 1;
+        if (dragDepth.current <= 0) {
+            dragDepth.current = 0;
+            setIsDragging(false);
+        }
+    };
+    const onDragOver = (e: React.DragEvent) => {
+        if (!isDirector || aModalIsOpen() || !dragHasFiles(e)) return;
+        e.preventDefault();
+    };
+    const onDrop = (e: React.DragEvent) => {
+        if (!isDirector || aModalIsOpen()) return;
+        e.preventDefault();
+        dragDepth.current = 0;
+        setIsDragging(false);
+        if (e.dataTransfer.files && e.dataTransfer.files.length > 0) {
+            void handleUploadFiles(e.dataTransfer.files);
+        }
+    };
+
+    const handleCreateFolder = async () => {
+        const name = newFolderName.trim();
+        if (!name) {
+            toastError("Folder name can't be empty.");
+            return;
+        }
+        if (name.includes("/")) {
+            toastError("Folder name can't contain a slash.");
+            return;
+        }
+        setCreatingFolder(true);
+        const prefix = selectedFolderPath
+            ? `${selectedFolderPath}/${name}`
+            : name;
+        const { error: upErr } = await uploadFile(
+            `${prefix}/.emptyFolderPlaceholder`,
+            new Blob([]),
+        );
+        setCreatingFolder(false);
+
+        if (upErr) {
+            toastError(humanizeStorageError(upErr.message, "create"));
+            return;
+        }
+        toastSuccess(`Folder "${name}" created.`);
+        setNewFolderOpen(false);
+        setNewFolderName("");
+        await refreshAfterWrite();
+    };
+
+    const openRename = (
+        kind: "file" | "folder",
+        name: string,
+        path: string,
+    ) => {
+        setRenameTarget({ kind, name, path });
+        setRenameValue(name);
+    };
+
+    const handleRename = async () => {
+        if (!renameTarget) return;
+        const newName = renameValue.trim();
+        if (!newName) {
+            toastError("Name can't be empty.");
+            return;
+        }
+        if (newName.includes("/")) {
+            toastError("Name can't contain a slash.");
+            return;
+        }
+        if (newName === renameTarget.name) {
+            setRenameTarget(null);
+            return;
+        }
+        setRenaming(true);
+        const prefix = parentOf(renameTarget.path);
+        const newPath = prefix ? `${prefix}/${newName}` : newName;
+
+        try {
+            if (renameTarget.kind === "file") {
+                await moveObject(renameTarget.path, newPath);
+            } else {
+                await moveFolder(renameTarget.path, newPath);
+            }
+            invalidatePrefix(renameTarget.path);
+            invalidatePrefix(newPath);
+            toastSuccess(
+                `${renameTarget.kind === "file" ? "File" : "Folder"} renamed to "${newName}".`,
+            );
+            setRenameTarget(null);
+            await refreshAfterWrite();
+        } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            toastError(humanizeStorageError(msg, "rename"));
+        } finally {
+            setRenaming(false);
+        }
+    };
+
+    const handleConfirmDelete = async () => {
+        if (!deleteTarget) return;
+        try {
+            if (deleteTarget.kind === "file") {
+                await removePaths([deleteTarget.path]);
+            } else {
+                await deleteFolder(deleteTarget.path);
+            }
+            invalidatePrefix(deleteTarget.path);
+            invalidatePath(parentOf(deleteTarget.path));
+            toastSuccess(
+                `${deleteTarget.kind === "file" ? "File" : "Folder"} "${deleteTarget.name}" deleted.`,
+            );
+            setDeleteTarget(null);
+            await refreshAfterWrite();
+        } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            toastError(humanizeStorageError(msg, "delete"));
+        }
+    };
+
     return (
-        <div className="relative min-h-screen bg-sbi-dark text-white overflow-hidden">
-            <header className="border-b border-sbi-dark-border px-12 py-6 fade-in">
-                <h1 className="text-2xl font-semibold tracking-wide">
-                    Client Document Portal
-                </h1>
-                <p className="text-sm text-sbi-muted-dark mt-1">
-                    Secure access to organizational records
-                </p>
-            </header>
+        <DashboardShell>
+            <DndContext
+                sensors={sensors}
+                collisionDetection={pointerWithin}
+                autoScroll={{
+                    threshold: { x: 0.1, y: 0.15 },
+                    acceleration: 12,
+                }}
+                onDragStart={handleDragStart}
+                onDragEnd={handleDragEnd}
+            >
+            <PageHeader
+                title="Client Document Portal"
+                subtitle="Browse and download files shared on your project."
+            />
 
-            <div className="flex">
-                <aside className="w-80 border-r border-sbi-dark-border p-8 fade-in">
-                    <h2 className="text-xs uppercase tracking-widest text-sbi-muted-dark mb-6">
-                        Folders
-                    </h2>
-                    {folderTree.length > 0 ? renderTree(folderTree) : <p>No folders found</p>}
-                </aside>
+            <div className="flex flex-1 min-h-0 gap-6">
+                {/* Folder tree sidebar */}
+                <Panel className="w-64 shrink-0 overflow-y-auto" padded>
+                    <SectionLabel className="mb-4">Folders</SectionLabel>
+                    {/* Home / Root droppable — move items to storage root. */}
+                    <button
+                        ref={setRootDropRef}
+                        type="button"
+                        onClick={() => void handleSelectFolder("")}
+                        className={`group mb-2 flex w-full cursor-pointer items-center gap-1.5 rounded-md px-2 py-1.5 text-left text-sm transition-colors duration-150 ${
+                            showRootDropRing
+                                ? "border border-sbi-green/40 bg-sbi-green/10 [animation:sbiDragPulse_1.1s_ease-in-out_infinite]"
+                                : "border border-transparent"
+                        } ${
+                            selectedFolderPath === ""
+                                ? "bg-sbi-green/10 text-sbi-green"
+                                : "text-sbi-muted hover:text-white hover:bg-white/[0.03]"
+                        }`}
+                    >
+                        <span className="size-3.5 shrink-0" />
+                        <Home
+                            className={`size-4 shrink-0 transition-colors ${
+                                selectedFolderPath === ""
+                                    ? "text-sbi-green"
+                                    : "text-sbi-muted group-hover:text-white"
+                            }`}
+                        />
+                        <span className="flex-1 truncate leading-none">
+                            Home
+                        </span>
+                    </button>
+                    {isLoadingTree ? (
+                        <ul className="space-y-2 text-sm">
+                            {Array.from({ length: 5 }).map((_, i) => (
+                                <FolderSkeletonRow key={i} />
+                            ))}
+                        </ul>
+                    ) : folderTree.length > 0 ? (
+                        <ul className="space-y-2 text-sm">
+                            {folderTree.map((node) => (
+                                <TreeNode
+                                    key={node.path}
+                                    node={node}
+                                    level={0}
+                                    expandedPaths={expandedPaths}
+                                    selectedFolderPath={selectedFolderPath}
+                                    onNodeClick={handleTreeNodeClick}
+                                />
+                            ))}
+                        </ul>
+                    ) : (
+                        <p className="text-sm text-sbi-muted">No folders found</p>
+                    )}
+                </Panel>
 
-                <main className="flex-1 p-12 fade-in">
-                    <div className="text-sm text-sbi-muted-dark mb-8">{breadcrumb}</div>
+                <main className="flex-1 min-w-0 overflow-y-auto flex flex-col">
+                    {/* Breadcrumb + director toolbar */}
+                    <div className="mb-6 flex flex-wrap items-center justify-between gap-3 shrink-0">
+                        <nav
+                            aria-label="Folder breadcrumb"
+                            className="text-sm text-sbi-muted flex flex-wrap items-center gap-1"
+                        >
+                            {breadcrumbSegments.map((seg, i) => {
+                                const isLast =
+                                    i === breadcrumbSegments.length - 1;
+                                return (
+                                    <span
+                                        key={`${seg.path}-${i}`}
+                                        className="flex items-center gap-1"
+                                    >
+                                        {isLast ? (
+                                            <span className="text-white">
+                                                {seg.label}
+                                            </span>
+                                        ) : (
+                                            <button
+                                                type="button"
+                                                onClick={() =>
+                                                    handleSelectFolder(seg.path)
+                                                }
+                                                className="cursor-pointer hover:text-sbi-green transition-colors"
+                                            >
+                                                {seg.label}
+                                            </button>
+                                        )}
+                                        {!isLast && (
+                                            <span className="text-sbi-muted/40">
+                                                /
+                                            </span>
+                                        )}
+                                    </span>
+                                );
+                            })}
+                        </nav>
+
+                        {isDirector ? (
+                            <div className="flex items-center gap-2">
+                                <input
+                                    ref={fileInputRef}
+                                    type="file"
+                                    multiple
+                                    className="sr-only"
+                                    onChange={onFileInputChange}
+                                />
+                                <button
+                                    type="button"
+                                    onClick={() => fileInputRef.current?.click()}
+                                    disabled={isUploading}
+                                    className={btnPrimary}
+                                >
+                                    {isUploading ? (
+                                        <>
+                                            <span className="h-3.5 w-3.5 border-2 border-current border-t-transparent rounded-full animate-spin" />
+                                            Uploading {uploadCount}…
+                                        </>
+                                    ) : (
+                                        <>
+                                            <Upload className="h-3.5 w-3.5" />
+                                            Upload
+                                        </>
+                                    )}
+                                </button>
+                                <button
+                                    type="button"
+                                    onClick={() => {
+                                        setNewFolderName("");
+                                        setNewFolderOpen(true);
+                                    }}
+                                    disabled={isUploading}
+                                    className={btnGhost}
+                                >
+                                    <FolderPlus className="h-3.5 w-3.5" />
+                                    New Folder
+                                </button>
+                            </div>
+                        ) : null}
+                    </div>
 
                     {error ? (
-                        <div className="text-sm text-red-400 mb-6">
-                            {error.message || "Failed to load files or folders."}
+                        <div className="text-sm text-red-400 mb-6 shrink-0">
+                            {error.message ||
+                                "Failed to load files or folders."}
                         </div>
                     ) : null}
 
-                    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
-                        {subfolders.map((folder) => (
-                            <FolderCard
-                                key={folder.path}
-                                name={folder.name}
-                                onOpen={() => handleSelectFolder(folder.path)}
+                    <div
+                        className="relative flex-1 flex flex-col"
+                        onDragEnter={onDragEnter}
+                        onDragLeave={onDragLeave}
+                        onDragOver={onDragOver}
+                        onDrop={onDrop}
+                    >
+                        {isDirector && isDragging ? (
+                            <div className="absolute inset-0 z-10 flex items-center justify-center rounded-xl border-2 border-dashed border-sbi-green/30 bg-sbi-dark/80 backdrop-blur-sm pointer-events-none">
+                                <div className="flex flex-col items-center gap-2 text-sbi-green">
+                                    <Upload className="h-7 w-7" />
+                                    <span className="text-sm font-medium tracking-wide">
+                                        Drop files to upload
+                                    </span>
+                                </div>
+                            </div>
+                        ) : null}
+
+                        {isEmpty ? (
+                            <EmptyState
+                                icon={<FolderOpen size={24} />}
+                                title="This folder is empty"
+                                description="No files or subfolders have been added here yet."
                             />
-                        ))}
-                        {files.map((item) => (
-                            <FileCard
-                                key={item.name}
-                                name={item.name}
-                                folderPath={selectedFolderPath}
-                                updatedAt={item.updated_at}
-                            />
-                        ))}
+                        ) : (
+                            <div className="grid gap-3 [grid-template-columns:repeat(auto-fill,minmax(220px,1fr))]">
+                                {isLoadingContents ? (
+                                    Array.from({ length: 6 }).map((_, i) => (
+                                        <SkeletonTile key={i} />
+                                    ))
+                                ) : (
+                                    <>
+                                        {subfolders.map((folder) => (
+                                            <FolderCard
+                                                key={folder.path}
+                                                name={folder.name}
+                                                draggableId={folder.path}
+                                                droppableId={folder.path}
+                                                canManage={isDirector}
+                                                onOpen={() =>
+                                                    handleSelectFolder(
+                                                        folder.path,
+                                                    )
+                                                }
+                                                onRename={() =>
+                                                    openRename(
+                                                        "folder",
+                                                        folder.name,
+                                                        folder.path,
+                                                    )
+                                                }
+                                                onDelete={() =>
+                                                    setDeleteTarget({
+                                                        kind: "folder",
+                                                        name: folder.name,
+                                                        path: folder.path,
+                                                    })
+                                                }
+                                            />
+                                        ))}
+                                        {files.map((item) => {
+                                            const fullPath = selectedFolderPath
+                                                ? `${selectedFolderPath}/${item.name}`
+                                                : item.name;
+                                            return (
+                                                <FileCard
+                                                    key={item.name}
+                                                    name={item.name}
+                                                    folderPath={
+                                                        selectedFolderPath
+                                                    }
+                                                    draggableId={fullPath}
+                                                    updatedAt={item.updated_at}
+                                                    canManage={isDirector}
+                                                    onRename={() =>
+                                                        openRename(
+                                                            "file",
+                                                            item.name,
+                                                            fullPath,
+                                                        )
+                                                    }
+                                                    onDelete={() =>
+                                                        setDeleteTarget({
+                                                            kind: "file",
+                                                            name: item.name,
+                                                            path: fullPath,
+                                                        })
+                                                    }
+                                                />
+                                            );
+                                        })}
+                                    </>
+                                )}
+                            </div>
+                        )}
                     </div>
                 </main>
             </div>
-        </div>
+
+            {/* New Folder modal */}
+            <Modal
+                opened={newFolderOpen}
+                onClose={() => !creatingFolder && setNewFolderOpen(false)}
+                title="New Folder"
+                size="md"
+            >
+                <div>
+                    <TextField
+                        label="Folder name"
+                        placeholder="e.g. Contracts"
+                        value={newFolderName}
+                        onChange={setNewFolderName}
+                        disabled={creatingFolder}
+                        autoFocus
+                        onKeyDown={(e) => {
+                            if (e.key === "Enter") void handleCreateFolder();
+                        }}
+                    />
+                    <div className="mt-5 flex justify-end gap-2">
+                        <button
+                            type="button"
+                            onClick={() => setNewFolderOpen(false)}
+                            disabled={creatingFolder}
+                            className={btnGhost}
+                        >
+                            Cancel
+                        </button>
+                        <button
+                            type="button"
+                            onClick={() => void handleCreateFolder()}
+                            disabled={creatingFolder}
+                            className={btnPrimary}
+                        >
+                            {creatingFolder ? (
+                                <>
+                                    <span className="h-3.5 w-3.5 border-2 border-current border-t-transparent rounded-full animate-spin" />
+                                    Creating…
+                                </>
+                            ) : (
+                                "Create"
+                            )}
+                        </button>
+                    </div>
+                </div>
+            </Modal>
+
+            {/* Rename modal */}
+            <Modal
+                opened={renameTarget !== null}
+                onClose={() => !renaming && setRenameTarget(null)}
+                title={`Rename ${renameTarget?.kind === "folder" ? "Folder" : "File"}`}
+                size="md"
+            >
+                <div>
+                    <TextField
+                        label="New name"
+                        value={renameValue}
+                        onChange={setRenameValue}
+                        disabled={renaming}
+                        autoFocus
+                        onKeyDown={(e) => {
+                            if (e.key === "Enter") void handleRename();
+                        }}
+                    />
+                    <div className="mt-5 flex justify-end gap-2">
+                        <button
+                            type="button"
+                            onClick={() => setRenameTarget(null)}
+                            disabled={renaming}
+                            className={btnGhost}
+                        >
+                            Cancel
+                        </button>
+                        <button
+                            type="button"
+                            onClick={() => void handleRename()}
+                            disabled={renaming}
+                            className={btnPrimary}
+                        >
+                            {renaming ? (
+                                <>
+                                    <span className="h-3.5 w-3.5 border-2 border-current border-t-transparent rounded-full animate-spin" />
+                                    Renaming…
+                                </>
+                            ) : (
+                                "Rename"
+                            )}
+                        </button>
+                    </div>
+                </div>
+            </Modal>
+
+            {/* Delete confirmation */}
+            <ConfirmDialog
+                opened={deleteTarget !== null}
+                onClose={() => setDeleteTarget(null)}
+                danger
+                title={
+                    deleteTarget?.kind === "folder"
+                        ? "Delete folder"
+                        : "Delete file"
+                }
+                description={
+                    deleteTarget?.kind === "folder" ? (
+                        <>
+                            This permanently deletes{" "}
+                            <span className="text-white font-medium">
+                                {deleteTarget?.name}
+                            </span>{" "}
+                            and every file and subfolder inside it. This cannot
+                            be undone.
+                        </>
+                    ) : (
+                        <>
+                            This permanently deletes{" "}
+                            <span className="text-white font-medium">
+                                {deleteTarget?.name}
+                            </span>
+                            . This cannot be undone.
+                        </>
+                    )
+                }
+                confirmLabel="Delete"
+                confirmationText={
+                    deleteTarget?.kind === "folder"
+                        ? deleteTarget.name
+                        : undefined
+                }
+                onConfirm={handleConfirmDelete}
+            />
+
+            <DragOverlay dropAnimation={null}>
+                {activeDragItem ? (
+                    <DragOverlayCard
+                        name={activeDragItem.name}
+                        kind={activeDragItem.kind}
+                    />
+                ) : null}
+            </DragOverlay>
+            </DndContext>
+        </DashboardShell>
     );
 }

--- a/frontend/app/dashboard/files/storage.ts
+++ b/frontend/app/dashboard/files/storage.ts
@@ -1,0 +1,290 @@
+import { createClient } from "@/lib/supabase/client";
+
+const supabase = createClient();
+
+export const BUCKET = "Files";
+
+export interface StorageEntry {
+    id: string | null;
+    name: string;
+    updated_at?: string;
+}
+
+// Supabase Storage has no true empty folders: creating one inserts a zero-byte
+// sentinel object so the prefix exists. These must never render as files.
+export const SENTINEL_FILES = new Set([".emptyFolderPlaceholder", ".keep"]);
+
+export function isFolder(entry: StorageEntry) {
+    return entry.id === null;
+}
+
+export function isSentinel(entry: StorageEntry) {
+    return SENTINEL_FILES.has(entry.name);
+}
+
+// ---------------------------------------------------------------------------
+// In-memory listing cache (keyed by folder path).
+// ---------------------------------------------------------------------------
+
+const listCache = new Map<string, StorageEntry[]>();
+
+export function getCachedList(path: string): StorageEntry[] | undefined {
+    return listCache.get(path);
+}
+
+export function setCachedList(path: string, entries: StorageEntry[]) {
+    listCache.set(path, entries);
+}
+
+/** Invalidate a single path's cached listing. */
+export function invalidatePath(path: string) {
+    listCache.delete(path);
+}
+
+/**
+ * Invalidate a prefix and everything beneath it (used after recursive
+ * folder delete/rename so stale subtree listings can't resurface).
+ */
+export function invalidatePrefix(prefix: string) {
+    if (!prefix) {
+        listCache.clear();
+        return;
+    }
+    listCache.delete(prefix);
+    for (const key of Array.from(listCache.keys())) {
+        if (key === prefix || key.startsWith(`${prefix}/`)) {
+            listCache.delete(key);
+        }
+    }
+}
+
+/** Parent prefix of a path ("" for a top-level folder). */
+export function parentOf(path: string): string {
+    const idx = path.lastIndexOf("/");
+    return idx === -1 ? "" : path.slice(0, idx);
+}
+
+/**
+ * True if dropping `srcPath` into `destFolderPath` is not a real move:
+ * onto itself, into one of its own descendants, or into the parent it
+ * already lives in. Mirrors the hard guards in `useDragMove.handleDragEnd`
+ * so drop targets only highlight when the drop would actually do something
+ * (collision is intentionally NOT pre-checked here — it's async and, like
+ * Google Drive, surfaces on drop).
+ */
+export function isInvalidMoveTarget(
+    srcPath: string,
+    srcKind: "file" | "folder",
+    destFolderPath: string,
+): boolean {
+    if (srcPath === destFolderPath) return true;
+    if (srcKind === "folder" && destFolderPath.startsWith(`${srcPath}/`)) {
+        return true;
+    }
+    return parentOf(srcPath) === destFolderPath;
+}
+
+// ---------------------------------------------------------------------------
+// Listing (cache-aware)
+// ---------------------------------------------------------------------------
+
+/**
+ * List a folder, returning cached entries when available. Pass
+ * `force` to bypass the cache (used right after a write op).
+ */
+export async function listFolder(
+    path: string,
+    opts?: { force?: boolean; limit?: number },
+): Promise<{ data: StorageEntry[]; error: { message: string } | null }> {
+    if (!opts?.force) {
+        const cached = getCachedList(path);
+        if (cached) {
+            return { data: cached, error: null };
+        }
+    }
+
+    const { data, error } = await supabase.storage
+        .from(BUCKET)
+        .list(path, { limit: opts?.limit ?? 200 });
+
+    if (error) {
+        return { data: [], error };
+    }
+
+    const entries = (data ?? []) as StorageEntry[];
+    setCachedList(path, entries);
+    return { data: entries, error: null };
+}
+
+// ---------------------------------------------------------------------------
+// Recursive collect — every object path under a prefix.
+// ---------------------------------------------------------------------------
+
+/**
+ * Walk a prefix recursively and collect every object path beneath it,
+ * including `.emptyFolderPlaceholder` sentinels. Subfolders are entries
+ * whose `id === null`.
+ */
+export async function collectAllObjectPaths(prefix: string): Promise<string[]> {
+    const { data, error } = await supabase.storage
+        .from(BUCKET)
+        .list(prefix, { limit: 1000 });
+
+    if (error) {
+        throw new Error(error.message);
+    }
+
+    const entries = (data ?? []) as StorageEntry[];
+    const paths: string[] = [];
+
+    for (const entry of entries) {
+        const childPath = `${prefix}/${entry.name}`;
+        if (isFolder(entry)) {
+            const nested = await collectAllObjectPaths(childPath);
+            paths.push(...nested);
+        } else {
+            paths.push(childPath);
+        }
+    }
+
+    return paths;
+}
+
+function chunk<T>(arr: T[], size: number): T[][] {
+    const out: T[][] = [];
+    for (let i = 0; i < arr.length; i += size) {
+        out.push(arr.slice(i, i + size));
+    }
+    return out;
+}
+
+/** Remove a list of object paths in batches of <= 100. */
+export async function removePaths(paths: string[]): Promise<void> {
+    for (const batch of chunk(paths, 100)) {
+        const { data, error } = await supabase.storage
+            .from(BUCKET)
+            .remove(batch);
+        if (error) {
+            throw new Error(error.message);
+        }
+        // Supabase Storage returns 200 with an EMPTY array (no error) when a
+        // DELETE is blocked by bucket RLS — a silent failure. Treat "deleted
+        // fewer than requested" as a permission error instead of false success.
+        if (!data || data.length < batch.length) {
+            throw new Error(
+                "Delete was blocked — you don't have permission to delete here.",
+            );
+        }
+    }
+}
+
+/**
+ * Recursively delete everything under a folder prefix (including the
+ * sentinel that makes the prefix exist).
+ */
+export async function deleteFolder(prefix: string): Promise<void> {
+    const allPaths = await collectAllObjectPaths(prefix);
+    if (allPaths.length === 0) return;
+    await removePaths(allPaths);
+}
+
+/**
+ * Move/rename a folder by moving every object from oldPrefix/... to
+ * newPrefix/... (Storage has no native, atomic folder move). Sequential
+ * on purpose: on the first failed object move, every already-moved
+ * object is moved back, so a mid-move failure leaves the folder wholly
+ * at the source rather than silently split across both prefixes. If the
+ * compensating rollback itself fails, the thrown error names both
+ * locations so the caller can tell the user the data is split.
+ */
+export async function moveFolder(
+    oldPrefix: string,
+    newPrefix: string,
+): Promise<void> {
+    const allPaths = await collectAllObjectPaths(oldPrefix);
+    const moved: { from: string; to: string }[] = [];
+
+    for (const from of allPaths) {
+        const to = `${newPrefix}${from.slice(oldPrefix.length)}`;
+        const { error } = await supabase.storage
+            .from(BUCKET)
+            .move(from, to);
+
+        if (!error) {
+            moved.push({ from, to });
+            continue;
+        }
+
+        // Partial failure: best-effort compensating rollback (newest
+        // first) so the folder ends up wholly at the source.
+        let rollbackOk = true;
+        for (const m of moved.reverse()) {
+            const { error: rbErr } = await supabase.storage
+                .from(BUCKET)
+                .move(m.to, m.from);
+            if (rbErr) rollbackOk = false;
+        }
+
+        if (!rollbackOk) {
+            throw new Error(
+                `Move failed and the folder is now split between "${oldPrefix}" and "${newPrefix}". ${error.message}`,
+            );
+        }
+        throw new Error(error.message);
+    }
+}
+
+export async function moveObject(
+    oldPath: string,
+    newPath: string,
+): Promise<void> {
+    const { error } = await supabase.storage
+        .from(BUCKET)
+        .move(oldPath, newPath);
+    if (error) {
+        throw new Error(error.message);
+    }
+}
+
+export async function uploadFile(
+    targetPath: string,
+    file: File | Blob,
+): Promise<{ error: { message: string; statusCode?: string } | null }> {
+    const { error } = await supabase.storage
+        .from(BUCKET)
+        .upload(targetPath, file, { upsert: false });
+    return { error: error as { message: string; statusCode?: string } | null };
+}
+
+/** Human-readable message for common storage failures. */
+export function humanizeStorageError(
+    message: string | undefined,
+    context: "upload" | "delete" | "rename" | "create",
+): string {
+    const msg = (message ?? "").toLowerCase();
+    if (
+        msg.includes("already exists") ||
+        msg.includes("duplicate") ||
+        msg.includes("409")
+    ) {
+        return "An item with that name already exists here.";
+    }
+    if (
+        msg.includes("permission") ||
+        msg.includes("unauthorized") ||
+        msg.includes("403") ||
+        msg.includes("row-level security") ||
+        msg.includes("violates")
+    ) {
+        const verb =
+            context === "upload"
+                ? "upload here"
+                : context === "delete"
+                  ? "delete this"
+                  : context === "rename"
+                    ? "rename this"
+                    : "create folders here";
+        return `You don't have permission to ${verb}.`;
+    }
+    return message || "Something went wrong. Please try again.";
+}

--- a/frontend/app/dashboard/files/useDragMove.ts
+++ b/frontend/app/dashboard/files/useDragMove.ts
@@ -1,0 +1,250 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import type { DragEndEvent, DragStartEvent } from "@dnd-kit/core";
+import { toast } from "sonner";
+import { createElement } from "react";
+import { Toast } from "@/components/dashboard/common/Toast";
+import {
+    toastError,
+    toastMoveUndo,
+} from "@/lib/notifications";
+import {
+    humanizeStorageError,
+    invalidatePath,
+    invalidatePrefix,
+    listFolder,
+    moveFolder,
+    moveObject,
+    parentOf,
+} from "./storage";
+
+export interface ActiveDragItem {
+    id: string;
+    name: string;
+    kind: "file" | "folder";
+}
+
+interface UseDragMoveArgs {
+    isDirector: boolean;
+    // Optimistically drop the item out of the current grid, returning a
+    // rollback callback that restores it if the move fails.
+    removeFromGrid: (srcPath: string, kind: "file" | "folder") => () => void;
+    // Force-relist both sides of the move (grid + tree) so the UI converges.
+    refreshAfterMove: (
+        srcParent: string,
+        destFolderPath: string,
+    ) => Promise<void>;
+}
+
+function showMovingToast(name: string): string | number {
+    return toast.custom(
+        () =>
+            createElement(Toast, {
+                kind: "info",
+                title: "Moving",
+                message: name,
+            }),
+        { duration: 60000 },
+    );
+}
+
+export function useDragMove({
+    isDirector,
+    removeFromGrid,
+    refreshAfterMove,
+}: UseDragMoveArgs) {
+    const [activeDragItem, setActiveDragItem] =
+        useState<ActiveDragItem | null>(null);
+
+    const handleDragStart = useCallback((event: DragStartEvent) => {
+        const data = event.active.data.current as
+            | { kind: "file" | "folder"; name: string; path: string }
+            | undefined;
+        if (!data) return;
+        setActiveDragItem({
+            id: data.path,
+            name: data.name,
+            kind: data.kind,
+        });
+    }, []);
+
+    const handleDragEnd = useCallback(
+        async (event: DragEndEvent) => {
+            setActiveDragItem(null);
+
+            // @dnd-kit restores focus to the dragged card after a pointer
+            // drag. That re-triggers the card's group-focus-within (blurred
+            // name + revealed action icons), leaving it "stuck" until the
+            // user clicks away. Drop that focus on the next frame (after
+            // @dnd-kit's own focus restore) so the card returns to rest.
+            if (typeof window !== "undefined") {
+                requestAnimationFrame(() => {
+                    const el = document.activeElement;
+                    if (el instanceof HTMLElement) el.blur();
+                });
+            }
+
+            const { active, over } = event;
+
+            // 1. Only directors can move.
+            if (!isDirector) return;
+            // 2. Dropped outside any droppable.
+            if (!over) return;
+
+            const activeData = active.data.current as
+                | { kind: "file" | "folder"; name: string; path: string }
+                | undefined;
+            const overData = over.data.current as
+                | { path?: string }
+                | undefined;
+            if (!activeData || overData?.path === undefined) return;
+
+            const srcPath = activeData.path;
+            const srcKind = activeData.kind;
+            const destFolderPath = overData.path; // root = ""
+
+            // 4. Self drop.
+            if (srcPath === destFolderPath) return;
+
+            // 5. Folder into its own descendant.
+            if (
+                srcKind === "folder" &&
+                destFolderPath.startsWith(`${srcPath}/`)
+            ) {
+                toastError(
+                    "Can't move a folder into one of its own subfolders.",
+                );
+                return;
+            }
+
+            // 6. No-op: already lives in the destination.
+            const srcParent = parentOf(srcPath);
+            if (srcParent === destFolderPath) return;
+
+            const srcName = srcPath.split("/").pop() as string;
+            const newPath = destFolderPath
+                ? `${destFolderPath}/${srcName}`
+                : srcName;
+
+            // 8. Name collision in the destination (cache-first; if listing
+            //    fails we proceed and let storage reject on conflict).
+            try {
+                const { data, error: listErr } =
+                    await listFolder(destFolderPath);
+                if (
+                    !listErr &&
+                    data.some((entry) => entry.name === srcName)
+                ) {
+                    toastError(
+                        "An item with that name already exists here.",
+                        "Can't move",
+                    );
+                    return;
+                }
+            } catch {
+                // Listing error — proceed; the move will fail loudly if it
+                // genuinely collides.
+            }
+
+            // 9. Optimistically remove from the grid; show a "Moving" toast.
+            const rollback = removeFromGrid(srcPath, srcKind);
+            const movingId = showMovingToast(srcName);
+
+            const destLabel = destFolderPath || "Home";
+
+            try {
+                if (srcKind === "folder") {
+                    await moveFolder(srcPath, newPath);
+                } else {
+                    await moveObject(srcPath, newPath);
+                }
+
+                toast.dismiss(movingId);
+
+                invalidatePrefix(srcPath);
+                invalidatePrefix(newPath);
+                invalidatePath(srcParent);
+                invalidatePath(destFolderPath);
+
+                await refreshAfterMove(srcParent, destFolderPath);
+
+                toastMoveUndo(
+                    srcName,
+                    destLabel,
+                    async () => {
+                        try {
+                            // Mirror the forward collision guard: the
+                            // reverse destination may have been reoccupied
+                            // since the move (cache-first, advisory).
+                            let reverseCollision = false;
+                            try {
+                                const { data, error: listErr } =
+                                    await listFolder(srcParent);
+                                reverseCollision =
+                                    !listErr &&
+                                    data.some((e) => e.name === srcName);
+                            } catch {
+                                // Listing failed: proceed; storage rejects
+                                // a genuine conflict on its own.
+                            }
+                            if (reverseCollision) {
+                                throw new Error(
+                                    `Can't move "${srcName}" back; it's still in "${destLabel}".`,
+                                );
+                            }
+
+                            if (srcKind === "folder") {
+                                await moveFolder(newPath, srcPath);
+                            } else {
+                                await moveObject(newPath, srcPath);
+                            }
+                            invalidatePrefix(srcPath);
+                            invalidatePrefix(newPath);
+                            invalidatePath(srcParent);
+                            invalidatePath(destFolderPath);
+                            await refreshAfterMove(destFolderPath, srcParent);
+                        } catch (err) {
+                            // Converge cache + UI to the true state even on
+                            // a (partially) failed reverse so nothing is
+                            // left stale, then surface the error.
+                            invalidatePrefix(srcPath);
+                            invalidatePrefix(newPath);
+                            invalidatePath(srcParent);
+                            invalidatePath(destFolderPath);
+                            await refreshAfterMove(
+                                destFolderPath,
+                                srcParent,
+                            );
+                            const msg =
+                                err instanceof Error
+                                    ? err.message
+                                    : String(err);
+                            throw new Error(
+                                humanizeStorageError(msg, "rename"),
+                            );
+                        }
+                    },
+                );
+            } catch (err) {
+                toast.dismiss(movingId);
+                rollback();
+                invalidatePrefix(srcPath);
+                invalidatePrefix(newPath);
+                invalidatePath(srcParent);
+                invalidatePath(destFolderPath);
+                await refreshAfterMove(srcParent, destFolderPath);
+                const msg =
+                    err instanceof Error ? err.message : String(err);
+                // No undo toast on a partial/failed move.
+                toastError(
+                    humanizeStorageError(msg, "rename"),
+                    "Move failed",
+                );
+            }
+        },
+        [isDirector, removeFromGrid, refreshAfterMove],
+    );
+
+    return { activeDragItem, handleDragStart, handleDragEnd };
+}

--- a/frontend/app/dashboard/settings/actions.ts
+++ b/frontend/app/dashboard/settings/actions.ts
@@ -2,6 +2,7 @@
 
 import { createClient } from "@/lib/supabase/server";
 import { createClient as createAdminClient } from "@supabase/supabase-js";
+import { DEFAULT_NOTIFICATION_PREFS, type NotificationPrefs } from "./types";
 
 function getAdminClient() {
   return createAdminClient(
@@ -9,22 +10,6 @@ function getAdminClient() {
     process.env.SUPABASE_SECRET_KEY!
   );
 }
-
-export interface NotificationPrefs {
-  messages: boolean;
-  calendar: boolean;
-  requests: boolean;
-  reports: boolean;
-  weeklyDigest: boolean;
-}
-
-export const DEFAULT_NOTIFICATION_PREFS: NotificationPrefs = {
-  messages: true,
-  calendar: true,
-  requests: true,
-  reports: true,
-  weeklyDigest: false,
-};
 
 async function requireUser() {
   const supabase = await createClient();
@@ -84,7 +69,7 @@ export async function createAccount(data: {
     return { error: "Password must be at least 8 characters" };
   }
 
-  const { error: authzError, admin } = await requireDirector();
+  const { error: authzError, admin, profileId: callerProfileId } = await requireDirector();
   if (authzError || !admin) return { error: authzError || "Not authorized" };
 
   // Create auth user
@@ -118,7 +103,10 @@ export async function createAccount(data: {
     return { error: profileError.message };
   }
 
-  // If client, create a project
+  // If client, create a project AND link the client as its owner. Without
+  // the project_members(owner) row the project is orphaned — no member sees
+  // the client in the team list, and downstream queries that look up the
+  // owner (calendar attendees, etc.) miss them entirely.
   if (data.role === "client" && data.companyName) {
     const slug = data.companyName
       .toLowerCase()
@@ -126,16 +114,41 @@ export async function createAccount(data: {
       .replace(/^-|-$/g, "")
       + "-" + Math.random().toString(36).slice(2, 6);
 
-    const { error: projectError } = await admin
+    const { data: project, error: projectError } = await admin
       .from("projects")
       .insert({
         url_slug: slug,
         company_name: data.companyName,
         created_by: profile.id,
+      })
+      .select("id")
+      .single();
+
+    if (projectError || !project) {
+      // Roll back: auth user → profile cascades via FK. Without this the
+      // email is permanently burned and re-running the form fails with a
+      // duplicate-email error.
+      await admin.auth.admin.deleteUser(uid);
+      return { error: projectError?.message || "Couldn't create project" };
+    }
+
+    const { error: ownerError } = await admin
+      .from("project_members")
+      .insert({
+        profile_id: profile.id,
+        project_id: project.id,
+        role: "owner",
+        assigned_by: callerProfileId ?? null,
       });
 
-    if (projectError) {
-      return { error: projectError.message };
+    if (ownerError) {
+      // Project exists but ownership link failed. Surface a non-fatal
+      // warning — the director can recover from the Team panel.
+      return {
+        success: true,
+        profileId: profile.id,
+        warning: `Project created, but couldn't link the owner: ${ownerError.message}. Use the Team panel to assign the owner manually.`,
+      };
     }
   }
 
@@ -156,6 +169,49 @@ export async function listAccounts() {
 
   if (error) return { error: error.message, accounts: [] };
   return { accounts: profiles || [] };
+}
+
+export async function updateAccount(data: {
+  id: number;
+  name: string;
+  role: "client" | "director" | "member";
+  department: string | null;
+}) {
+  const { error: authzError, admin, profileId: callerProfileId } = await requireDirector();
+  if (authzError || !admin) return { error: authzError || "Not authorized" };
+
+  const name = data.name.trim();
+  if (name.length < 2) return { error: "Name must be at least 2 characters" };
+
+  const department = data.department?.trim() || null;
+
+  // Fetch the existing row so we can detect a role change.
+  const { data: existing, error: existingError } = await admin
+    .from("profiles")
+    .select("id, role")
+    .eq("id", data.id)
+    .single();
+  if (existingError || !existing) return { error: existingError?.message || "Profile not found" };
+
+  // Block self role-change to prevent locking yourself out mid-session.
+  if (data.id === callerProfileId && data.role !== existing.role) {
+    return { error: "You can't change your own role." };
+  }
+
+  const { error } = await admin
+    .from("profiles")
+    .update({ name, role: data.role, department })
+    .eq("id", data.id);
+  if (error) return { error: error.message };
+
+  // If the role changed, clean stale project_members rows so they don't
+  // reference a role the profile no longer has. The caller can reassign
+  // memberships explicitly from the Team panel.
+  if (data.role !== existing.role) {
+    await admin.from("project_members").delete().eq("profile_id", data.id);
+  }
+
+  return { success: true };
 }
 
 export async function deleteAccount(profileId: number) {
@@ -199,18 +255,69 @@ export async function listProjects() {
 export async function listProjectMembers(projectId: number) {
   const { error: authzError, admin } = await requireDirector();
   if (authzError || !admin) return { error: authzError || "Not authorized", members: [] };
-  const { data, error } = await admin
+
+  // project_members has two FKs to profiles (profile_id + assigned_by), so
+  // we name the constraints. Aliasing the assigner embed as `assigner` keeps
+  // the resulting payload tidy.
+  const { data: assigned, error: assignedError } = await admin
     .from("project_members")
-    .select("id, role, profile_id, profiles(id, name, email, role)")
+    .select(
+      "id, role, profile_id, created_at, " +
+        "profiles!project_members_profile_id_fkey(id, name, email, role), " +
+        "assigner:profiles!project_members_assigned_by_fkey(id, name)",
+    )
     .eq("project_id", projectId)
     .order("role");
+  if (assignedError) return { error: assignedError.message, members: [] };
 
-  if (error) return { error: error.message, members: [] };
-  return { members: data || [] };
+  // Directors are documented as auto-assigned to every project. If the
+  // backfill trigger has missed any, materialise them in the response so
+  // the UI never shows an empty list when a director clearly belongs.
+  const { data: directors, error: directorsError } = await admin
+    .from("profiles")
+    .select("id, name, email, role")
+    .eq("role", "director")
+    .order("name");
+  if (directorsError) return { error: directorsError.message, members: [] };
+
+  type AssignedRow = {
+    id: number;
+    role: string;
+    profile_id: number;
+    created_at: string | null;
+    profiles: { id: number; name: string; email: string | null; role: string } | null;
+    assigner: { id: number; name: string } | null;
+  };
+  type DirectorRow = { id: number; name: string; email: string | null; role: string };
+
+  const assignedRows = (assigned || []) as unknown as AssignedRow[];
+  const directorRows = (directors || []) as unknown as DirectorRow[];
+
+  const seen = new Set(assignedRows.map((m) => m.profile_id));
+  const synthetic = directorRows
+    .filter((d) => !seen.has(d.id))
+    .map((d) => ({
+      // Display-only rows for directors auto-assigned without a backing
+      // project_members row. `synthetic: true` is the discriminator — the
+      // negative id is just for React keys, but UI code MUST check
+      // `synthetic` before passing the id to any mutation.
+      id: -d.id,
+      synthetic: true as const,
+      role: "director" as const,
+      profile_id: d.id,
+      created_at: null,
+      profiles: { id: d.id, name: d.name, email: d.email, role: d.role },
+      assigner: null,
+    }));
+
+  // Mark real rows explicitly for symmetry.
+  const real = assignedRows.map((m) => ({ ...m, synthetic: false as const }));
+
+  return { members: [...synthetic, ...real] };
 }
 
 export async function assignMemberToProject(profileId: number, projectId: number) {
-  const { error: authzError, admin } = await requireDirector();
+  const { error: authzError, admin, profileId: callerProfileId } = await requireDirector();
   if (authzError || !admin) return { error: authzError || "Not authorized" };
 
   const { error } = await admin
@@ -219,6 +326,7 @@ export async function assignMemberToProject(profileId: number, projectId: number
       profile_id: profileId,
       project_id: projectId,
       role: "member",
+      assigned_by: callerProfileId ?? null,
     });
 
   if (error) {
@@ -230,6 +338,13 @@ export async function assignMemberToProject(profileId: number, projectId: number
 }
 
 export async function removeMemberFromProject(membershipId: number) {
+  // Synthetic director rows use negative ids (no real row backs them).
+  // Reject them defensively — Supabase would silently match zero rows
+  // and report success, masking a real bug.
+  if (!Number.isInteger(membershipId) || membershipId <= 0) {
+    return { error: "Invalid membership id" };
+  }
+
   const { error: authzError, admin } = await requireDirector();
   if (authzError || !admin) return { error: authzError || "Not authorized" };
 
@@ -242,6 +357,68 @@ export async function removeMemberFromProject(membershipId: number) {
   return { success: true };
 }
 
+export async function assignOwnerToProject(profileId: number, projectId: number) {
+  const { error: authzError, admin, profileId: callerProfileId } = await requireDirector();
+  if (authzError || !admin) return { error: authzError || "Not authorized" };
+
+  // Verify the target is actually a client.
+  const { data: target } = await admin
+    .from("profiles")
+    .select("id, role")
+    .eq("id", profileId)
+    .single();
+  if (!target) return { error: "Profile not found" };
+  if (target.role !== "client") return { error: "Only clients can be project owners" };
+
+  // Enforce one-owner-per-project at the application layer (no partial
+  // unique index exists yet).
+  const { data: existingOwner } = await admin
+    .from("project_members")
+    .select("id")
+    .eq("project_id", projectId)
+    .eq("role", "owner")
+    .maybeSingle();
+  if (existingOwner) return { error: "This project already has an owner" };
+
+  const { error } = await admin
+    .from("project_members")
+    .insert({
+      profile_id: profileId,
+      project_id: projectId,
+      role: "owner",
+      assigned_by: callerProfileId ?? null,
+    });
+  if (error) {
+    if (error.code === "23505") return { error: "Client is already on this project" };
+    return { error: error.message };
+  }
+
+  return { success: true };
+}
+
+export async function listAvailableOwners(projectId: number) {
+  const { error: authzError, admin } = await requireDirector();
+  if (authzError || !admin) return { error: authzError || "Not authorized", clients: [] };
+
+  // All clients not already a member of this project.
+  const { data: existing } = await admin
+    .from("project_members")
+    .select("profile_id")
+    .eq("project_id", projectId);
+  const taken = (existing || []).map((r: { profile_id: number }) => r.profile_id);
+
+  let query = admin
+    .from("profiles")
+    .select("id, name, email")
+    .eq("role", "client")
+    .order("name");
+  if (taken.length > 0) query = query.not("id", "in", `(${taken.join(",")})`);
+
+  const { data, error } = await query;
+  if (error) return { error: error.message, clients: [] };
+  return { clients: data || [] };
+}
+
 export async function listUnassignedMembers(projectId: number) {
   const { error: authzError, admin } = await requireDirector();
   if (authzError || !admin) return { error: authzError || "Not authorized", members: [] };
@@ -252,7 +429,7 @@ export async function listUnassignedMembers(projectId: number) {
     .select("profile_id")
     .eq("project_id", projectId);
 
-  const assignedIds = (existingIds || []).map((r: any) => r.profile_id);
+  const assignedIds = (existingIds || []).map((r: { profile_id: number }) => r.profile_id);
 
   let query = admin
     .from("profiles")

--- a/frontend/app/dashboard/settings/actions.ts
+++ b/frontend/app/dashboard/settings/actions.ts
@@ -10,6 +10,45 @@ function getAdminClient() {
   );
 }
 
+export interface NotificationPrefs {
+  messages: boolean;
+  calendar: boolean;
+  requests: boolean;
+  reports: boolean;
+  weeklyDigest: boolean;
+}
+
+export const DEFAULT_NOTIFICATION_PREFS: NotificationPrefs = {
+  messages: true,
+  calendar: true,
+  requests: true,
+  reports: true,
+  weeklyDigest: false,
+};
+
+async function requireUser() {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return { error: "Not authenticated" as const };
+
+  const admin = getAdminClient();
+  const { data: profile } = await admin
+    .from("profiles")
+    .select("id, role, name, email, department, config")
+    .eq("uid", user.id)
+    .single();
+
+  if (!profile) return { error: "Profile not found" as const };
+
+  return {
+    error: null,
+    admin,
+    supabase,
+    uid: user.id,
+    profile,
+  };
+}
+
 async function requireDirector() {
   const supabase = await createClient();
   const { data: { user } } = await supabase.auth.getUser();
@@ -228,4 +267,74 @@ export async function listUnassignedMembers(projectId: number) {
   const { data, error } = await query;
   if (error) return { error: error.message, members: [] };
   return { members: data || [] };
+}
+
+// ============================================================
+// Personal Account (any authenticated user)
+// ============================================================
+
+export async function getMyAccount() {
+  const ctx = await requireUser();
+  if (ctx.error) return { error: ctx.error };
+
+  const config = (ctx.profile.config as Record<string, unknown>) || {};
+  const storedPrefs = (config.notifications as Partial<NotificationPrefs>) || {};
+  const prefs: NotificationPrefs = { ...DEFAULT_NOTIFICATION_PREFS, ...storedPrefs };
+
+  return {
+    error: null,
+    account: {
+      id: ctx.profile.id,
+      name: ctx.profile.name,
+      email: ctx.profile.email,
+      role: ctx.profile.role,
+      department: ctx.profile.department,
+      prefs,
+    },
+  };
+}
+
+export async function updateMyProfile(data: { name: string; department: string | null }) {
+  const ctx = await requireUser();
+  if (ctx.error) return { error: ctx.error };
+
+  const name = data.name.trim();
+  if (name.length < 2) return { error: "Name must be at least 2 characters" };
+
+  const department = data.department?.trim() || null;
+
+  const { error } = await ctx.admin
+    .from("profiles")
+    .update({ name, department })
+    .eq("id", ctx.profile.id);
+
+  if (error) return { error: error.message };
+  return { success: true };
+}
+
+export async function updateMyPassword(newPassword: string) {
+  const ctx = await requireUser();
+  if (ctx.error) return { error: ctx.error };
+
+  if (newPassword.length < 8) return { error: "Password must be at least 8 characters" };
+
+  const { error } = await ctx.supabase.auth.updateUser({ password: newPassword });
+  if (error) return { error: error.message };
+  return { success: true };
+}
+
+export async function updateMyNotificationPrefs(prefs: NotificationPrefs) {
+  const ctx = await requireUser();
+  if (ctx.error) return { error: ctx.error };
+
+  const config = ((ctx.profile.config as Record<string, unknown>) || {});
+  const nextConfig = { ...config, notifications: prefs };
+
+  const { error } = await ctx.admin
+    .from("profiles")
+    .update({ config: nextConfig })
+    .eq("id", ctx.profile.id);
+
+  if (error) return { error: error.message };
+  return { success: true };
 }

--- a/frontend/app/dashboard/settings/loading.tsx
+++ b/frontend/app/dashboard/settings/loading.tsx
@@ -1,0 +1,19 @@
+import { Loader2 } from "lucide-react";
+import { DashboardShell, PageHeader, Panel } from "@/components/dashboard/common/ui";
+
+export default function SettingsLoading() {
+  return (
+    <DashboardShell className="overflow-y-auto">
+      <PageHeader title="Settings" subtitle="Loading…" />
+      <div className="grid grid-cols-1 md:grid-cols-[200px_minmax(0,1fr)] gap-8 lg:gap-12 pb-8">
+        <div className="h-40 rounded-md border border-sbi-dark-border/30 bg-sbi-dark-card/20" />
+        <Panel>
+          <div className="flex items-center gap-2 text-sbi-muted text-sm">
+            <Loader2 className="size-4 animate-spin" />
+            Loading settings…
+          </div>
+        </Panel>
+      </div>
+    </DashboardShell>
+  );
+}

--- a/frontend/app/dashboard/settings/page.tsx
+++ b/frontend/app/dashboard/settings/page.tsx
@@ -1,10 +1,21 @@
 "use client";
 
-import { Calendar, Users, Shield, Plus, Trash2, UserPlus, ChevronDown, Check, Loader2 } from "lucide-react";
+import { Calendar, Users, Shield, Plus, Trash2, UserPlus, ChevronDown, Check, Loader2, User, Lock, Bell, type LucideIcon } from "lucide-react";
 import { useProject } from "@/lib/project/project-context";
 import { createClient } from "@/lib/supabase/client";
-import { useRouter } from "next/navigation";
-import { useEffect, useState, useCallback } from "react";
+import { useSearchParams, useRouter } from "next/navigation";
+import { useEffect, useState, useCallback, useMemo, Suspense } from "react";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+import { toastSuccess, toastError } from "@/lib/notifications";
+import {
+  DashboardShell,
+  PageHeader,
+  SectionLabel,
+  Panel,
+  EmptyState,
+  btnPrimary,
+  btnGhost,
+} from "@/components/dashboard/common/ui";
 import {
   createAccount,
   listAccounts,
@@ -14,7 +25,17 @@ import {
   assignMemberToProject,
   removeMemberFromProject,
   listUnassignedMembers,
+  getMyAccount,
+  updateMyProfile,
+  updateMyPassword,
+  updateMyNotificationPrefs,
+  DEFAULT_NOTIFICATION_PREFS,
+  type NotificationPrefs,
 } from "./actions";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
 
 interface Account {
   id: number;
@@ -53,43 +74,577 @@ interface GoogleCalendar {
   accessRole: string;
 }
 
+interface MyAccount {
+  id: number;
+  name: string;
+  email: string | null;
+  role: "client" | "director" | "member";
+  department: string | null;
+  prefs: NotificationPrefs;
+}
+
+// ---------------------------------------------------------------------------
+// Section configuration
+// ---------------------------------------------------------------------------
+
+type SectionId = "profile" | "security" | "notifications" | "calendar" | "team" | "accounts";
+
+interface SectionDef {
+  id: SectionId;
+  label: string;
+  icon: LucideIcon;
+  group: "personal" | "workspace";
+  directorOnly?: boolean;
+}
+
+const SECTIONS: SectionDef[] = [
+  { id: "profile", label: "Profile", icon: User, group: "personal" },
+  { id: "security", label: "Security", icon: Lock, group: "personal" },
+  { id: "notifications", label: "Notifications", icon: Bell, group: "personal" },
+  { id: "calendar", label: "Calendar", icon: Calendar, group: "workspace", directorOnly: true },
+  { id: "team", label: "Team", icon: Users, group: "workspace", directorOnly: true },
+  { id: "accounts", label: "Accounts", icon: Shield, group: "workspace", directorOnly: true },
+];
+
+const SECTION_IDS = SECTIONS.map((s) => s.id);
+
+function roleBadgeColor(role: string) {
+  switch (role) {
+    case "director": return "bg-amber-500/10 text-amber-400 border-amber-500/30";
+    case "client": return "bg-blue-500/10 text-blue-400 border-blue-500/30";
+    case "member": return "bg-sbi-green/10 text-sbi-green border-sbi-green/30";
+    case "owner": return "bg-purple-500/10 text-purple-400 border-purple-500/30";
+    default: return "bg-white/10 text-white/70 border-white/20";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Page
+// ---------------------------------------------------------------------------
+
 export default function SettingsPage() {
+  return (
+    <Suspense fallback={null}>
+      <SettingsPageInner />
+    </Suspense>
+  );
+}
+
+function SettingsPageInner() {
   const { user, isLoading } = useProject();
   const router = useRouter();
+  const searchParams = useSearchParams();
 
-  // Account state
-  const [accounts, setAccounts] = useState<Account[]>([]);
-  const [showCreateForm, setShowCreateForm] = useState(false);
-  const [createForm, setCreateForm] = useState({ email: "", password: "", name: "", role: "member" as "client" | "director" | "member", companyName: "", department: "" });
-  const [createError, setCreateError] = useState("");
-  const [createLoading, setCreateLoading] = useState(false);
+  const isDirector = user?.role === "director";
 
-  // Calendar state
-  const [calendars, setCalendars] = useState<GoogleCalendar[]>([]);
-  const [selectedCalendarId, setSelectedCalendarId] = useState<string>("");
-  const [calendarLoading, setCalendarLoading] = useState(false);
-  const [calendarSaving, setCalendarSaving] = useState(false);
-  const [calendarError, setCalendarError] = useState("");
-  const [calendarSuccess, setCalendarSuccess] = useState("");
+  const requestedSection = searchParams.get("section");
+  const activeSection: SectionId = useMemo(() => {
+    const candidate = SECTION_IDS.includes(requestedSection as SectionId)
+      ? (requestedSection as SectionId)
+      : "profile";
+    const def = SECTIONS.find((s) => s.id === candidate);
+    if (def?.directorOnly && !isDirector) return "profile";
+    return candidate;
+  }, [requestedSection, isDirector]);
 
-  // Team state
-  const [projects, setProjects] = useState<Project[]>([]);
-  const [selectedProjectId, setSelectedProjectId] = useState<number | null>(null);
-  const [projectMembers, setProjectMembers] = useState<ProjectMember[]>([]);
-  const [unassignedMembers, setUnassignedMembers] = useState<UnassignedMember[]>([]);
-  const [showAssignDropdown, setShowAssignDropdown] = useState(false);
+  const setActiveSection = useCallback(
+    (id: SectionId) => {
+      const params = new URLSearchParams(searchParams.toString());
+      params.set("section", id);
+      router.replace(`/dashboard/settings?${params.toString()}`, { scroll: false });
+    },
+    [router, searchParams],
+  );
+
+  const visibleSections = useMemo(
+    () => SECTIONS.filter((s) => isDirector || !s.directorOnly),
+    [isDirector],
+  );
+
+  if (isLoading || !user) return null;
+
+  return (
+    <DashboardShell className="overflow-y-auto">
+      <PageHeader
+        title="Settings"
+        subtitle={isDirector ? "Manage your account and the portal workspace" : "Manage your account"}
+      />
+
+      <div className="grid grid-cols-1 md:grid-cols-[200px_minmax(0,1fr)] gap-8 lg:gap-12 pb-8">
+        <SettingsNav
+          sections={visibleSections}
+          activeSection={activeSection}
+          onSelect={setActiveSection}
+        />
+
+        <div className="min-w-0">
+          {activeSection === "profile" && <ProfileSection />}
+          {activeSection === "security" && <SecuritySection />}
+          {activeSection === "notifications" && <NotificationsSection />}
+          {activeSection === "calendar" && isDirector && <CalendarSection />}
+          {activeSection === "team" && isDirector && <TeamSection />}
+          {activeSection === "accounts" && isDirector && <AccountsSection currentUserId={user.id} />}
+        </div>
+      </div>
+    </DashboardShell>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Vertical nav
+// ---------------------------------------------------------------------------
+
+function SettingsNav({
+  sections,
+  activeSection,
+  onSelect,
+}: {
+  sections: SectionDef[];
+  activeSection: SectionId;
+  onSelect: (id: SectionId) => void;
+}) {
+  const personal = sections.filter((s) => s.group === "personal");
+  const workspace = sections.filter((s) => s.group === "workspace");
+
+  return (
+    <nav className="md:sticky md:top-0 self-start space-y-7">
+      <NavGroup label="Personal" sections={personal} active={activeSection} onSelect={onSelect} />
+      {workspace.length > 0 && (
+        <NavGroup label="Workspace" sections={workspace} active={activeSection} onSelect={onSelect} />
+      )}
+    </nav>
+  );
+}
+
+function NavGroup({
+  label,
+  sections,
+  active,
+  onSelect,
+}: {
+  label: string;
+  sections: SectionDef[];
+  active: SectionId;
+  onSelect: (id: SectionId) => void;
+}) {
+  return (
+    <div>
+      <div className="px-3 mb-2 text-[10px] tracking-[0.25em] uppercase text-sbi-muted-dark font-light">
+        {label}
+      </div>
+      <div className="space-y-0.5">
+        {sections.map((s) => {
+          const isActive = active === s.id;
+          return (
+            <button
+              key={s.id}
+              type="button"
+              onClick={() => onSelect(s.id)}
+              className={`group relative w-full flex items-center gap-3 px-3 py-2 rounded-md text-sm font-light transition-colors cursor-pointer ${
+                isActive ? "text-white bg-sbi-green/5" : "text-sbi-muted hover:text-white hover:bg-white/[0.02]"
+              }`}
+            >
+              <span
+                className={`absolute left-0 top-1/2 -translate-y-1/2 w-0.5 h-4 rounded-full bg-sbi-green transition-opacity ${
+                  isActive ? "opacity-100" : "opacity-0"
+                }`}
+              />
+              <s.icon
+                className={`size-4 transition-colors ${
+                  isActive ? "text-sbi-green" : "text-sbi-muted-dark group-hover:text-sbi-green/70"
+                }`}
+                strokeWidth={1.5}
+              />
+              <span>{s.label}</span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Shared classes
+// ---------------------------------------------------------------------------
+
+const inputClass =
+  "w-full bg-sbi-dark border border-sbi-dark-border/50 text-white text-sm rounded-md px-3 py-2 " +
+  "focus:outline-none focus:border-sbi-green/50 disabled:opacity-50 placeholder:text-sbi-muted-dark/60";
+
+const labelClass = "text-[11px] tracking-[0.15em] uppercase text-sbi-muted-dark font-light";
+
+function initialsOf(name: string): string {
+  const parts = name.trim().split(/\s+/);
+  if (parts.length >= 2) return `${parts[0][0]}${parts[parts.length - 1][0]}`.toUpperCase();
+  return parts[0]?.substring(0, 2).toUpperCase() || "??";
+}
+
+// ---------------------------------------------------------------------------
+// Profile section
+// ---------------------------------------------------------------------------
+
+function ProfileSection() {
+  const [account, setAccount] = useState<MyAccount | null>(null);
+  const [name, setName] = useState("");
+  const [department, setDepartment] = useState("");
+  const [saving, setSaving] = useState(false);
 
   useEffect(() => {
-    if (!isLoading && user?.role !== "director") {
-      router.replace("/dashboard");
-    }
-  }, [user, isLoading, router]);
+    getMyAccount().then((res) => {
+      if (res.account) {
+        setAccount(res.account);
+        setName(res.account.name);
+        setDepartment(res.account.department ?? "");
+      }
+    });
+  }, []);
 
-  const loadCalendars = useCallback(async () => {
-    setCalendarLoading(true);
-    setCalendarError("");
+  if (!account) {
+    return (
+      <Panel>
+        <div className="flex items-center gap-2 text-sbi-muted text-sm">
+          <Loader2 className="size-4 animate-spin" /> Loading your profile…
+        </div>
+      </Panel>
+    );
+  }
+
+  const isDirty =
+    name.trim() !== account.name ||
+    (department.trim() || null) !== (account.department || null);
+  const showDepartment = account.role === "member" || account.role === "director";
+
+  const handleSave = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSaving(true);
+    const result = await updateMyProfile({ name, department: department.trim() || null });
+    if (result.error) {
+      toastError(result.error, "Couldn't save profile");
+    } else {
+      const next = { ...account, name: name.trim(), department: department.trim() || null };
+      setAccount(next);
+      toastSuccess("Profile saved.");
+    }
+    setSaving(false);
+  };
+
+  return (
+    <div className="max-w-2xl space-y-4">
+      <Panel>
+        <SectionLabel>Profile</SectionLabel>
+        <p className="text-sbi-muted text-sm mb-6">
+          How you appear inside the portal. Your email is your sign-in and cannot be changed here.
+        </p>
+
+        <form onSubmit={handleSave} className="space-y-5">
+          <div className="grid grid-cols-1 sm:grid-cols-[80px_1fr] items-center gap-4">
+            <div className="size-16 rounded-lg border border-sbi-dark-border/60 flex items-center justify-center text-base font-light text-sbi-green tracking-wider">
+              {initialsOf(account.name)}
+            </div>
+            <div className="min-w-0">
+              <p className="text-white text-base font-light truncate">{account.name}</p>
+              <p className="text-sbi-muted text-sm truncate">{account.email}</p>
+              <span
+                className={`mt-2 inline-block text-[10px] uppercase tracking-[0.15em] px-2 py-0.5 rounded border ${roleBadgeColor(account.role)}`}
+              >
+                {account.role}
+              </span>
+            </div>
+          </div>
+
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 pt-2">
+            <div>
+              <label className={labelClass}>Name</label>
+              <input
+                type="text"
+                required
+                minLength={2}
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                className={`${inputClass} mt-1`}
+              />
+            </div>
+            <div>
+              <label className={labelClass}>Email</label>
+              <input
+                type="email"
+                value={account.email ?? ""}
+                readOnly
+                className={`${inputClass} mt-1 cursor-not-allowed text-sbi-muted`}
+              />
+            </div>
+            {showDepartment && (
+              <div className="sm:col-span-2">
+                <label className={labelClass}>Department</label>
+                <input
+                  type="text"
+                  value={department}
+                  onChange={(e) => setDepartment(e.target.value)}
+                  placeholder="e.g. Engineering, Architecture, Business"
+                  className={`${inputClass} mt-1`}
+                />
+              </div>
+            )}
+          </div>
+
+          <div className="flex justify-end pt-2">
+            <button type="submit" disabled={!isDirty || saving} className={btnPrimary}>
+              {saving ? "Saving…" : "Save changes"}
+            </button>
+          </div>
+        </form>
+      </Panel>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Security section
+// ---------------------------------------------------------------------------
+
+function SecuritySection() {
+  const router = useRouter();
+  const [newPassword, setNewPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState("");
+  const [showSignOutEverywhere, setShowSignOutEverywhere] = useState(false);
+
+  const handleChangePassword = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError("");
+    if (newPassword.length < 8) {
+      setError("Password must be at least 8 characters.");
+      return;
+    }
+    if (newPassword !== confirmPassword) {
+      setError("Passwords don't match.");
+      return;
+    }
+    setSaving(true);
+    const result = await updateMyPassword(newPassword);
+    if (result.error) {
+      setError(result.error);
+      toastError(result.error, "Couldn't update password");
+    } else {
+      setNewPassword("");
+      setConfirmPassword("");
+      toastSuccess("Password updated.");
+    }
+    setSaving(false);
+  };
+
+  const handleSignOutEverywhere = async () => {
+    const supabase = createClient();
+    await supabase.auth.signOut({ scope: "global" });
+    router.push("/login");
+  };
+
+  return (
+    <div className="max-w-2xl space-y-4">
+      <Panel>
+        <SectionLabel>Password</SectionLabel>
+        <p className="text-sbi-muted text-sm mb-6">
+          Choose a new password at least 8 characters long. You'll stay signed in on this device.
+        </p>
+        <form onSubmit={handleChangePassword} className="space-y-4">
+          <div>
+            <label className={labelClass}>New password</label>
+            <input
+              type="password"
+              required
+              autoComplete="new-password"
+              value={newPassword}
+              onChange={(e) => setNewPassword(e.target.value)}
+              className={`${inputClass} mt-1`}
+            />
+          </div>
+          <div>
+            <label className={labelClass}>Confirm new password</label>
+            <input
+              type="password"
+              required
+              autoComplete="new-password"
+              value={confirmPassword}
+              onChange={(e) => setConfirmPassword(e.target.value)}
+              className={`${inputClass} mt-1`}
+            />
+          </div>
+          {error && <p className="text-red-400 text-sm">{error}</p>}
+          <div className="flex justify-end">
+            <button
+              type="submit"
+              disabled={saving || !newPassword || !confirmPassword}
+              className={btnPrimary}
+            >
+              {saving ? "Updating…" : "Update password"}
+            </button>
+          </div>
+        </form>
+      </Panel>
+
+      <Panel>
+        <SectionLabel>Sessions</SectionLabel>
+        <p className="text-sbi-muted text-sm mb-6">
+          Sign out of every device where this account is currently active.
+        </p>
+        <div className="flex justify-end">
+          <button
+            type="button"
+            onClick={() => setShowSignOutEverywhere(true)}
+            className={btnGhost}
+          >
+            Sign out everywhere
+          </button>
+        </div>
+      </Panel>
+
+      <ConfirmDialog
+        opened={showSignOutEverywhere}
+        onClose={() => setShowSignOutEverywhere(false)}
+        title="Sign out everywhere?"
+        description="You'll be signed out on every device including this one. You'll need to sign in again."
+        confirmLabel="Sign out everywhere"
+        onConfirm={handleSignOutEverywhere}
+      />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Notifications section
+// ---------------------------------------------------------------------------
+
+const NOTIFICATION_ITEMS: { key: keyof NotificationPrefs; label: string; description: string }[] = [
+  { key: "messages", label: "New messages", description: "Email me when I receive a portal message." },
+  { key: "calendar", label: "Calendar events", description: "Email me when an event involving me is created or changes." },
+  { key: "requests", label: "Request updates", description: "Email me when a request I'm involved in changes status." },
+  { key: "reports", label: "New reports", description: "Email me when a new report is published to my project." },
+  { key: "weeklyDigest", label: "Weekly digest", description: "A Monday summary of what changed last week." },
+];
+
+function NotificationsSection() {
+  const [prefs, setPrefs] = useState<NotificationPrefs | null>(null);
+  const [initial, setInitial] = useState<NotificationPrefs | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    getMyAccount().then((res) => {
+      if (res.account) {
+        setPrefs(res.account.prefs);
+        setInitial(res.account.prefs);
+      }
+    });
+  }, []);
+
+  if (!prefs || !initial) {
+    return (
+      <Panel>
+        <div className="flex items-center gap-2 text-sbi-muted text-sm">
+          <Loader2 className="size-4 animate-spin" /> Loading your preferences…
+        </div>
+      </Panel>
+    );
+  }
+
+  const isDirty = (Object.keys(prefs) as (keyof NotificationPrefs)[]).some(
+    (k) => prefs[k] !== initial[k],
+  );
+
+  const toggle = (k: keyof NotificationPrefs) => setPrefs({ ...prefs, [k]: !prefs[k] });
+
+  const handleSave = async () => {
+    setSaving(true);
+    const result = await updateMyNotificationPrefs(prefs);
+    if (result.error) {
+      toastError(result.error, "Couldn't save preferences");
+    } else {
+      setInitial(prefs);
+      toastSuccess("Preferences saved.");
+    }
+    setSaving(false);
+  };
+
+  const handleReset = () => setPrefs(DEFAULT_NOTIFICATION_PREFS);
+
+  return (
+    <div className="max-w-2xl space-y-4">
+      <Panel>
+        <SectionLabel>Email notifications</SectionLabel>
+        <p className="text-sbi-muted text-sm mb-6">
+          Choose what reaches your inbox. Anything turned off still appears inside the portal.
+        </p>
+
+        <ul className="divide-y divide-sbi-dark-border/30">
+          {NOTIFICATION_ITEMS.map((item) => (
+            <li key={item.key} className="flex items-start justify-between gap-6 py-4 first:pt-0 last:pb-0">
+              <div className="min-w-0">
+                <p className="text-sm text-white">{item.label}</p>
+                <p className="text-xs text-sbi-muted-dark mt-0.5">{item.description}</p>
+              </div>
+              <Toggle checked={prefs[item.key]} onChange={() => toggle(item.key)} label={item.label} />
+            </li>
+          ))}
+        </ul>
+
+        <div className="flex items-center justify-end gap-2 pt-6">
+          <button type="button" onClick={handleReset} className={btnGhost}>
+            Reset to defaults
+          </button>
+          <button type="button" onClick={handleSave} disabled={!isDirty || saving} className={btnPrimary}>
+            {saving ? "Saving…" : "Save changes"}
+          </button>
+        </div>
+      </Panel>
+    </div>
+  );
+}
+
+function Toggle({
+  checked,
+  onChange,
+  label,
+}: {
+  checked: boolean;
+  onChange: () => void;
+  label: string;
+}) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      aria-label={label}
+      onClick={onChange}
+      className={`relative shrink-0 inline-flex h-5 w-9 items-center rounded-full transition-colors cursor-pointer ${
+        checked ? "bg-sbi-green/70" : "bg-sbi-dark-border/60"
+      }`}
+    >
+      <span
+        className={`inline-block size-3.5 rounded-full bg-white shadow-sm transition-transform ${
+          checked ? "translate-x-[1.125rem]" : "translate-x-[0.1875rem]"
+        }`}
+      />
+    </button>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Calendar section (director only)
+// ---------------------------------------------------------------------------
+
+function CalendarSection() {
+  const [calendars, setCalendars] = useState<GoogleCalendar[]>([]);
+  const [selectedCalendarId, setSelectedCalendarId] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState("");
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError("");
     try {
-      // Fetch saved calendar_id from profile config
       const supabase = createClient();
       const { data: { user: authUser } } = await supabase.auth.getUser();
       if (authUser) {
@@ -98,27 +653,24 @@ export default function SettingsPage() {
           .select("config")
           .eq("uid", authUser.id)
           .single();
-        const savedId = (profile?.config as Record<string, any>)?.google?.calendar_id;
-        if (savedId) setSelectedCalendarId(savedId);
+        const google = (profile?.config as Record<string, unknown>)?.google as Record<string, string> | undefined;
+        if (google?.calendar_id) setSelectedCalendarId(google.calendar_id);
       }
-
-      // Fetch available calendars
       const res = await fetch("/api/contact/calendar/client-events/list");
       const data = await res.json();
-      if (res.ok && data.calendars) {
-        setCalendars(data.calendars);
-      }
+      if (res.ok && data.calendars) setCalendars(data.calendars);
     } catch {
-      // No OAuth token or network error — just leave calendars empty
+      // No OAuth token or network error — leave empty.
     } finally {
-      setCalendarLoading(false);
+      setLoading(false);
     }
   }, []);
 
-  const handleSelectCalendar = async (calendarId: string) => {
-    setCalendarSaving(true);
-    setCalendarError("");
-    setCalendarSuccess("");
+  useEffect(() => { load(); }, [load]);
+
+  const handleSelect = async (calendarId: string) => {
+    setSaving(true);
+    setError("");
     try {
       const res = await fetch("/api/contact/calendar/client-events/select", {
         method: "POST",
@@ -128,393 +680,456 @@ export default function SettingsPage() {
       const data = await res.json();
       if (res.ok && data.ok) {
         setSelectedCalendarId(calendarId);
-        setCalendarSuccess("Calendar saved successfully.");
-        setTimeout(() => setCalendarSuccess(""), 3000);
+        toastSuccess("Calendar saved.");
       } else {
-        setCalendarError(data.error || "Failed to save calendar.");
+        const msg = data.error || "Couldn't save the selected calendar.";
+        setError(msg);
+        toastError(msg, "Couldn't save calendar");
       }
     } catch {
-      setCalendarError("Failed to save calendar.");
+      const msg = "Couldn't reach the calendar service.";
+      setError(msg);
+      toastError(msg);
     } finally {
-      setCalendarSaving(false);
-    }
-  };
-
-  const loadAccounts = useCallback(async () => {
-    const result = await listAccounts();
-    if (result.accounts) setAccounts(result.accounts);
-  }, []);
-
-  const loadProjects = useCallback(async () => {
-    const result = await listProjects();
-    if (result.projects) {
-      setProjects(result.projects);
-      if (result.projects.length > 0 && !selectedProjectId) {
-        setSelectedProjectId(result.projects[0].id);
-      }
-    }
-  }, [selectedProjectId]);
-
-  useEffect(() => {
-    if (user?.role === "director") {
-      loadAccounts();
-      loadProjects();
-      loadCalendars();
-    }
-  }, [user, loadAccounts, loadProjects, loadCalendars]);
-
-  const loadProjectMembers = useCallback(async (projectId: number) => {
-    const [membersResult, unassignedResult] = await Promise.all([
-      listProjectMembers(projectId),
-      listUnassignedMembers(projectId),
-    ]);
-    if (membersResult.members) setProjectMembers(membersResult.members as ProjectMember[]);
-    if (unassignedResult.members) setUnassignedMembers(unassignedResult.members);
-  }, []);
-
-  useEffect(() => {
-    if (selectedProjectId) loadProjectMembers(selectedProjectId);
-  }, [selectedProjectId, loadProjectMembers]);
-
-  const handleCreateAccount = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setCreateLoading(true);
-    setCreateError("");
-
-    const result = await createAccount(createForm);
-    if (result.error) {
-      setCreateError(result.error);
-    } else {
-      setShowCreateForm(false);
-      setCreateForm({ email: "", password: "", name: "", role: "member", companyName: "", department: "" });
-      loadAccounts();
-    }
-    setCreateLoading(false);
-  };
-
-  const handleDeleteAccount = async (profileId: number) => {
-    if (!confirm("Are you sure you want to delete this account?")) return;
-    const result = await deleteAccount(profileId);
-    if (!result.error) loadAccounts();
-  };
-
-  const handleAssignMember = async (profileId: number) => {
-    if (!selectedProjectId) return;
-    const result = await assignMemberToProject(profileId, selectedProjectId);
-    if (!result.error) {
-      loadProjectMembers(selectedProjectId);
-      setShowAssignDropdown(false);
-    }
-  };
-
-  const handleRemoveMember = async (membershipId: number) => {
-    if (!selectedProjectId) return;
-    const result = await removeMemberFromProject(membershipId);
-    if (!result.error) loadProjectMembers(selectedProjectId);
-  };
-
-  if (isLoading || user?.role !== "director") return null;
-
-  const roleBadgeColor = (role: string) => {
-    switch (role) {
-      case "director": return "bg-amber-500/10 text-amber-400 border-amber-500/30";
-      case "client": return "bg-blue-500/10 text-blue-400 border-blue-500/30";
-      case "member": return "bg-sbi-green/10 text-sbi-green border-sbi-green/30";
-      case "owner": return "bg-purple-500/10 text-purple-400 border-purple-500/30";
-      default: return "bg-white/10 text-white/70 border-white/20";
+      setSaving(false);
     }
   };
 
   return (
-    <div className="h-[calc(100vh-4rem)] bg-sbi-dark flex flex-col p-6 md:p-8 overflow-y-auto">
-      <div className="max-w-4xl w-full mx-auto">
-        <h1 className="text-2xl md:text-3xl font-light tracking-tight text-white mb-2">Settings</h1>
-        <p className="text-sbi-muted text-sm mb-8">Manage your portal configuration</p>
+    <div className="max-w-2xl space-y-4">
+      <Panel>
+        <SectionLabel>Google Calendar</SectionLabel>
+        <p className="text-sbi-muted text-sm mb-5">
+          Connect your Google Calendar so clients can see your availability and scheduled events.
+        </p>
+        <a href="/api/contact/auth/google" className={btnPrimary}>
+          {calendars.length > 0 ? "Reconnect Google Calendar" : "Connect Google Calendar"}
+        </a>
 
-        <div className="grid gap-6">
-          {/* Google Calendar */}
-          <section className="bg-sbi-dark-card/40 border border-sbi-dark-border/30 rounded-lg p-6">
-            <div className="flex items-center gap-3 mb-4">
-              <Calendar className="size-5 text-sbi-green" />
-              <h2 className="text-lg font-light text-white">Google Calendar</h2>
+        {loading && (
+          <div className="flex items-center gap-2 mt-4 text-sbi-muted text-sm">
+            <Loader2 className="size-4 animate-spin" /> Loading calendars…
+          </div>
+        )}
+
+        {calendars.length > 0 && !loading && (
+          <div className="mt-6">
+            <label className={labelClass}>Calendar for client events</label>
+            <div className="relative mt-1">
+              <select
+                value={selectedCalendarId}
+                onChange={(e) => handleSelect(e.target.value)}
+                disabled={saving}
+                className={`${inputClass} appearance-none cursor-pointer pr-9`}
+              >
+                <option value="">Choose a calendar…</option>
+                {calendars.map((cal) => (
+                  <option key={cal.id} value={cal.id}>
+                    {cal.summary}{cal.primary ? " (Primary)" : ""}
+                  </option>
+                ))}
+              </select>
+              <ChevronDown className="absolute right-3 top-1/2 -translate-y-1/2 size-4 text-sbi-muted pointer-events-none" />
             </div>
-            <p className="text-sbi-muted text-sm mb-4">
-              Connect your Google Calendar so clients can see your availability and scheduled events.
-            </p>
-            <a
-              href="/api/contact/auth/google"
-              className="inline-flex items-center gap-2 px-4 py-2 text-sm bg-sbi-green/10 text-sbi-green border border-sbi-green/30 hover:bg-sbi-green hover:text-sbi-dark transition-all duration-300 rounded"
+            {selectedCalendarId && (
+              <div className="flex items-center gap-2 mt-2 text-sbi-green text-sm">
+                <Check className="size-4" />
+                Using: {calendars.find((c) => c.id === selectedCalendarId)?.summary ?? selectedCalendarId}
+              </div>
+            )}
+          </div>
+        )}
+
+        {error && <p className="text-red-400 text-sm mt-3">{error}</p>}
+      </Panel>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Team section (director only)
+// ---------------------------------------------------------------------------
+
+function TeamSection() {
+  const [projects, setProjects] = useState<Project[]>([]);
+  const [selectedProjectId, setSelectedProjectId] = useState<number | null>(null);
+  const [projectMembers, setProjectMembers] = useState<ProjectMember[]>([]);
+  const [unassignedMembers, setUnassignedMembers] = useState<UnassignedMember[]>([]);
+  const [showAssignDropdown, setShowAssignDropdown] = useState(false);
+  const [memberToRemove, setMemberToRemove] = useState<ProjectMember | null>(null);
+
+  const loadProjects = useCallback(async () => {
+    const res = await listProjects();
+    if (res.projects) {
+      setProjects(res.projects);
+      if (res.projects.length > 0) setSelectedProjectId((curr) => curr ?? res.projects[0].id);
+    }
+  }, []);
+
+  const loadProjectMembers = useCallback(async (projectId: number) => {
+    const [m, u] = await Promise.all([
+      listProjectMembers(projectId),
+      listUnassignedMembers(projectId),
+    ]);
+    if (m.members) setProjectMembers(m.members as ProjectMember[]);
+    if (u.members) setUnassignedMembers(u.members);
+  }, []);
+
+  useEffect(() => { loadProjects(); }, [loadProjects]);
+  useEffect(() => { if (selectedProjectId) loadProjectMembers(selectedProjectId); }, [selectedProjectId, loadProjectMembers]);
+
+  const handleAssign = async (profileId: number) => {
+    if (!selectedProjectId) return;
+    const res = await assignMemberToProject(profileId, selectedProjectId);
+    if (res.error) toastError(res.error, "Couldn't assign member");
+    else {
+      loadProjectMembers(selectedProjectId);
+      setShowAssignDropdown(false);
+      toastSuccess("Member assigned to project.");
+    }
+  };
+
+  const confirmRemove = async () => {
+    if (!memberToRemove || !selectedProjectId) return;
+    const target = memberToRemove;
+    const res = await removeMemberFromProject(target.id);
+    if (res.error) toastError(res.error, "Couldn't remove member");
+    else {
+      toastSuccess(`Removed ${target.profiles.name} from project.`);
+      loadProjectMembers(selectedProjectId);
+    }
+    setMemberToRemove(null);
+  };
+
+  return (
+    <div className="max-w-3xl space-y-4">
+      <Panel>
+        <SectionLabel>Project members</SectionLabel>
+        <p className="text-sbi-muted text-sm mb-5">
+          Assign members to projects. Directors are automatically assigned to every project.
+        </p>
+
+        <div className="mb-5">
+          <label className={labelClass}>Project</label>
+          <div className="relative mt-1">
+            <select
+              value={selectedProjectId ?? ""}
+              onChange={(e) => setSelectedProjectId(Number(e.target.value))}
+              className={`${inputClass} appearance-none cursor-pointer pr-9`}
             >
-              {calendars.length > 0 ? "Reconnect Google Calendar" : "Connect Google Calendar"}
-            </a>
-
-            {calendarLoading && (
-              <div className="flex items-center gap-2 mt-4 text-sbi-muted text-sm">
-                <Loader2 className="size-4 animate-spin" />
-                Loading calendars...
-              </div>
-            )}
-
-            {calendars.length > 0 && !calendarLoading && (
-              <div className="mt-4">
-                <label className="text-xs tracking-widest uppercase text-sbi-muted mb-2 block">
-                  Select Calendar for Client Events
-                </label>
-                <div className="relative">
-                  <select
-                    value={selectedCalendarId}
-                    onChange={(e) => handleSelectCalendar(e.target.value)}
-                    disabled={calendarSaving}
-                    className="w-full bg-sbi-dark border border-sbi-dark-border/50 text-white text-sm rounded px-3 py-2 appearance-none cursor-pointer focus:outline-none focus:border-sbi-green/50 disabled:opacity-50"
-                  >
-                    <option value="">Choose a calendar...</option>
-                    {calendars.map((cal) => (
-                      <option key={cal.id} value={cal.id}>
-                        {cal.summary}{cal.primary ? " (Primary)" : ""}
-                      </option>
-                    ))}
-                  </select>
-                  <ChevronDown className="absolute right-3 top-1/2 -translate-y-1/2 size-4 text-sbi-muted pointer-events-none" />
-                </div>
-                {selectedCalendarId && (
-                  <div className="flex items-center gap-2 mt-2 text-sbi-green text-sm">
-                    <Check className="size-4" />
-                    Using: {calendars.find((c) => c.id === selectedCalendarId)?.summary ?? selectedCalendarId}
-                  </div>
-                )}
-              </div>
-            )}
-
-            {calendarSuccess && (
-              <p className="text-sbi-green text-sm mt-2">{calendarSuccess}</p>
-            )}
-            {calendarError && (
-              <p className="text-red-400 text-sm mt-2">{calendarError}</p>
-            )}
-          </section>
-
-          {/* Team Management */}
-          <section className="bg-sbi-dark-card/40 border border-sbi-dark-border/30 rounded-lg p-6">
-            <div className="flex items-center gap-3 mb-4">
-              <Users className="size-5 text-sbi-green" />
-              <h2 className="text-lg font-light text-white">Team Management</h2>
-            </div>
-            <p className="text-sbi-muted text-sm mb-4">
-              Assign members to projects. Directors are auto-assigned to all projects.
-            </p>
-
-            {/* Project selector */}
-            <div className="mb-4">
-              <label className="text-xs tracking-widest uppercase text-sbi-muted mb-2 block">Project</label>
-              <div className="relative">
-                <select
-                  value={selectedProjectId ?? ""}
-                  onChange={(e) => setSelectedProjectId(Number(e.target.value))}
-                  className="w-full bg-sbi-dark border border-sbi-dark-border/50 text-white text-sm rounded px-3 py-2 appearance-none cursor-pointer focus:outline-none focus:border-sbi-green/50"
-                >
-                  {projects.map((p) => (
-                    <option key={p.id} value={p.id}>{p.company_name}</option>
-                  ))}
-                </select>
-                <ChevronDown className="absolute right-3 top-1/2 -translate-y-1/2 size-4 text-sbi-muted pointer-events-none" />
-              </div>
-            </div>
-
-            {/* Current members */}
-            <div className="space-y-2 mb-4">
-              {projectMembers.map((pm) => (
-                <div key={pm.id} className="flex items-center justify-between px-3 py-2 bg-sbi-dark/50 border border-sbi-dark-border/20 rounded">
-                  <div className="flex items-center gap-3">
-                    <span className="text-sm text-white">{pm.profiles.name}</span>
-                    <span className="text-xs text-sbi-muted">{pm.profiles.email}</span>
-                    <span className={`text-[10px] uppercase tracking-wider px-2 py-0.5 rounded border ${roleBadgeColor(pm.role)}`}>
-                      {pm.role}
-                    </span>
-                  </div>
-                  {pm.role === "member" && (
-                    <button
-                      type="button"
-                      onClick={() => handleRemoveMember(pm.id)}
-                      className="text-red-400/50 hover:text-red-400 transition-colors cursor-pointer"
-                    >
-                      <Trash2 className="size-4" />
-                    </button>
-                  )}
-                </div>
+              {projects.map((p) => (
+                <option key={p.id} value={p.id}>{p.company_name}</option>
               ))}
-              {projectMembers.length === 0 && (
-                <p className="text-sbi-muted/50 text-sm">No members assigned yet.</p>
-              )}
-            </div>
+            </select>
+            <ChevronDown className="absolute right-3 top-1/2 -translate-y-1/2 size-4 text-sbi-muted pointer-events-none" />
+          </div>
+        </div>
 
-            {/* Assign member */}
-            <div className="relative">
-              <button
-                type="button"
-                onClick={() => setShowAssignDropdown(!showAssignDropdown)}
-                className="inline-flex items-center gap-2 px-3 py-2 text-sm bg-sbi-green/10 text-sbi-green border border-sbi-green/30 hover:bg-sbi-green hover:text-sbi-dark transition-all duration-300 rounded cursor-pointer"
+        {projectMembers.length === 0 ? (
+          <EmptyState
+            icon={<Users className="size-6" />}
+            title="No members assigned"
+            description="Assign members to this project using the button below."
+            className="py-10"
+          />
+        ) : (
+          <div className="space-y-2 mb-5">
+            {projectMembers.map((pm) => (
+              <div
+                key={pm.id}
+                className="flex items-center justify-between px-3 py-2 bg-sbi-dark/40 border border-sbi-dark-border/20 rounded-md"
               >
-                <UserPlus className="size-4" />
-                Assign Member
-              </button>
-              {showAssignDropdown && (
-                <div className="absolute top-full mt-1 left-0 w-80 bg-sbi-dark border border-sbi-dark-border/50 rounded-lg shadow-2xl shadow-black/50 z-50 max-h-60 overflow-y-auto">
-                  {unassignedMembers.length === 0 ? (
-                    <p className="px-4 py-3 text-sbi-muted/50 text-sm">No unassigned members available.</p>
-                  ) : (
-                    unassignedMembers.map((m) => (
-                      <button
-                        key={m.id}
-                        type="button"
-                        onClick={() => handleAssignMember(m.id)}
-                        className="w-full text-left px-4 py-2.5 hover:bg-white/5 transition-colors cursor-pointer"
-                      >
-                        <span className="text-sm text-white">{m.name}</span>
-                        <span className="text-xs text-sbi-muted ml-2">{m.email}</span>
-                        {m.department && <span className="text-xs text-sbi-muted/50 ml-2">({m.department})</span>}
-                      </button>
-                    ))
-                  )}
+                <div className="flex items-center gap-3 min-w-0">
+                  <span className="text-sm text-white truncate">{pm.profiles.name}</span>
+                  <span className="text-xs text-sbi-muted truncate">{pm.profiles.email}</span>
+                  <span className={`shrink-0 text-[10px] uppercase tracking-[0.15em] px-2 py-0.5 rounded border ${roleBadgeColor(pm.role)}`}>
+                    {pm.role}
+                  </span>
                 </div>
-              )}
-            </div>
-          </section>
-
-          {/* Account Management */}
-          <section className="bg-sbi-dark-card/40 border border-sbi-dark-border/30 rounded-lg p-6">
-            <div className="flex items-center justify-between mb-4">
-              <div className="flex items-center gap-3">
-                <Shield className="size-5 text-sbi-green" />
-                <h2 className="text-lg font-light text-white">Account Management</h2>
-              </div>
-              <button
-                type="button"
-                onClick={() => setShowCreateForm(!showCreateForm)}
-                className="inline-flex items-center gap-2 px-3 py-2 text-sm bg-sbi-green/10 text-sbi-green border border-sbi-green/30 hover:bg-sbi-green hover:text-sbi-dark transition-all duration-300 rounded cursor-pointer"
-              >
-                <Plus className="size-4" />
-                Create Account
-              </button>
-            </div>
-
-            {/* Create form */}
-            {showCreateForm && (
-              <form onSubmit={handleCreateAccount} className="mb-6 p-4 bg-sbi-dark/50 border border-sbi-dark-border/20 rounded-lg space-y-3">
-                <div className="grid grid-cols-2 gap-3">
-                  <div>
-                    <label className="text-xs tracking-widest uppercase text-sbi-muted mb-1 block">Name</label>
-                    <input
-                      type="text"
-                      required
-                      value={createForm.name}
-                      onChange={(e) => setCreateForm(f => ({ ...f, name: e.target.value }))}
-                      className="w-full bg-sbi-dark border border-sbi-dark-border/50 text-white text-sm rounded px-3 py-2 focus:outline-none focus:border-sbi-green/50"
-                    />
-                  </div>
-                  <div>
-                    <label className="text-xs tracking-widest uppercase text-sbi-muted mb-1 block">Email</label>
-                    <input
-                      type="email"
-                      required
-                      value={createForm.email}
-                      onChange={(e) => setCreateForm(f => ({ ...f, email: e.target.value }))}
-                      className="w-full bg-sbi-dark border border-sbi-dark-border/50 text-white text-sm rounded px-3 py-2 focus:outline-none focus:border-sbi-green/50"
-                    />
-                  </div>
-                  <div>
-                    <label className="text-xs tracking-widest uppercase text-sbi-muted mb-1 block">Password</label>
-                    <input
-                      type="password"
-                      required
-                      value={createForm.password}
-                      onChange={(e) => setCreateForm(f => ({ ...f, password: e.target.value }))}
-                      className="w-full bg-sbi-dark border border-sbi-dark-border/50 text-white text-sm rounded px-3 py-2 focus:outline-none focus:border-sbi-green/50"
-                    />
-                  </div>
-                  <div>
-                    <label className="text-xs tracking-widest uppercase text-sbi-muted mb-1 block">Role</label>
-                    <select
-                      value={createForm.role}
-                      onChange={(e) => setCreateForm(f => ({ ...f, role: e.target.value as any }))}
-                      className="w-full bg-sbi-dark border border-sbi-dark-border/50 text-white text-sm rounded px-3 py-2 appearance-none cursor-pointer focus:outline-none focus:border-sbi-green/50"
-                    >
-                      <option value="member">Member</option>
-                      <option value="client">Client</option>
-                      <option value="director">Director</option>
-                    </select>
-                  </div>
-                  {createForm.role === "client" && (
-                    <div className="col-span-2">
-                      <label className="text-xs tracking-widest uppercase text-sbi-muted mb-1 block">Company Name</label>
-                      <input
-                        type="text"
-                        required
-                        value={createForm.companyName}
-                        onChange={(e) => setCreateForm(f => ({ ...f, companyName: e.target.value }))}
-                        className="w-full bg-sbi-dark border border-sbi-dark-border/50 text-white text-sm rounded px-3 py-2 focus:outline-none focus:border-sbi-green/50"
-                      />
-                    </div>
-                  )}
-                  {createForm.role === "member" && (
-                    <div className="col-span-2">
-                      <label className="text-xs tracking-widest uppercase text-sbi-muted mb-1 block">Department</label>
-                      <input
-                        type="text"
-                        value={createForm.department}
-                        onChange={(e) => setCreateForm(f => ({ ...f, department: e.target.value }))}
-                        className="w-full bg-sbi-dark border border-sbi-dark-border/50 text-white text-sm rounded px-3 py-2 focus:outline-none focus:border-sbi-green/50"
-                        placeholder="e.g. Engineering, Business, Tech"
-                      />
-                    </div>
-                  )}
-                </div>
-                {createError && <p className="text-red-400 text-sm">{createError}</p>}
-                <div className="flex gap-2">
-                  <button
-                    type="submit"
-                    disabled={createLoading}
-                    className="px-4 py-2 text-sm bg-sbi-green text-sbi-dark rounded hover:bg-sbi-green/80 transition-colors disabled:opacity-50 cursor-pointer"
-                  >
-                    {createLoading ? "Creating..." : "Create"}
-                  </button>
+                {pm.role === "member" && (
                   <button
                     type="button"
-                    onClick={() => setShowCreateForm(false)}
-                    className="px-4 py-2 text-sm text-sbi-muted hover:text-white transition-colors cursor-pointer"
+                    onClick={() => setMemberToRemove(pm)}
+                    aria-label={`Remove ${pm.profiles.name} from project`}
+                    title={`Remove ${pm.profiles.name} from project`}
+                    className="text-red-400/50 hover:text-red-400 transition-colors cursor-pointer"
                   >
-                    Cancel
+                    <Trash2 className="size-4" />
                   </button>
-                </div>
-              </form>
-            )}
+                )}
+              </div>
+            ))}
+          </div>
+        )}
 
-            {/* Account list */}
-            <div className="space-y-2">
-              {accounts.map((account) => (
-                <div key={account.id} className="flex items-center justify-between px-3 py-2 bg-sbi-dark/50 border border-sbi-dark-border/20 rounded">
-                  <div className="flex items-center gap-3">
-                    <span className="text-sm text-white">{account.name}</span>
-                    <span className="text-xs text-sbi-muted">{account.email}</span>
-                    <span className={`text-[10px] uppercase tracking-wider px-2 py-0.5 rounded border ${roleBadgeColor(account.role)}`}>
-                      {account.role}
-                    </span>
-                    {account.department && <span className="text-xs text-sbi-muted/50">({account.department})</span>}
-                  </div>
-                  {account.id !== user?.id && (
-                    <button
-                      type="button"
-                      onClick={() => handleDeleteAccount(account.id)}
-                      className="text-red-400/50 hover:text-red-400 transition-colors cursor-pointer"
-                    >
-                      <Trash2 className="size-4" />
-                    </button>
-                  )}
-                </div>
-              ))}
+        <div className="relative mt-4">
+          <button
+            type="button"
+            onClick={() => setShowAssignDropdown(!showAssignDropdown)}
+            className={btnPrimary}
+          >
+            <UserPlus className="size-4" />
+            Assign member
+          </button>
+          {showAssignDropdown && (
+            <div className="absolute top-full mt-1 left-0 w-80 bg-sbi-dark border border-sbi-dark-border/50 rounded-lg shadow-2xl shadow-black/50 z-50 max-h-60 overflow-y-auto">
+              {unassignedMembers.length === 0 ? (
+                <p className="px-4 py-3 text-sbi-muted/70 text-sm">No unassigned members available.</p>
+              ) : (
+                unassignedMembers.map((m) => (
+                  <button
+                    key={m.id}
+                    type="button"
+                    onClick={() => handleAssign(m.id)}
+                    className="w-full text-left px-4 py-2.5 hover:bg-white/5 transition-colors cursor-pointer"
+                  >
+                    <span className="text-sm text-white">{m.name}</span>
+                    <span className="text-xs text-sbi-muted ml-2">{m.email}</span>
+                    {m.department && <span className="text-xs text-sbi-muted/50 ml-2">({m.department})</span>}
+                  </button>
+                ))
+              )}
             </div>
-          </section>
+          )}
         </div>
-      </div>
+      </Panel>
+
+      <ConfirmDialog
+        opened={!!memberToRemove}
+        onClose={() => setMemberToRemove(null)}
+        title="Remove member?"
+        danger
+        description={
+          memberToRemove ? (
+            <p>
+              Remove <span className="text-white font-medium">{memberToRemove.profiles.name}</span>{" "}
+              from this project? Their account stays; only the project assignment is removed.
+            </p>
+          ) : null
+        }
+        confirmLabel="Remove"
+        onConfirm={confirmRemove}
+      />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Accounts section (director only)
+// ---------------------------------------------------------------------------
+
+function AccountsSection({ currentUserId }: { currentUserId: number }) {
+  const [accounts, setAccounts] = useState<Account[]>([]);
+  const [showCreateForm, setShowCreateForm] = useState(false);
+  const [createForm, setCreateForm] = useState({
+    email: "", password: "", name: "",
+    role: "member" as "client" | "director" | "member",
+    companyName: "", department: "",
+  });
+  const [createError, setCreateError] = useState("");
+  const [createLoading, setCreateLoading] = useState(false);
+  const [accountToDelete, setAccountToDelete] = useState<Account | null>(null);
+
+  const loadAccounts = useCallback(async () => {
+    const res = await listAccounts();
+    if (res.accounts) setAccounts(res.accounts);
+  }, []);
+
+  useEffect(() => { loadAccounts(); }, [loadAccounts]);
+
+  const handleCreate = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setCreateLoading(true);
+    setCreateError("");
+    const res = await createAccount(createForm);
+    if (res.error) {
+      setCreateError(res.error);
+      toastError(res.error, "Couldn't create account");
+    } else {
+      const createdName = createForm.name;
+      setShowCreateForm(false);
+      setCreateForm({ email: "", password: "", name: "", role: "member", companyName: "", department: "" });
+      loadAccounts();
+      toastSuccess(`Account created for ${createdName}.`);
+    }
+    setCreateLoading(false);
+  };
+
+  const confirmDelete = async () => {
+    if (!accountToDelete) return;
+    const target = accountToDelete;
+    const res = await deleteAccount(target.id);
+    if (res.error) toastError(res.error, "Couldn't delete account");
+    else {
+      toastSuccess(`Deleted ${target.name}'s account.`);
+      loadAccounts();
+    }
+    setAccountToDelete(null);
+  };
+
+  return (
+    <div className="max-w-3xl space-y-4">
+      <Panel>
+        <div className="flex items-center justify-between mb-2">
+          <SectionLabel className="mb-0">Portal accounts</SectionLabel>
+          <button
+            type="button"
+            onClick={() => setShowCreateForm(!showCreateForm)}
+            className={btnPrimary}
+          >
+            <Plus className="size-4" />
+            Create account
+          </button>
+        </div>
+        <p className="text-sbi-muted text-sm mb-5">
+          Create and manage portal accounts for directors, members, and clients.
+        </p>
+
+        {showCreateForm && (
+          <form onSubmit={handleCreate} className="mt-2 p-4 bg-sbi-dark/50 border border-sbi-dark-border/20 rounded-lg space-y-3">
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <label className={labelClass}>Name</label>
+                <input
+                  type="text"
+                  required
+                  value={createForm.name}
+                  onChange={(e) => setCreateForm((f) => ({ ...f, name: e.target.value }))}
+                  className={`${inputClass} mt-1`}
+                />
+              </div>
+              <div>
+                <label className={labelClass}>Email</label>
+                <input
+                  type="email"
+                  required
+                  value={createForm.email}
+                  onChange={(e) => setCreateForm((f) => ({ ...f, email: e.target.value }))}
+                  className={`${inputClass} mt-1`}
+                />
+              </div>
+              <div>
+                <label className={labelClass}>Password</label>
+                <input
+                  type="password"
+                  required
+                  value={createForm.password}
+                  onChange={(e) => setCreateForm((f) => ({ ...f, password: e.target.value }))}
+                  className={`${inputClass} mt-1`}
+                />
+              </div>
+              <div>
+                <label className={labelClass}>Role</label>
+                <select
+                  value={createForm.role}
+                  onChange={(e) => setCreateForm((f) => ({ ...f, role: e.target.value as "client" | "director" | "member" }))}
+                  className={`${inputClass} mt-1 appearance-none cursor-pointer`}
+                >
+                  <option value="member">Member</option>
+                  <option value="client">Client</option>
+                  <option value="director">Director</option>
+                </select>
+              </div>
+              {createForm.role === "client" && (
+                <div className="col-span-2">
+                  <label className={labelClass}>Company name</label>
+                  <input
+                    type="text"
+                    required
+                    value={createForm.companyName}
+                    onChange={(e) => setCreateForm((f) => ({ ...f, companyName: e.target.value }))}
+                    className={`${inputClass} mt-1`}
+                  />
+                </div>
+              )}
+              {createForm.role === "member" && (
+                <div className="col-span-2">
+                  <label className={labelClass}>Department</label>
+                  <input
+                    type="text"
+                    value={createForm.department}
+                    onChange={(e) => setCreateForm((f) => ({ ...f, department: e.target.value }))}
+                    placeholder="e.g. Engineering, Business, Tech"
+                    className={`${inputClass} mt-1`}
+                  />
+                </div>
+              )}
+            </div>
+            {createError && <p className="text-red-400 text-sm">{createError}</p>}
+            <div className="flex gap-2">
+              <button type="submit" disabled={createLoading} className={btnPrimary}>
+                {createLoading ? "Creating…" : "Create"}
+              </button>
+              <button type="button" onClick={() => setShowCreateForm(false)} className={btnGhost}>
+                Cancel
+              </button>
+            </div>
+          </form>
+        )}
+      </Panel>
+
+      <Panel padded={accounts.length > 0}>
+        {accounts.length === 0 ? (
+          <EmptyState
+            icon={<Shield className="size-6" />}
+            title="No accounts yet"
+            description="Create the first portal account using the button above."
+          />
+        ) : (
+          <div className="divide-y divide-sbi-dark-border/20">
+            {accounts.map((account) => (
+              <div key={account.id} className="flex items-center justify-between px-3 py-3 first:pt-0 last:pb-0">
+                <div className="flex items-center gap-3 min-w-0">
+                  <span className="text-sm text-white truncate">{account.name}</span>
+                  <span className="text-xs text-sbi-muted truncate">{account.email}</span>
+                  <span className={`shrink-0 text-[10px] uppercase tracking-[0.15em] px-2 py-0.5 rounded border ${roleBadgeColor(account.role)}`}>
+                    {account.role}
+                  </span>
+                  {account.department && <span className="text-xs text-sbi-muted/50 truncate">({account.department})</span>}
+                </div>
+                {account.id !== currentUserId ? (
+                  <button
+                    type="button"
+                    onClick={() => setAccountToDelete(account)}
+                    aria-label={`Delete ${account.name}'s account`}
+                    title={`Delete ${account.name}'s account`}
+                    className="text-red-400/50 hover:text-red-400 transition-colors cursor-pointer"
+                  >
+                    <Trash2 className="size-4" />
+                  </button>
+                ) : (
+                  <Trash2
+                    className="size-4 text-sbi-muted/30"
+                    aria-label="Cannot delete your own account"
+                  />
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </Panel>
+
+      <ConfirmDialog
+        opened={!!accountToDelete}
+        onClose={() => setAccountToDelete(null)}
+        title="Delete account?"
+        danger
+        description={
+          accountToDelete ? (
+            <>
+              <p className="mb-2">
+                You're about to permanently delete{" "}
+                <span className="text-white font-medium">{accountToDelete.name}</span>{" "}
+                ({accountToDelete.email}).
+              </p>
+              <p>This removes their profile, project memberships, and auth account. This cannot be undone.</p>
+            </>
+          ) : null
+        }
+        confirmationText={accountToDelete?.name}
+        confirmLabel="Delete account"
+        onConfirm={confirmDelete}
+      />
     </div>
   );
 }

--- a/frontend/app/dashboard/settings/page.tsx
+++ b/frontend/app/dashboard/settings/page.tsx
@@ -1,10 +1,18 @@
 "use client";
 
-import { Calendar, Users, Shield, Plus, Trash2, UserPlus, ChevronDown, Check, Loader2, User, Lock, Bell, type LucideIcon } from "lucide-react";
+import { Calendar, Users, Shield, Plus, Trash2, UserPlus, Check, Loader2, User, Lock, Bell, Search, Pencil, type LucideIcon } from "lucide-react";
+import { Modal } from "@/components/dashboard/common/Modal";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { useProject } from "@/lib/project/project-context";
 import { createClient } from "@/lib/supabase/client";
 import { useSearchParams, useRouter } from "next/navigation";
-import { useEffect, useState, useCallback, useMemo, Suspense } from "react";
+import { useEffect, useState, useCallback, useMemo, useRef, Suspense } from "react";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import { toastSuccess, toastError } from "@/lib/notifications";
 import {
@@ -20,18 +28,24 @@ import {
   createAccount,
   listAccounts,
   deleteAccount,
+  updateAccount,
   listProjects,
   listProjectMembers,
   assignMemberToProject,
   removeMemberFromProject,
   listUnassignedMembers,
+  assignOwnerToProject,
+  listAvailableOwners,
   getMyAccount,
   updateMyProfile,
   updateMyPassword,
   updateMyNotificationPrefs,
-  DEFAULT_NOTIFICATION_PREFS,
-  type NotificationPrefs,
 } from "./actions";
+import {
+  DEFAULT_NOTIFICATION_PREFS,
+  DEPARTMENTS,
+  type NotificationPrefs,
+} from "./types";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -54,9 +68,12 @@ interface Project {
 
 interface ProjectMember {
   id: number;
+  synthetic: boolean;
   role: string;
   profile_id: number;
+  created_at: string | null;
   profiles: { id: number; name: string; email: string; role: string };
+  assigner: { id: number; name: string } | null;
 }
 
 interface UnassignedMember {
@@ -269,10 +286,38 @@ function NavGroup({
 // ---------------------------------------------------------------------------
 
 const inputClass =
-  "w-full bg-sbi-dark border border-sbi-dark-border/50 text-white text-sm rounded-md px-3 py-2 " +
+  "w-full h-9 bg-sbi-dark border border-sbi-dark-border/50 text-white text-sm rounded-md px-3 " +
   "focus:outline-none focus:border-sbi-green/50 disabled:opacity-50 placeholder:text-sbi-muted-dark/60";
 
 const labelClass = "text-[11px] tracking-[0.15em] uppercase text-sbi-muted-dark font-light";
+
+function useClickOutside<T extends HTMLElement>(
+  ref: React.RefObject<T | null>,
+  onOutside: () => void,
+  enabled: boolean,
+) {
+  useEffect(() => {
+    if (!enabled) return;
+    const handle = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        onOutside();
+      }
+    };
+    document.addEventListener("mousedown", handle);
+    return () => document.removeEventListener("mousedown", handle);
+  }, [ref, onOutside, enabled]);
+}
+
+function useEscapeKey(onEscape: () => void, enabled: boolean) {
+  useEffect(() => {
+    if (!enabled) return;
+    const handle = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onEscape();
+    };
+    document.addEventListener("keydown", handle);
+    return () => document.removeEventListener("keydown", handle);
+  }, [onEscape, enabled]);
+}
 
 function initialsOf(name: string): string {
   const parts = name.trim().split(/\s+/);
@@ -286,6 +331,7 @@ function initialsOf(name: string): string {
 
 function ProfileSection() {
   const [account, setAccount] = useState<MyAccount | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
   const [name, setName] = useState("");
   const [department, setDepartment] = useState("");
   const [saving, setSaving] = useState(false);
@@ -296,9 +342,19 @@ function ProfileSection() {
         setAccount(res.account);
         setName(res.account.name);
         setDepartment(res.account.department ?? "");
+      } else {
+        setLoadError(res.error || "Couldn't load your profile.");
       }
     });
   }, []);
+
+  if (loadError) {
+    return (
+      <Panel>
+        <p className="text-red-400 text-sm">{loadError}</p>
+      </Panel>
+    );
+  }
 
   if (!account) {
     return (
@@ -377,13 +433,17 @@ function ProfileSection() {
             {showDepartment && (
               <div className="sm:col-span-2">
                 <label className={labelClass}>Department</label>
-                <input
-                  type="text"
-                  value={department}
-                  onChange={(e) => setDepartment(e.target.value)}
-                  placeholder="e.g. Engineering, Architecture, Business"
-                  className={`${inputClass} mt-1`}
-                />
+                <Select value={department || "__none__"} onValueChange={(v) => setDepartment(v === "__none__" ? "" : v)}>
+                  <SelectTrigger className="mt-1">
+                    <SelectValue placeholder="No department" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="__none__">No department</SelectItem>
+                    {DEPARTMENTS.map((d) => (
+                      <SelectItem key={d} value={d}>{d}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
               </div>
             )}
           </div>
@@ -405,6 +465,7 @@ function ProfileSection() {
 
 function SecuritySection() {
   const router = useRouter();
+  const [currentPassword, setCurrentPassword] = useState("");
   const [newPassword, setNewPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
   const [saving, setSaving] = useState(false);
@@ -415,19 +476,46 @@ function SecuritySection() {
     e.preventDefault();
     setError("");
     if (newPassword.length < 8) {
-      setError("Password must be at least 8 characters.");
+      setError("New password must be at least 8 characters.");
       return;
     }
     if (newPassword !== confirmPassword) {
-      setError("Passwords don't match.");
+      setError("New passwords don't match.");
       return;
     }
+    if (newPassword === currentPassword) {
+      setError("New password must be different from the current one.");
+      return;
+    }
+
     setSaving(true);
+
+    // Verify current password by signing in with it. On success the session
+    // is refreshed for the same user; on failure we know it's wrong before
+    // touching the auth record.
+    const supabase = createClient();
+    const { data: { user: authUser } } = await supabase.auth.getUser();
+    if (!authUser?.email) {
+      setError("Couldn't read your current session. Please sign in again.");
+      setSaving(false);
+      return;
+    }
+    const { error: verifyError } = await supabase.auth.signInWithPassword({
+      email: authUser.email,
+      password: currentPassword,
+    });
+    if (verifyError) {
+      setError("Current password is incorrect.");
+      setSaving(false);
+      return;
+    }
+
     const result = await updateMyPassword(newPassword);
     if (result.error) {
       setError(result.error);
       toastError(result.error, "Couldn't update password");
     } else {
+      setCurrentPassword("");
       setNewPassword("");
       setConfirmPassword("");
       toastSuccess("Password updated.");
@@ -449,6 +537,17 @@ function SecuritySection() {
           Choose a new password at least 8 characters long. You'll stay signed in on this device.
         </p>
         <form onSubmit={handleChangePassword} className="space-y-4">
+          <div>
+            <label className={labelClass}>Current password</label>
+            <input
+              type="password"
+              required
+              autoComplete="current-password"
+              value={currentPassword}
+              onChange={(e) => setCurrentPassword(e.target.value)}
+              className={`${inputClass} mt-1`}
+            />
+          </div>
           <div>
             <label className={labelClass}>New password</label>
             <input
@@ -475,7 +574,7 @@ function SecuritySection() {
           <div className="flex justify-end">
             <button
               type="submit"
-              disabled={saving || !newPassword || !confirmPassword}
+              disabled={saving || !currentPassword || !newPassword || !confirmPassword}
               className={btnPrimary}
             >
               {saving ? "Updating…" : "Update password"}
@@ -527,6 +626,7 @@ const NOTIFICATION_ITEMS: { key: keyof NotificationPrefs; label: string; descrip
 function NotificationsSection() {
   const [prefs, setPrefs] = useState<NotificationPrefs | null>(null);
   const [initial, setInitial] = useState<NotificationPrefs | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
 
   useEffect(() => {
@@ -534,9 +634,19 @@ function NotificationsSection() {
       if (res.account) {
         setPrefs(res.account.prefs);
         setInitial(res.account.prefs);
+      } else {
+        setLoadError(res.error || "Couldn't load your preferences.");
       }
     });
   }, []);
+
+  if (loadError) {
+    return (
+      <Panel>
+        <p className="text-red-400 text-sm">{loadError}</p>
+      </Panel>
+    );
+  }
 
   if (!prefs || !initial) {
     return (
@@ -647,6 +757,7 @@ function CalendarSection() {
     try {
       const supabase = createClient();
       const { data: { user: authUser } } = await supabase.auth.getUser();
+      let hadSavedCalendar = false;
       if (authUser) {
         const { data: profile } = await supabase
           .from("profiles")
@@ -654,13 +765,37 @@ function CalendarSection() {
           .eq("uid", authUser.id)
           .single();
         const google = (profile?.config as Record<string, unknown>)?.google as Record<string, string> | undefined;
-        if (google?.calendar_id) setSelectedCalendarId(google.calendar_id);
+        if (google?.calendar_id) {
+          setSelectedCalendarId(google.calendar_id);
+          hadSavedCalendar = true;
+        }
       }
+
       const res = await fetch("/api/contact/calendar/client-events/list");
-      const data = await res.json();
-      if (res.ok && data.calendars) setCalendars(data.calendars);
-    } catch {
-      // No OAuth token or network error — leave empty.
+      const data = await res.json().catch(() => ({}));
+
+      if (res.ok && data.calendars) {
+        setCalendars(data.calendars);
+        return;
+      }
+
+      // Distinguish "never connected" from "token expired" — the latter
+      // matters because the user may have a saved calendar choice that no
+      // longer resolves.
+      if (res.status === 401 || res.status === 403) {
+        setError(
+          hadSavedCalendar
+            ? "Your Google Calendar connection has expired. Reconnect to refresh the calendar list."
+            : "",
+        );
+        return;
+      }
+
+      if (!res.ok) {
+        setError(data?.error || `Couldn't load calendars (${res.status}).`);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Couldn't reach the calendar service.");
     } finally {
       setLoading(false);
     }
@@ -715,22 +850,18 @@ function CalendarSection() {
         {calendars.length > 0 && !loading && (
           <div className="mt-6">
             <label className={labelClass}>Calendar for client events</label>
-            <div className="relative mt-1">
-              <select
-                value={selectedCalendarId}
-                onChange={(e) => handleSelect(e.target.value)}
-                disabled={saving}
-                className={`${inputClass} appearance-none cursor-pointer pr-9`}
-              >
-                <option value="">Choose a calendar…</option>
+            <Select value={selectedCalendarId} onValueChange={handleSelect} disabled={saving}>
+              <SelectTrigger className="mt-1">
+                <SelectValue placeholder="Choose a calendar…" />
+              </SelectTrigger>
+              <SelectContent>
                 {calendars.map((cal) => (
-                  <option key={cal.id} value={cal.id}>
+                  <SelectItem key={cal.id} value={cal.id}>
                     {cal.summary}{cal.primary ? " (Primary)" : ""}
-                  </option>
+                  </SelectItem>
                 ))}
-              </select>
-              <ChevronDown className="absolute right-3 top-1/2 -translate-y-1/2 size-4 text-sbi-muted pointer-events-none" />
-            </div>
+              </SelectContent>
+            </Select>
             {selectedCalendarId && (
               <div className="flex items-center gap-2 mt-2 text-sbi-green text-sm">
                 <Check className="size-4" />
@@ -752,11 +883,41 @@ function CalendarSection() {
 
 function TeamSection() {
   const [projects, setProjects] = useState<Project[]>([]);
+  const [projectsLoaded, setProjectsLoaded] = useState(false);
+  const [membersLoaded, setMembersLoaded] = useState(false);
   const [selectedProjectId, setSelectedProjectId] = useState<number | null>(null);
   const [projectMembers, setProjectMembers] = useState<ProjectMember[]>([]);
   const [unassignedMembers, setUnassignedMembers] = useState<UnassignedMember[]>([]);
   const [showAssignDropdown, setShowAssignDropdown] = useState(false);
+  const [assignQuery, setAssignQuery] = useState("");
   const [memberToRemove, setMemberToRemove] = useState<ProjectMember | null>(null);
+  const [availableOwners, setAvailableOwners] = useState<{ id: number; name: string; email: string }[]>([]);
+  const [showOwnerDropdown, setShowOwnerDropdown] = useState(false);
+  const [ownerQuery, setOwnerQuery] = useState("");
+
+  const assignDropdownRef = useRef<HTMLDivElement>(null);
+  const ownerDropdownRef = useRef<HTMLDivElement>(null);
+  const closeAssign = useCallback(() => setShowAssignDropdown(false), []);
+  const closeOwner = useCallback(() => setShowOwnerDropdown(false), []);
+  useClickOutside(assignDropdownRef, closeAssign, showAssignDropdown);
+  useEscapeKey(closeAssign, showAssignDropdown);
+  useClickOutside(ownerDropdownRef, closeOwner, showOwnerDropdown);
+  useEscapeKey(closeOwner, showOwnerDropdown);
+
+  useEffect(() => {
+    if (!showAssignDropdown) setAssignQuery("");
+  }, [showAssignDropdown]);
+
+  const filteredUnassigned = useMemo(() => {
+    const q = assignQuery.trim().toLowerCase();
+    if (!q) return unassignedMembers;
+    return unassignedMembers.filter(
+      (m) =>
+        m.name.toLowerCase().includes(q) ||
+        m.email.toLowerCase().includes(q) ||
+        (m.department?.toLowerCase().includes(q) ?? false),
+    );
+  }, [unassignedMembers, assignQuery]);
 
   const loadProjects = useCallback(async () => {
     const res = await listProjects();
@@ -764,19 +925,65 @@ function TeamSection() {
       setProjects(res.projects);
       if (res.projects.length > 0) setSelectedProjectId((curr) => curr ?? res.projects[0].id);
     }
+    setProjectsLoaded(true);
   }, []);
 
   const loadProjectMembers = useCallback(async (projectId: number) => {
-    const [m, u] = await Promise.all([
+    const [m, u, o] = await Promise.all([
       listProjectMembers(projectId),
       listUnassignedMembers(projectId),
+      listAvailableOwners(projectId),
     ]);
     if (m.members) setProjectMembers(m.members as ProjectMember[]);
     if (u.members) setUnassignedMembers(u.members);
+    if (o.clients) setAvailableOwners(o.clients);
+    setMembersLoaded(true);
   }, []);
 
+  useEffect(() => {
+    if (!showOwnerDropdown) setOwnerQuery("");
+  }, [showOwnerDropdown]);
+
+  const filteredOwners = useMemo(() => {
+    const q = ownerQuery.trim().toLowerCase();
+    if (!q) return availableOwners;
+    return availableOwners.filter(
+      (c) => c.name.toLowerCase().includes(q) || c.email.toLowerCase().includes(q),
+    );
+  }, [availableOwners, ownerQuery]);
+
+  const handleAssignOwner = async (profileId: number) => {
+    if (!selectedProjectId) return;
+    const res = await assignOwnerToProject(profileId, selectedProjectId);
+    if (res.error) toastError(res.error, "Couldn't assign owner");
+    else {
+      loadProjectMembers(selectedProjectId);
+      setShowOwnerDropdown(false);
+      toastSuccess("Owner assigned to project.");
+    }
+  };
+
   useEffect(() => { loadProjects(); }, [loadProjects]);
-  useEffect(() => { if (selectedProjectId) loadProjectMembers(selectedProjectId); }, [selectedProjectId, loadProjectMembers]);
+  useEffect(() => {
+    if (!selectedProjectId) return;
+    let cancelled = false;
+    setMembersLoaded(false);
+    (async () => {
+      const [m, u, o] = await Promise.all([
+        listProjectMembers(selectedProjectId),
+        listUnassignedMembers(selectedProjectId),
+        listAvailableOwners(selectedProjectId),
+      ]);
+      if (cancelled) return;
+      if (m.members) setProjectMembers(m.members as ProjectMember[]);
+      if (u.members) setUnassignedMembers(u.members);
+      if (o.clients) setAvailableOwners(o.clients);
+      setMembersLoaded(true);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedProjectId]);
 
   const handleAssign = async (profileId: number) => {
     if (!selectedProjectId) return;
@@ -801,97 +1008,253 @@ function TeamSection() {
     setMemberToRemove(null);
   };
 
+  // Inline loading matches the Accounts pattern — header + selector stay
+  // visible, only the table area shows the spinner during the first fetch
+  // or while switching projects.
+  const isLoading = !projectsLoaded || (selectedProjectId !== null && !membersLoaded);
+
+  const memberCount = projectMembers.filter((m) => m.role === "member").length;
+  const directorCount = projectMembers.filter((m) => m.role === "director").length;
+  const ownerCount = projectMembers.filter((m) => m.role === "owner").length;
+  const hasOwner = ownerCount > 0;
+  const countLine = projectMembers.length === 0
+    ? null
+    : [
+        ownerCount > 0 ? `${ownerCount} owner` : null,
+        `${memberCount} member${memberCount === 1 ? "" : "s"}`,
+        `${directorCount} director${directorCount === 1 ? "" : "s"}`,
+      ].filter(Boolean).join(" · ");
+
   return (
     <div className="max-w-3xl space-y-4">
       <Panel>
-        <SectionLabel>Project members</SectionLabel>
-        <p className="text-sbi-muted text-sm mb-5">
-          Assign members to projects. Directors are automatically assigned to every project.
-        </p>
-
-        <div className="mb-5">
-          <label className={labelClass}>Project</label>
-          <div className="relative mt-1">
-            <select
-              value={selectedProjectId ?? ""}
-              onChange={(e) => setSelectedProjectId(Number(e.target.value))}
-              className={`${inputClass} appearance-none cursor-pointer pr-9`}
+        <div className="flex items-center justify-between gap-4 mb-5">
+          <SectionLabel className="mb-0">Project members</SectionLabel>
+          <div className="flex items-center gap-2">
+            {!hasOwner && selectedProjectId && !isLoading && (
+              <div className="relative" ref={ownerDropdownRef}>
+                <button
+                  type="button"
+                  onClick={() => setShowOwnerDropdown(!showOwnerDropdown)}
+                  className={btnGhost}
+                >
+                  <UserPlus className="size-4" />
+                  Assign owner
+                </button>
+                {showOwnerDropdown && (
+                  <div className="absolute top-full mt-2 right-0 w-96 bg-sbi-dark border border-sbi-dark-border/60 rounded-lg shadow-2xl shadow-black/60 z-50 flex flex-col max-h-96">
+                      <div className="p-2 border-b border-sbi-dark-border/40">
+                        <div className="relative">
+                          <Search className="absolute left-3 top-1/2 -translate-y-1/2 size-4 text-sbi-muted-dark" strokeWidth={1.5} />
+                          <input
+                            type="text"
+                            autoFocus
+                            value={ownerQuery}
+                            onChange={(e) => setOwnerQuery(e.target.value)}
+                            placeholder="Search clients"
+                            className="w-full h-8 bg-sbi-dark border border-sbi-dark-border/50 text-white text-sm rounded-md pl-9 pr-3 focus:outline-none focus:border-sbi-green/50 placeholder:text-sbi-muted-dark/60"
+                          />
+                        </div>
+                      </div>
+                      <div className="flex items-center justify-between px-3 pt-2 pb-1 text-[10px] tracking-[0.2em] uppercase text-sbi-muted-dark">
+                        <span>Available clients</span>
+                        <span className="tabular-nums">
+                          {filteredOwners.length}
+                          {ownerQuery && filteredOwners.length !== availableOwners.length
+                            ? ` of ${availableOwners.length}`
+                            : ""}
+                        </span>
+                      </div>
+                      <div className="flex-1 overflow-y-auto py-1">
+                        {availableOwners.length === 0 ? (
+                          <p className="px-3 py-6 text-sbi-muted-dark text-sm text-center">
+                            No unassigned clients available.
+                          </p>
+                        ) : filteredOwners.length === 0 ? (
+                          <p className="px-3 py-6 text-sbi-muted-dark text-sm text-center">
+                            No matches for <span className="text-sbi-muted">"{ownerQuery}"</span>.
+                          </p>
+                        ) : (
+                          filteredOwners.map((c) => (
+                            <button
+                              key={c.id}
+                              type="button"
+                              onClick={() => handleAssignOwner(c.id)}
+                              className="w-full text-left px-3 py-2 hover:bg-white/5 transition-colors cursor-pointer focus:bg-white/5 focus:outline-none"
+                            >
+                              <div className="text-sm text-white truncate">{c.name}</div>
+                              <div className="text-xs text-sbi-muted-dark truncate">{c.email}</div>
+                            </button>
+                          ))
+                        )}
+                      </div>
+                  </div>
+                )}
+              </div>
+            )}
+            <div className="relative" ref={assignDropdownRef}>
+            <button
+              type="button"
+              onClick={() => setShowAssignDropdown(!showAssignDropdown)}
+              disabled={!selectedProjectId}
+              className={btnPrimary}
             >
-              {projects.map((p) => (
-                <option key={p.id} value={p.id}>{p.company_name}</option>
-              ))}
-            </select>
-            <ChevronDown className="absolute right-3 top-1/2 -translate-y-1/2 size-4 text-sbi-muted pointer-events-none" />
+              <UserPlus className="size-4" />
+              Assign member
+            </button>
+            {showAssignDropdown && (
+              <div className="absolute top-full mt-2 right-0 w-96 bg-sbi-dark border border-sbi-dark-border/60 rounded-lg shadow-2xl shadow-black/60 z-50 flex flex-col max-h-96">
+                  <div className="p-2 border-b border-sbi-dark-border/40">
+                    <div className="relative">
+                      <Search className="absolute left-3 top-1/2 -translate-y-1/2 size-4 text-sbi-muted-dark" strokeWidth={1.5} />
+                      <input
+                        type="text"
+                        autoFocus
+                        value={assignQuery}
+                        onChange={(e) => setAssignQuery(e.target.value)}
+                        placeholder="Search by name, email, or department"
+                        className="w-full h-8 bg-sbi-dark border border-sbi-dark-border/50 text-white text-sm rounded-md pl-9 pr-3 focus:outline-none focus:border-sbi-green/50 placeholder:text-sbi-muted-dark/60"
+                      />
+                    </div>
+                  </div>
+                  <div className="flex items-center justify-between px-3 pt-2 pb-1 text-[10px] tracking-[0.2em] uppercase text-sbi-muted-dark">
+                    <span>Available members</span>
+                    <span className="tabular-nums">
+                      {filteredUnassigned.length}
+                      {assignQuery && filteredUnassigned.length !== unassignedMembers.length
+                        ? ` of ${unassignedMembers.length}`
+                        : ""}
+                    </span>
+                  </div>
+                  <div className="flex-1 overflow-y-auto py-1">
+                    {unassignedMembers.length === 0 ? (
+                      <p className="px-3 py-6 text-sbi-muted-dark text-sm text-center">
+                        Everyone available is already on this project.
+                      </p>
+                    ) : filteredUnassigned.length === 0 ? (
+                      <p className="px-3 py-6 text-sbi-muted-dark text-sm text-center">
+                        No matches for <span className="text-sbi-muted">"{assignQuery}"</span>.
+                      </p>
+                    ) : (
+                      filteredUnassigned.map((m) => (
+                        <button
+                          key={m.id}
+                          type="button"
+                          onClick={() => handleAssign(m.id)}
+                          className="w-full text-left px-3 py-2 hover:bg-white/5 transition-colors cursor-pointer focus:bg-white/5 focus:outline-none"
+                        >
+                          <div className="flex items-center justify-between gap-3">
+                            <div className="text-sm text-white truncate">{m.name}</div>
+                            {m.department && (
+                              <span className="shrink-0 text-[10px] tracking-[0.15em] uppercase text-sbi-muted-dark">
+                                {m.department}
+                              </span>
+                            )}
+                          </div>
+                          <div className="text-xs text-sbi-muted-dark truncate">{m.email}</div>
+                        </button>
+                      ))
+                    )}
+                  </div>
+              </div>
+            )}
+          </div>
           </div>
         </div>
 
-        {projectMembers.length === 0 ? (
-          <EmptyState
-            icon={<Users className="size-6" />}
-            title="No members assigned"
-            description="Assign members to this project using the button below."
-            className="py-10"
-          />
+        <div className="flex items-end gap-4 mb-5">
+          <div className="flex-1 min-w-0 max-w-xs">
+            <label className={labelClass}>Project</label>
+            <Select
+              value={selectedProjectId ? String(selectedProjectId) : undefined}
+              onValueChange={(v) => setSelectedProjectId(Number(v))}
+              disabled={projects.length === 0}
+            >
+              <SelectTrigger className="mt-1">
+                <SelectValue placeholder={projects.length === 0 ? "No projects yet" : "Select a project"} />
+              </SelectTrigger>
+              <SelectContent>
+                {projects.map((p) => (
+                  <SelectItem key={p.id} value={String(p.id)}>{p.company_name}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          {countLine && (
+            <p className="text-xs text-sbi-muted-dark tabular-nums pb-2.5">{countLine}</p>
+          )}
+        </div>
+
+        {isLoading ? (
+          <div className="flex items-center gap-2 text-sbi-muted text-sm py-2">
+            <Loader2 className="size-4 animate-spin" /> Loading team…
+          </div>
+        ) : projectMembers.length === 0 ? (
+          <p className="text-sm text-sbi-muted-dark py-3">
+            No one's on this project yet. Use <span className="text-sbi-muted">Assign member</span> above.
+          </p>
         ) : (
-          <div className="space-y-2 mb-5">
-            {projectMembers.map((pm) => (
+          <div className="border border-sbi-dark-border/30 rounded-md overflow-hidden">
+            <div className="grid grid-cols-[1.2fr_1.8fr_96px_32px] gap-3 px-3 py-2 text-[10px] tracking-[0.2em] uppercase text-sbi-muted-dark border-b border-sbi-dark-border/30">
+              <div>Name</div>
+              <div>Email</div>
+              <div>Role</div>
+              <div />
+            </div>
+            {projectMembers.map((pm) => {
+              const assignedTooltip = pm.assigner
+                ? `Added by ${pm.assigner.name}${pm.created_at ? ` on ${new Date(pm.created_at).toLocaleDateString()}` : ""}`
+                : undefined;
+              return (
               <div
                 key={pm.id}
-                className="flex items-center justify-between px-3 py-2 bg-sbi-dark/40 border border-sbi-dark-border/20 rounded-md"
+                className="grid grid-cols-[1.2fr_1.8fr_96px_32px] gap-3 items-center px-3 py-2.5 border-b border-sbi-dark-border/15 last:border-b-0 hover:bg-white/[0.015] transition-colors"
               >
-                <div className="flex items-center gap-3 min-w-0">
-                  <span className="text-sm text-white truncate">{pm.profiles.name}</span>
-                  <span className="text-xs text-sbi-muted truncate">{pm.profiles.email}</span>
-                  <span className={`shrink-0 text-[10px] uppercase tracking-[0.15em] px-2 py-0.5 rounded border ${roleBadgeColor(pm.role)}`}>
+                <div className="text-sm text-white truncate">{pm.profiles.name}</div>
+                <div className="text-xs text-sbi-muted truncate flex items-center gap-2 min-w-0">
+                  <span className="truncate">{pm.profiles.email}</span>
+                  {pm.assigner && (
+                    <span
+                      title={assignedTooltip}
+                      className="shrink-0 text-[10px] uppercase tracking-[0.15em] text-sbi-muted-dark/70"
+                    >
+                      · by {pm.assigner.name.split(" ")[0]}
+                    </span>
+                  )}
+                </div>
+                <div>
+                  <span className={`text-[10px] uppercase tracking-[0.15em] px-2 py-0.5 rounded border ${roleBadgeColor(pm.role)}`}>
                     {pm.role}
                   </span>
                 </div>
-                {pm.role === "member" && (
-                  <button
-                    type="button"
-                    onClick={() => setMemberToRemove(pm)}
-                    aria-label={`Remove ${pm.profiles.name} from project`}
-                    title={`Remove ${pm.profiles.name} from project`}
-                    className="text-red-400/50 hover:text-red-400 transition-colors cursor-pointer"
-                  >
-                    <Trash2 className="size-4" />
-                  </button>
-                )}
+                <div className="flex justify-end">
+                  {pm.role === "member" && !pm.synthetic ? (
+                    <button
+                      type="button"
+                      onClick={() => setMemberToRemove(pm)}
+                      aria-label={`Remove ${pm.profiles.name} from project`}
+                      title={`Remove ${pm.profiles.name} from project`}
+                      className="text-red-400/50 hover:text-red-400 transition-colors cursor-pointer"
+                    >
+                      <Trash2 className="size-4" />
+                    </button>
+                  ) : (
+                    <button
+                      type="button"
+                      disabled
+                      aria-label="Directors can't be removed from a project"
+                      title="Directors can't be removed from a project"
+                      className="text-red-400/25 cursor-not-allowed"
+                    >
+                      <Trash2 className="size-4" />
+                    </button>
+                  )}
+                </div>
               </div>
-            ))}
+              );
+            })}
           </div>
         )}
-
-        <div className="relative mt-4">
-          <button
-            type="button"
-            onClick={() => setShowAssignDropdown(!showAssignDropdown)}
-            className={btnPrimary}
-          >
-            <UserPlus className="size-4" />
-            Assign member
-          </button>
-          {showAssignDropdown && (
-            <div className="absolute top-full mt-1 left-0 w-80 bg-sbi-dark border border-sbi-dark-border/50 rounded-lg shadow-2xl shadow-black/50 z-50 max-h-60 overflow-y-auto">
-              {unassignedMembers.length === 0 ? (
-                <p className="px-4 py-3 text-sbi-muted/70 text-sm">No unassigned members available.</p>
-              ) : (
-                unassignedMembers.map((m) => (
-                  <button
-                    key={m.id}
-                    type="button"
-                    onClick={() => handleAssign(m.id)}
-                    className="w-full text-left px-4 py-2.5 hover:bg-white/5 transition-colors cursor-pointer"
-                  >
-                    <span className="text-sm text-white">{m.name}</span>
-                    <span className="text-xs text-sbi-muted ml-2">{m.email}</span>
-                    {m.department && <span className="text-xs text-sbi-muted/50 ml-2">({m.department})</span>}
-                  </button>
-                ))
-              )}
-            </div>
-          )}
-        </div>
       </Panel>
 
       <ConfirmDialog
@@ -918,8 +1281,11 @@ function TeamSection() {
 // Accounts section (director only)
 // ---------------------------------------------------------------------------
 
+type AccountFilter = "all" | "director" | "member" | "client";
+
 function AccountsSection({ currentUserId }: { currentUserId: number }) {
   const [accounts, setAccounts] = useState<Account[]>([]);
+  const [accountsLoaded, setAccountsLoaded] = useState(false);
   const [showCreateForm, setShowCreateForm] = useState(false);
   const [createForm, setCreateForm] = useState({
     email: "", password: "", name: "",
@@ -929,13 +1295,33 @@ function AccountsSection({ currentUserId }: { currentUserId: number }) {
   const [createError, setCreateError] = useState("");
   const [createLoading, setCreateLoading] = useState(false);
   const [accountToDelete, setAccountToDelete] = useState<Account | null>(null);
+  const [accountToEdit, setAccountToEdit] = useState<Account | null>(null);
+  const [query, setQuery] = useState("");
+  const [filter, setFilter] = useState<AccountFilter>("all");
 
   const loadAccounts = useCallback(async () => {
     const res = await listAccounts();
     if (res.accounts) setAccounts(res.accounts);
+    setAccountsLoaded(true);
   }, []);
 
   useEffect(() => { loadAccounts(); }, [loadAccounts]);
+
+  const counts = useMemo(() => {
+    const acc = { director: 0, member: 0, client: 0 };
+    for (const a of accounts) {
+      if (a.role === "director" || a.role === "member" || a.role === "client") acc[a.role]++;
+    }
+    return acc;
+  }, [accounts]);
+
+  const visibleAccounts = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    return accounts
+      .filter((a) => filter === "all" || a.role === filter)
+      .filter((a) => !q || a.name.toLowerCase().includes(q) || a.email.toLowerCase().includes(q))
+      .sort((a, b) => a.name.localeCompare(b.name));
+  }, [accounts, filter, query]);
 
   const handleCreate = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -950,7 +1336,11 @@ function AccountsSection({ currentUserId }: { currentUserId: number }) {
       setShowCreateForm(false);
       setCreateForm({ email: "", password: "", name: "", role: "member", companyName: "", department: "" });
       loadAccounts();
-      toastSuccess(`Account created for ${createdName}.`);
+      if (res.warning) {
+        toastError(res.warning, `Account created for ${createdName}, with a warning`);
+      } else {
+        toastSuccess(`Account created for ${createdName}.`);
+      }
     }
     setCreateLoading(false);
   };
@@ -970,7 +1360,7 @@ function AccountsSection({ currentUserId }: { currentUserId: number }) {
   return (
     <div className="max-w-3xl space-y-4">
       <Panel>
-        <div className="flex items-center justify-between mb-2">
+        <div className="flex items-center justify-between gap-4 mb-5">
           <SectionLabel className="mb-0">Portal accounts</SectionLabel>
           <button
             type="button"
@@ -981,12 +1371,9 @@ function AccountsSection({ currentUserId }: { currentUserId: number }) {
             Create account
           </button>
         </div>
-        <p className="text-sbi-muted text-sm mb-5">
-          Create and manage portal accounts for directors, members, and clients.
-        </p>
 
         {showCreateForm && (
-          <form onSubmit={handleCreate} className="mt-2 p-4 bg-sbi-dark/50 border border-sbi-dark-border/20 rounded-lg space-y-3">
+          <form onSubmit={handleCreate} className="mb-6 p-4 bg-sbi-dark/50 border border-sbi-dark-border/20 rounded-lg space-y-3">
             <div className="grid grid-cols-2 gap-3">
               <div>
                 <label className={labelClass}>Name</label>
@@ -1020,15 +1407,19 @@ function AccountsSection({ currentUserId }: { currentUserId: number }) {
               </div>
               <div>
                 <label className={labelClass}>Role</label>
-                <select
+                <Select
                   value={createForm.role}
-                  onChange={(e) => setCreateForm((f) => ({ ...f, role: e.target.value as "client" | "director" | "member" }))}
-                  className={`${inputClass} mt-1 appearance-none cursor-pointer`}
+                  onValueChange={(v) => setCreateForm((f) => ({ ...f, role: v as "client" | "director" | "member" }))}
                 >
-                  <option value="member">Member</option>
-                  <option value="client">Client</option>
-                  <option value="director">Director</option>
-                </select>
+                  <SelectTrigger className="mt-1">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="member">Member</SelectItem>
+                    <SelectItem value="client">Client</SelectItem>
+                    <SelectItem value="director">Director</SelectItem>
+                  </SelectContent>
+                </Select>
               </div>
               {createForm.role === "client" && (
                 <div className="col-span-2">
@@ -1045,13 +1436,19 @@ function AccountsSection({ currentUserId }: { currentUserId: number }) {
               {createForm.role === "member" && (
                 <div className="col-span-2">
                   <label className={labelClass}>Department</label>
-                  <input
-                    type="text"
-                    value={createForm.department}
-                    onChange={(e) => setCreateForm((f) => ({ ...f, department: e.target.value }))}
-                    placeholder="e.g. Engineering, Business, Tech"
-                    className={`${inputClass} mt-1`}
-                  />
+                  <Select
+                    value={createForm.department || undefined}
+                    onValueChange={(v) => setCreateForm((f) => ({ ...f, department: v }))}
+                  >
+                    <SelectTrigger className="mt-1">
+                      <SelectValue placeholder="Choose a department…" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {DEPARTMENTS.map((d) => (
+                        <SelectItem key={d} value={d}>{d}</SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
                 </div>
               )}
             </div>
@@ -1066,48 +1463,113 @@ function AccountsSection({ currentUserId }: { currentUserId: number }) {
             </div>
           </form>
         )}
-      </Panel>
 
-      <Panel padded={accounts.length > 0}>
-        {accounts.length === 0 ? (
+        {!accountsLoaded ? (
+          <div className="flex items-center gap-2 text-sbi-muted text-sm py-2">
+            <Loader2 className="size-4 animate-spin" /> Loading accounts…
+          </div>
+        ) : accounts.length === 0 ? (
           <EmptyState
             icon={<Shield className="size-6" />}
             title="No accounts yet"
-            description="Create the first portal account using the button above."
+            description="Create the first portal account using Create account above."
+            className="py-10"
           />
         ) : (
-          <div className="divide-y divide-sbi-dark-border/20">
-            {accounts.map((account) => (
-              <div key={account.id} className="flex items-center justify-between px-3 py-3 first:pt-0 last:pb-0">
-                <div className="flex items-center gap-3 min-w-0">
-                  <span className="text-sm text-white truncate">{account.name}</span>
-                  <span className="text-xs text-sbi-muted truncate">{account.email}</span>
-                  <span className={`shrink-0 text-[10px] uppercase tracking-[0.15em] px-2 py-0.5 rounded border ${roleBadgeColor(account.role)}`}>
-                    {account.role}
-                  </span>
-                  {account.department && <span className="text-xs text-sbi-muted/50 truncate">({account.department})</span>}
-                </div>
-                {account.id !== currentUserId ? (
-                  <button
-                    type="button"
-                    onClick={() => setAccountToDelete(account)}
-                    aria-label={`Delete ${account.name}'s account`}
-                    title={`Delete ${account.name}'s account`}
-                    className="text-red-400/50 hover:text-red-400 transition-colors cursor-pointer"
-                  >
-                    <Trash2 className="size-4" />
-                  </button>
-                ) : (
-                  <Trash2
-                    className="size-4 text-sbi-muted/30"
-                    aria-label="Cannot delete your own account"
-                  />
-                )}
+          <>
+            <div className="flex flex-wrap items-center gap-3 mb-4">
+              <div className="relative flex-1 min-w-[200px]">
+                <Search className="absolute left-3 top-1/2 -translate-y-1/2 size-4 text-sbi-muted-dark" strokeWidth={1.5} />
+                <input
+                  type="text"
+                  value={query}
+                  onChange={(e) => setQuery(e.target.value)}
+                  placeholder="Search by name or email"
+                  className="w-full h-8 bg-sbi-dark border border-sbi-dark-border/50 text-white text-sm rounded-md pl-9 pr-3 focus:outline-none focus:border-sbi-green/50 placeholder:text-sbi-muted-dark/60"
+                />
               </div>
-            ))}
-          </div>
+              <div className="flex items-center gap-1 text-xs">
+                <FilterChip label="All" count={accounts.length} active={filter === "all"} onClick={() => setFilter("all")} />
+                <FilterChip label="Directors" count={counts.director} active={filter === "director"} onClick={() => setFilter("director")} />
+                <FilterChip label="Members" count={counts.member} active={filter === "member"} onClick={() => setFilter("member")} />
+                <FilterChip label="Clients" count={counts.client} active={filter === "client"} onClick={() => setFilter("client")} />
+              </div>
+            </div>
+
+            <div className="border border-sbi-dark-border/30 rounded-md overflow-hidden">
+              <div className="grid grid-cols-[1.3fr_1.7fr_92px_120px_64px] gap-3 px-3 py-2 text-[10px] tracking-[0.2em] uppercase text-sbi-muted-dark border-b border-sbi-dark-border/30">
+                <div>Name</div>
+                <div>Email</div>
+                <div>Role</div>
+                <div>Department</div>
+                <div />
+              </div>
+              {visibleAccounts.length === 0 ? (
+                <p className="px-3 py-6 text-sm text-sbi-muted-dark text-center">
+                  No accounts match this filter.
+                </p>
+              ) : (
+                visibleAccounts.map((account) => (
+                  <div
+                    key={account.id}
+                    className="grid grid-cols-[1.3fr_1.7fr_92px_120px_28px] gap-3 items-center px-3 py-2.5 border-b border-sbi-dark-border/15 last:border-b-0 hover:bg-white/[0.015] transition-colors"
+                  >
+                    <div className="text-sm text-white truncate">{account.name}</div>
+                    <div className="text-xs text-sbi-muted truncate">{account.email}</div>
+                    <div>
+                      <span className={`text-[10px] uppercase tracking-[0.15em] px-2 py-0.5 rounded border ${roleBadgeColor(account.role)}`}>
+                        {account.role}
+                      </span>
+                    </div>
+                    <div className="text-xs text-sbi-muted-dark truncate">
+                      {account.department || <span className="text-sbi-muted-dark/40">—</span>}
+                    </div>
+                    <div className="flex justify-end items-center gap-3">
+                      <button
+                        type="button"
+                        onClick={() => setAccountToEdit(account)}
+                        aria-label={`Edit ${account.name}'s account`}
+                        title={`Edit ${account.name}'s account`}
+                        className="text-sbi-muted-dark/70 hover:text-sbi-green transition-colors cursor-pointer"
+                      >
+                        <Pencil className="size-4" strokeWidth={1.5} />
+                      </button>
+                      {account.id !== currentUserId ? (
+                        <button
+                          type="button"
+                          onClick={() => setAccountToDelete(account)}
+                          aria-label={`Delete ${account.name}'s account`}
+                          title={`Delete ${account.name}'s account`}
+                          className="text-red-400/50 hover:text-red-400 transition-colors cursor-pointer"
+                        >
+                          <Trash2 className="size-4" />
+                        </button>
+                      ) : (
+                        <button
+                          type="button"
+                          disabled
+                          aria-label="Cannot delete your own account"
+                          title="Cannot delete your own account"
+                          className="text-red-400/25 cursor-not-allowed"
+                        >
+                          <Trash2 className="size-4" />
+                        </button>
+                      )}
+                    </div>
+                  </div>
+                ))
+              )}
+            </div>
+          </>
         )}
       </Panel>
+
+      <EditAccountModal
+        account={accountToEdit}
+        currentUserId={currentUserId}
+        onClose={() => setAccountToEdit(null)}
+        onSaved={() => { setAccountToEdit(null); loadAccounts(); }}
+      />
 
       <ConfirmDialog
         opened={!!accountToDelete}
@@ -1131,5 +1593,188 @@ function AccountsSection({ currentUserId }: { currentUserId: number }) {
         onConfirm={confirmDelete}
       />
     </div>
+  );
+}
+
+function EditAccountModal({
+  account,
+  currentUserId,
+  onClose,
+  onSaved,
+}: {
+  account: Account | null;
+  currentUserId: number;
+  onClose: () => void;
+  onSaved: () => void;
+}) {
+  const [name, setName] = useState("");
+  const [role, setRole] = useState<"client" | "director" | "member">("member");
+  const [department, setDepartment] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState("");
+
+  const isSelf = account?.id === currentUserId;
+  const roleChanged = account && role !== account.role;
+
+  useEffect(() => {
+    if (account) {
+      setName(account.name);
+      setRole(account.role as "client" | "director" | "member");
+      setDepartment(account.department ?? "");
+      setError("");
+    }
+  }, [account]);
+
+  const handleSave = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!account) return;
+    setSaving(true);
+    setError("");
+    const result = await updateAccount({
+      id: account.id,
+      name: name.trim(),
+      role,
+      department: department.trim() || null,
+    });
+    if (result.error) {
+      setError(result.error);
+      toastError(result.error, "Couldn't save account");
+    } else {
+      toastSuccess(`Saved ${name.trim()}'s account.`);
+      onSaved();
+    }
+    setSaving(false);
+  };
+
+  const showDepartment = role === "member" || role === "director";
+
+  return (
+    <Modal
+      opened={!!account}
+      onClose={onClose}
+      title={account ? `Edit ${account.name}` : "Edit account"}
+      uppercaseTitle={false}
+      size="md"
+    >
+      {account && (
+        <form onSubmit={handleSave} className="space-y-4">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div className="sm:col-span-2">
+              <label className={labelClass}>Name</label>
+              <input
+                type="text"
+                required
+                minLength={2}
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                className={`${inputClass} mt-1`}
+              />
+            </div>
+            <div className="sm:col-span-2">
+              <label className={labelClass}>Email</label>
+              <input
+                type="email"
+                value={account.email}
+                readOnly
+                className={`${inputClass} mt-1 cursor-not-allowed text-sbi-muted`}
+              />
+              <p className="text-[11px] text-sbi-muted-dark mt-1">
+                Email changes require re-verification and aren't supported here.
+              </p>
+            </div>
+            <div>
+              <label className={labelClass}>Role</label>
+              <Select
+                value={role}
+                onValueChange={(v) => setRole(v as "client" | "director" | "member")}
+                disabled={isSelf}
+              >
+                <SelectTrigger className="mt-1">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="member">Member</SelectItem>
+                  <SelectItem value="client">Client</SelectItem>
+                  <SelectItem value="director">Director</SelectItem>
+                </SelectContent>
+              </Select>
+              {isSelf && (
+                <p className="text-[11px] text-sbi-muted-dark mt-1">
+                  You can't change your own role here.
+                </p>
+              )}
+              {!isSelf && roleChanged && (
+                <p className="text-[11px] text-amber-400/80 mt-1">
+                  Changing the role removes any project assignments tied to the old role.
+                </p>
+              )}
+            </div>
+            {showDepartment && (
+              <div>
+                <label className={labelClass}>Department</label>
+                <Select
+                  value={department || "__none__"}
+                  onValueChange={(v) => setDepartment(v === "__none__" ? "" : v)}
+                >
+                  <SelectTrigger className="mt-1">
+                    <SelectValue placeholder="No department" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="__none__">No department</SelectItem>
+                    {DEPARTMENTS.map((d) => (
+                      <SelectItem key={d} value={d}>{d}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            )}
+          </div>
+
+          {error && <p className="text-red-400 text-sm">{error}</p>}
+
+          <div className="flex justify-end gap-2 pt-2">
+            <button type="button" onClick={onClose} className={btnGhost}>
+              Cancel
+            </button>
+            <button type="submit" disabled={saving} className={btnPrimary}>
+              {saving ? "Saving…" : "Save changes"}
+            </button>
+          </div>
+        </form>
+      )}
+    </Modal>
+  );
+}
+
+function FilterChip({
+  label,
+  count,
+  active,
+  onClick,
+}: {
+  label: string;
+  count: number;
+  active: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`inline-flex items-center gap-1.5 px-2.5 h-8 rounded-md border transition-colors cursor-pointer ${
+        active
+          ? "bg-sbi-green/10 text-sbi-green border-sbi-green/40"
+          : "bg-transparent text-sbi-muted border-sbi-dark-border/40 hover:text-white hover:border-white/20"
+      }`}
+    >
+      <span>{label}</span>
+      <span
+        className={`tabular-nums text-[10px] px-1.5 py-px rounded-sm ${
+          active ? "bg-sbi-green/15 text-sbi-green" : "bg-sbi-dark-border/40 text-sbi-muted-dark"
+        }`}
+      >
+        {count}
+      </span>
+    </button>
   );
 }

--- a/frontend/app/dashboard/settings/types.ts
+++ b/frontend/app/dashboard/settings/types.ts
@@ -1,0 +1,27 @@
+export interface NotificationPrefs {
+  messages: boolean;
+  calendar: boolean;
+  requests: boolean;
+  reports: boolean;
+  weeklyDigest: boolean;
+}
+
+export const DEFAULT_NOTIFICATION_PREFS: NotificationPrefs = {
+  messages: true,
+  calendar: true,
+  requests: true,
+  reports: true,
+  weeklyDigest: false,
+};
+
+export const DEPARTMENTS = [
+  "Engineering",
+  "Architecture",
+  "Tech",
+  "Business",
+  "PR",
+  "Legal",
+  "Research",
+] as const;
+
+export type Department = (typeof DEPARTMENTS)[number];

--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -5,6 +5,9 @@
     "": {
       "name": "frontend",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@google/model-viewer": "^4.1.0",
         "@mantine/carousel": "^8.3.9",
         "@mantine/charts": "^8.3.9",
@@ -40,7 +43,6 @@
         "@tiptap/react": "^3.12.1",
         "@tiptap/starter-kit": "^3.12.1",
         "@types/pg": "^8.15.6",
-        "@types/react-syntax-highlighter": "^15.5.13",
         "@types/three": "^0.181.0",
         "@vercel/analytics": "^1.6.1",
         "@vercel/speed-insights": "^1.3.1",
@@ -65,6 +67,7 @@
         "react-syntax-highlighter": "^16.1.0",
         "recharts": "^3.5.1",
         "remark-gfm": "^4.0.1",
+        "sonner": "^2.0.7",
         "tailwind-merge": "^3.4.0",
         "three": "^0.181.2",
       },
@@ -74,6 +77,7 @@
         "@types/node": "^24.10.1",
         "@types/react": "^19.2.7",
         "@types/react-dom": "^19.2.3",
+        "@types/react-syntax-highlighter": "^15.5.13",
         "dotenv": "^17.4.2",
         "postcss": "^8.5.6",
         "postcss-preset-mantine": "^1.18.0",
@@ -108,6 +112,14 @@
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.3.8", "", { "os": "win32", "cpu": "x64" }, "sha512-RguzimPoZWtBapfKhKjcWXBVI91tiSprqdBYu7tWhgN8pKRZhw24rFeNZTNf6UiBfjCYCi9eFQs/JzJZIhuK4w=="],
 
     "@dimforge/rapier3d-compat": ["@dimforge/rapier3d-compat@0.12.0", "", {}, "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow=="],
+
+    "@dnd-kit/accessibility": ["@dnd-kit/accessibility@3.1.1", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0" } }, "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw=="],
+
+    "@dnd-kit/core": ["@dnd-kit/core@6.3.1", "", { "dependencies": { "@dnd-kit/accessibility": "^3.1.1", "@dnd-kit/utilities": "^3.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ=="],
+
+    "@dnd-kit/sortable": ["@dnd-kit/sortable@10.0.0", "", { "dependencies": { "@dnd-kit/utilities": "^3.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "@dnd-kit/core": "^6.3.0", "react": ">=16.8.0" } }, "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg=="],
+
+    "@dnd-kit/utilities": ["@dnd-kit/utilities@3.2.2", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0" } }, "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg=="],
 
     "@emnapi/runtime": ["@emnapi/runtime@1.7.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-PVtJr5CmLwYAU9PZDMITZoR5iAOShYREoR45EyyLrbntV50mdePTgUn4AmOw90Ifcj+x2kRjdzr1HP3RrNiHGA=="],
 
@@ -1164,6 +1176,8 @@
     "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
 
     "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
+
+    "sonner": ["sonner@2.0.7", "", { "peerDependencies": { "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc" } }, "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 

--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -29,6 +29,7 @@
         "@radix-ui/react-dropdown-menu": "^2.1.16",
         "@radix-ui/react-icons": "^1.3.2",
         "@radix-ui/react-label": "^2.1.8",
+        "@radix-ui/react-select": "^2.2.6",
         "@radix-ui/react-separator": "^1.1.8",
         "@radix-ui/react-slot": "^1.2.4",
         "@radix-ui/react-tooltip": "^1.2.8",

--- a/frontend/components/dashboard/common/Modal.tsx
+++ b/frontend/components/dashboard/common/Modal.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import * as Dialog from "@radix-ui/react-dialog";
+import { X } from "lucide-react";
+import type { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+interface ModalProps {
+    opened: boolean;
+    onClose: () => void;
+    title?: ReactNode;
+    /** Default true (label-style header). Set false for a literal value like a file name. */
+    uppercaseTitle?: boolean;
+    /** Rendered in the header row, between the title and the close button. */
+    headerActions?: ReactNode;
+    size?: "sm" | "md" | "lg" | "xl";
+    padded?: boolean;
+    hideClose?: boolean;
+    contentClassName?: string;
+    children: ReactNode;
+}
+
+const sizeToMaxWidth: Record<NonNullable<ModalProps["size"]>, string> = {
+    sm: "max-w-sm",
+    md: "max-w-lg",
+    lg: "max-w-2xl",
+    xl: "max-w-5xl",
+};
+
+const closeBtnClasses =
+    "shrink-0 rounded-md p-1 bg-transparent text-sbi-muted hover:bg-sbi-green/10 hover:text-sbi-green transition-colors";
+
+export function Modal({
+    opened,
+    onClose,
+    title,
+    uppercaseTitle = true,
+    headerActions,
+    size = "md",
+    padded = true,
+    hideClose = false,
+    contentClassName,
+    children,
+}: ModalProps) {
+    return (
+        <Dialog.Root
+            open={opened}
+            onOpenChange={(o) => {
+                if (!o) onClose();
+            }}
+        >
+            <Dialog.Portal>
+                <Dialog.Overlay className="fixed inset-0 z-50 bg-sbi-dark/70 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
+                <Dialog.Content
+                    className={cn(
+                        "fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 z-50 w-full",
+                        sizeToMaxWidth[size],
+                        "bg-sbi-dark text-white border border-sbi-dark-border/50 rounded-xl overflow-hidden shadow-[0_8px_32px_rgba(0,0,0,0.4)]",
+                        "max-h-[88vh] flex flex-col",
+                        "duration-300 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-98 data-[state=open]:zoom-in-98",
+                        contentClassName,
+                    )}
+                >
+                    {title ? (
+                        <div className="bg-sbi-dark-card border-b border-sbi-dark-border/50 px-5 py-4 flex items-center gap-4 shrink-0">
+                            <Dialog.Title
+                                className={cn(
+                                    "min-w-0 flex-1 truncate text-sm font-medium",
+                                    uppercaseTitle
+                                        ? "uppercase tracking-[0.04em] text-sbi-muted"
+                                        : "text-white",
+                                )}
+                            >
+                                {title}
+                            </Dialog.Title>
+                            {headerActions ? (
+                                <div className="flex shrink-0 items-center gap-2">
+                                    {headerActions}
+                                </div>
+                            ) : null}
+                            {!hideClose ? (
+                                <Dialog.Close
+                                    aria-label="Close"
+                                    className={closeBtnClasses}
+                                >
+                                    <X className="h-4 w-4" />
+                                </Dialog.Close>
+                            ) : null}
+                        </div>
+                    ) : (
+                        <>
+                            <Dialog.Title className="sr-only">
+                                Dialog
+                            </Dialog.Title>
+                            {!hideClose ? (
+                                <Dialog.Close
+                                    aria-label="Close"
+                                    className={cn(
+                                        "absolute right-3 top-3 z-10",
+                                        closeBtnClasses,
+                                    )}
+                                >
+                                    <X className="h-4 w-4" />
+                                </Dialog.Close>
+                            ) : null}
+                        </>
+                    )}
+                    <div
+                        className={cn(
+                            "flex-1 min-h-0 overflow-y-auto custom-scrollbar",
+                            padded && "p-6",
+                        )}
+                    >
+                        {children}
+                    </div>
+                </Dialog.Content>
+            </Dialog.Portal>
+        </Dialog.Root>
+    );
+}

--- a/frontend/components/dashboard/common/Modal.tsx
+++ b/frontend/components/dashboard/common/Modal.tsx
@@ -53,7 +53,7 @@ export function Modal({
                 <Dialog.Overlay className="fixed inset-0 z-50 bg-sbi-dark/70 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
                 <Dialog.Content
                     className={cn(
-                        "fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 z-50 w-full",
+                        "font-urbanist fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 z-50 w-full",
                         sizeToMaxWidth[size],
                         "bg-sbi-dark text-white border border-sbi-dark-border/50 rounded-xl overflow-hidden shadow-[0_8px_32px_rgba(0,0,0,0.4)]",
                         "max-h-[88vh] flex flex-col",
@@ -105,6 +105,9 @@ export function Modal({
                             ) : null}
                         </>
                     )}
+                    <Dialog.Description className="sr-only">
+                        Dialog content
+                    </Dialog.Description>
                     <div
                         className={cn(
                             "flex-1 min-h-0 overflow-y-auto custom-scrollbar",

--- a/frontend/components/dashboard/common/TextField.tsx
+++ b/frontend/components/dashboard/common/TextField.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import type { KeyboardEventHandler } from "react";
+
+interface TextFieldProps {
+    label?: string;
+    value: string;
+    onChange: (v: string) => void;
+    placeholder?: string;
+    disabled?: boolean;
+    autoFocus?: boolean;
+    onKeyDown?: KeyboardEventHandler<HTMLInputElement>;
+    type?: string;
+}
+
+export function TextField({
+    label,
+    value,
+    onChange,
+    placeholder,
+    disabled,
+    autoFocus,
+    onKeyDown,
+    type = "text",
+}: TextFieldProps) {
+    return (
+        <div>
+            {label ? (
+                <label className="block text-xs uppercase tracking-[0.04em] text-sbi-muted mb-2">
+                    {label}
+                </label>
+            ) : null}
+            <input
+                type={type}
+                value={value}
+                onChange={(e) => onChange(e.target.value)}
+                placeholder={placeholder}
+                disabled={disabled}
+                // biome-ignore lint/a11y/noAutofocus: modal inputs need focus for Enter-to-submit
+                autoFocus={autoFocus}
+                onKeyDown={onKeyDown}
+                className="w-full bg-sbi-dark-card text-white border border-sbi-dark-border/50 rounded-md px-3 py-2 text-sm focus:outline-none focus:border-sbi-green/50 transition-colors disabled:opacity-50 placeholder:text-sbi-muted-dark"
+            />
+        </div>
+    );
+}

--- a/frontend/components/dashboard/common/Toast.tsx
+++ b/frontend/components/dashboard/common/Toast.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { Check, TriangleAlert, Info } from "lucide-react";
+import type { ReactNode } from "react";
+
+export type ToastKind = "success" | "error" | "info";
+
+const ICON: Record<ToastKind, { Icon: typeof Check; color: string }> = {
+    success: { Icon: Check, color: "text-sbi-green" },
+    error: { Icon: TriangleAlert, color: "text-red-400" },
+    info: { Icon: Info, color: "text-sbi-muted" },
+};
+
+interface ToastProps {
+    kind: ToastKind;
+    title?: string;
+    message: ReactNode;
+}
+
+/**
+ * Quiet confirmation toast: one small status glyph, one line of text. No
+ * icon chip, no close button, no countdown bar, no backdrop blur. sonner
+ * owns stacking, swipe-to-dismiss, auto-dismiss, and enter/exit.
+ */
+export function Toast({ kind, title, message }: ToastProps) {
+    const { Icon, color } = ICON[kind];
+
+    return (
+        <div
+            role={kind === "error" ? "alert" : "status"}
+            aria-live={kind === "error" ? "assertive" : "polite"}
+            aria-atomic="true"
+            className="flex w-fit min-w-[240px] max-w-[min(380px,calc(100vw-2rem))] items-start gap-3 rounded-xl border border-sbi-dark-border/60 bg-sbi-dark-card px-4 py-3 shadow-[0_16px_48px_-16px_rgba(0,0,0,0.75)]"
+        >
+            <Icon className={`mt-0.5 h-4 w-4 shrink-0 ${color}`} />
+            <div className="min-w-0 flex-1">
+                {title ? (
+                    <p className="text-sm font-medium leading-snug text-white">
+                        {title}
+                    </p>
+                ) : null}
+                <div
+                    className={
+                        title
+                            ? "mt-0.5 text-[0.8rem] leading-snug text-sbi-muted"
+                            : "text-[0.8rem] leading-snug text-white"
+                    }
+                >
+                    {message}
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/frontend/components/dashboard/common/app-sidebar.tsx
+++ b/frontend/components/dashboard/common/app-sidebar.tsx
@@ -273,7 +273,7 @@ export function AppSidebar() {
             <ChevronUp className={`size-4 text-sbi-muted transition-transform ${isProjectMenuOpen ? "" : "rotate-180"}`} />
           </button>
           {isProjectMenuOpen && (
-            <div className="absolute bottom-full left-3 right-3 mb-1 bg-sbi-dark border border-sbi-dark-border/50 rounded-lg overflow-hidden shadow-2xl shadow-black/50 z-50">
+            <div className="absolute top-full left-3 right-3 mt-1 bg-sbi-dark border border-sbi-dark-border/50 rounded-lg overflow-hidden shadow-2xl shadow-black/50 z-50">
               {projects.map((project) => (
                 <button
                   key={project.projectId}
@@ -378,35 +378,36 @@ export function AppSidebar() {
             <div className="py-1">
               <button
                 type="button"
-                className="w-full flex items-center gap-3 px-3 py-2.5 text-sbi-muted hover:text-white hover:bg-sbi-green/5 transition-colors duration-200"
+                onClick={() => { router.push("/dashboard/settings?section=profile"); setIsUserMenuOpen(false); }}
+                className="w-full flex items-center gap-3 px-3 py-2.5 text-sbi-muted hover:text-white hover:bg-sbi-green/5 transition-colors duration-200 cursor-pointer"
               >
                 <User className="size-4" strokeWidth={1.5} />
                 <span className="text-sm font-light">Account</span>
               </button>
               <button
                 type="button"
-                className="w-full flex items-center gap-3 px-3 py-2.5 text-sbi-muted hover:text-white hover:bg-sbi-green/5 transition-colors duration-200"
+                onClick={() => { router.push("/dashboard/settings?section=notifications"); setIsUserMenuOpen(false); }}
+                className="w-full flex items-center gap-3 px-3 py-2.5 text-sbi-muted hover:text-white hover:bg-sbi-green/5 transition-colors duration-200 cursor-pointer"
               >
                 <Bell className="size-4" strokeWidth={1.5} />
                 <span className="text-sm font-light">Notifications</span>
               </button>
-              {userRole === "director" && (
-                <button
-                  type="button"
-                  onClick={() => { router.push("/dashboard/settings"); setIsUserMenuOpen(false); }}
-                  className="w-full flex items-center gap-3 px-3 py-2.5 text-sbi-muted hover:text-white hover:bg-sbi-green/5 transition-colors duration-200 cursor-pointer"
-                >
-                  <Settings className="size-4" strokeWidth={1.5} />
-                  <span className="text-sm font-light">Settings</span>
-                </button>
-              )}
               <button
                 type="button"
-                className="w-full flex items-center gap-3 px-3 py-2.5 text-sbi-muted hover:text-white hover:bg-sbi-green/5 transition-colors duration-200"
+                onClick={() => { router.push("/dashboard/settings"); setIsUserMenuOpen(false); }}
+                className="w-full flex items-center gap-3 px-3 py-2.5 text-sbi-muted hover:text-white hover:bg-sbi-green/5 transition-colors duration-200 cursor-pointer"
+              >
+                <Settings className="size-4" strokeWidth={1.5} />
+                <span className="text-sm font-light">Settings</span>
+              </button>
+              <a
+                href="mailto:support@utsbi.org?subject=Portal%20support"
+                onClick={() => setIsUserMenuOpen(false)}
+                className="w-full flex items-center gap-3 px-3 py-2.5 text-sbi-muted hover:text-white hover:bg-sbi-green/5 transition-colors duration-200 cursor-pointer"
               >
                 <HelpCircle className="size-4" strokeWidth={1.5} />
                 <span className="text-sm font-light">Help</span>
-              </button>
+              </a>
             </div>
 
             {/* Logout */}
@@ -414,7 +415,7 @@ export function AppSidebar() {
               <button
                 type="button"
                 onClick={handleLogout}
-                className="w-full flex items-center gap-3 px-3 py-2.5 text-sbi-muted hover:text-white hover:bg-sbi-green/5 transition-colors duration-200"
+                className="w-full flex items-center gap-3 px-3 py-2.5 text-sbi-muted hover:text-white hover:bg-sbi-green/5 transition-colors duration-200 cursor-pointer"
               >
                 <LogOut className="size-4" strokeWidth={1.5} />
                 <span className="text-sm font-light">Log out</span>

--- a/frontend/components/dashboard/common/ui.tsx
+++ b/frontend/components/dashboard/common/ui.tsx
@@ -1,0 +1,228 @@
+import type { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+export { Modal } from "./Modal";
+export { TextField } from "./TextField";
+
+/**
+ * Shared dashboard UI primitives. One surface system so every screen reads as
+ * the same product. See DESIGN.md "Dashboard System".
+ *
+ * Button language deliberately mirrors the public site (outlined green that
+ * fills on hover) — NOT loud solid-green fills.
+ */
+
+// ---------------------------------------------------------------------------
+// Page shell
+// ---------------------------------------------------------------------------
+
+/**
+ * Standard dashboard page wrapper: full height under the 4rem header, dark
+ * background, consistent padding, centered max-width column.
+ */
+export function DashboardShell({
+  children,
+  className,
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <div className="h-[calc(100vh-4rem)] bg-sbi-dark flex flex-col p-6 md:p-8 overflow-hidden">
+      <div
+        className={cn(
+          "max-w-7xl w-full mx-auto flex flex-col h-full min-h-0",
+          className,
+        )}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Page title + subtitle + optional right-aligned action. Every dashboard page
+ * uses this so headers are pixel-identical.
+ */
+export function PageHeader({
+  title,
+  subtitle,
+  action,
+  className,
+}: {
+  title: string;
+  subtitle?: string;
+  action?: ReactNode;
+  className?: string;
+}) {
+  return (
+    <div
+      className={cn(
+        "flex justify-between items-end gap-4 mb-8 shrink-0",
+        className,
+      )}
+    >
+      <div>
+        <h1 className="text-2xl md:text-3xl font-light tracking-tight text-white mb-2">
+          {title}
+        </h1>
+        {subtitle ? (
+          <p className="text-sbi-muted text-sm">{subtitle}</p>
+        ) : null}
+      </div>
+      {action ? <div className="shrink-0">{action}</div> : null}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Section label (green line + uppercase tracked text — public-site pattern)
+// ---------------------------------------------------------------------------
+
+export function SectionLabel({
+  children,
+  className,
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <div className={cn("flex items-center gap-4 mb-6", className)}>
+      <div className="w-10 h-px bg-sbi-green" />
+      <span className="text-xs tracking-[0.25em] uppercase text-sbi-green">
+        {children}
+      </span>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Surface / Panel — the containment system
+// ---------------------------------------------------------------------------
+
+/**
+ * The canonical contained surface. Everything that floats on black today
+ * should sit inside one of these.
+ */
+export function Panel({
+  children,
+  className,
+  padded = true,
+}: {
+  children: ReactNode;
+  className?: string;
+  padded?: boolean;
+}) {
+  return (
+    <div
+      className={cn(
+        "bg-sbi-dark-card/40 border border-sbi-dark-border/50 rounded-xl",
+        padded && "p-6",
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Stat tile — replaces bare numbers floating on black
+// ---------------------------------------------------------------------------
+
+export function StatTile({
+  label,
+  value,
+  sublabel,
+  icon,
+  accent = false,
+}: {
+  label: string;
+  value: ReactNode;
+  sublabel?: string;
+  icon?: ReactNode;
+  accent?: boolean;
+}) {
+  return (
+    <div className="bg-sbi-dark-card/40 border border-sbi-dark-border/50 rounded-xl p-5">
+      <div className="flex items-start justify-between mb-3">
+        <span className="text-[0.7rem] tracking-[0.2em] uppercase text-sbi-muted-dark">
+          {label}
+        </span>
+        {icon ? (
+          <span className="text-sbi-muted-dark">{icon}</span>
+        ) : null}
+      </div>
+      <div
+        className={cn(
+          "text-4xl font-thin tracking-tight tabular-nums",
+          accent ? "text-sbi-green" : "text-white",
+        )}
+      >
+        {value}
+      </div>
+      {sublabel ? (
+        <p className="text-xs text-sbi-muted-dark mt-2">{sublabel}</p>
+      ) : null}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Empty state — fills its container instead of being a tiny island
+// ---------------------------------------------------------------------------
+
+export function EmptyState({
+  icon,
+  title,
+  description,
+  action,
+  className,
+}: {
+  icon?: ReactNode;
+  title: string;
+  description?: string;
+  action?: ReactNode;
+  className?: string;
+}) {
+  return (
+    <div
+      className={cn(
+        "flex-1 flex flex-col items-center justify-center text-center px-6 py-16",
+        className,
+      )}
+    >
+      {icon ? (
+        <div className="mb-5 flex h-14 w-14 items-center justify-center rounded-full border border-sbi-green/20 bg-sbi-green/5 text-sbi-green">
+          {icon}
+        </div>
+      ) : null}
+      <h3 className="text-lg font-light text-white">{title}</h3>
+      {description ? (
+        <p className="mt-2 max-w-sm text-sm text-sbi-muted">{description}</p>
+      ) : null}
+      {action ? <div className="mt-6">{action}</div> : null}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Button class language (outlined green → fills on hover; public-site match)
+// ---------------------------------------------------------------------------
+
+/** Primary action. Refined outline, not a loud solid fill. */
+export const btnPrimary =
+  "inline-flex items-center justify-center gap-2 px-5 h-10 text-xs font-medium tracking-[0.04em] uppercase " +
+  "bg-sbi-green/10 text-sbi-green border border-sbi-green/30 rounded-md cursor-pointer " +
+  "hover:bg-sbi-green hover:text-sbi-dark disabled:opacity-50 disabled:cursor-not-allowed transition-colors";
+
+/** Secondary / neutral action. */
+export const btnGhost =
+  "inline-flex items-center justify-center gap-2 px-5 h-10 text-xs font-medium tracking-[0.04em] uppercase " +
+  "bg-transparent text-sbi-muted border border-sbi-dark-border/60 rounded-md cursor-pointer " +
+  "hover:text-white hover:border-white/30 disabled:opacity-50 disabled:cursor-not-allowed transition-colors";
+
+/** Mantine <Button> classNames override to match btnPrimary. */
+export const mantinePrimaryClasses =
+  "!bg-sbi-green/10 !text-sbi-green !border !border-sbi-green/30 hover:!bg-sbi-green hover:!text-sbi-dark transition-colors uppercase tracking-[0.04em] text-xs font-medium";

--- a/frontend/components/ui/confirm-dialog.tsx
+++ b/frontend/components/ui/confirm-dialog.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import { useState, type ReactNode } from "react";
+import { AlertTriangle } from "lucide-react";
+import { Modal } from "@/components/dashboard/common/Modal";
+
+interface ConfirmDialogProps {
+  opened: boolean;
+  onClose: () => void;
+  title: string;
+  description: ReactNode;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  danger?: boolean;
+  /**
+   * If provided, the user must type this exact string (case-insensitive)
+   * before the confirm button enables. Use for high-risk destructive actions.
+   */
+  confirmationText?: string;
+  onConfirm: () => void | Promise<void>;
+}
+
+export function ConfirmDialog({
+  opened,
+  onClose,
+  title,
+  description,
+  confirmLabel = "Confirm",
+  cancelLabel = "Cancel",
+  danger = false,
+  confirmationText,
+  onConfirm,
+}: ConfirmDialogProps) {
+  const [typed, setTyped] = useState("");
+  const [isWorking, setIsWorking] = useState(false);
+
+  const typedMatches = confirmationText
+    ? typed.trim().toLowerCase() === confirmationText.trim().toLowerCase()
+    : true;
+  const canConfirm = typedMatches && !isWorking;
+
+  const handleConfirm = async () => {
+    setIsWorking(true);
+    try {
+      await onConfirm();
+    } finally {
+      setIsWorking(false);
+      setTyped("");
+    }
+  };
+
+  const handleClose = () => {
+    if (isWorking) return;
+    setTyped("");
+    onClose();
+  };
+
+  return (
+    <Modal opened={opened} onClose={handleClose} hideClose size="sm">
+      <div>
+        <div className="flex items-start gap-3 mb-4">
+          {danger && (
+            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-red-500/10 text-red-400">
+              <AlertTriangle className="h-5 w-5" />
+            </div>
+          )}
+          <div className="flex-1 min-w-0">
+            <h2 className="text-lg font-light tracking-tight text-white mb-1">
+              {title}
+            </h2>
+            <div className="text-sm text-sbi-muted leading-relaxed">
+              {description}
+            </div>
+          </div>
+        </div>
+
+        {confirmationText && (
+          <div className="mb-5 mt-2">
+            <label className="block text-xs uppercase tracking-[0.15em] text-sbi-muted mb-2">
+              Type{" "}
+              <span className="text-white font-medium normal-case">
+                {confirmationText}
+              </span>{" "}
+              to confirm
+            </label>
+            <input
+              type="text"
+              value={typed}
+              onChange={(e) => setTyped(e.target.value)}
+              disabled={isWorking}
+              autoFocus
+              className="w-full bg-sbi-dark-card border border-sbi-dark-border/50 rounded-md px-3 py-2 text-sm text-white focus:outline-none focus:border-sbi-green/50 transition-colors disabled:opacity-50"
+              placeholder={confirmationText}
+            />
+          </div>
+        )}
+
+        <div className="flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={handleClose}
+            disabled={isWorking}
+            className="cursor-pointer rounded-md border border-sbi-dark-border/50 px-4 py-2 text-xs font-medium text-sbi-muted hover:text-white hover:border-sbi-dark-border transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {cancelLabel}
+          </button>
+          <button
+            type="button"
+            onClick={handleConfirm}
+            disabled={!canConfirm}
+            className={[
+              "inline-flex items-center gap-2 rounded-md px-4 py-2 text-xs font-medium uppercase tracking-[0.04em] transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed",
+              danger
+                ? "bg-red-500/15 text-red-300 border border-red-500/40 hover:bg-red-500/25 hover:text-red-200"
+                : "bg-sbi-green text-sbi-dark hover:bg-sbi-green/90",
+            ].join(" ")}
+          >
+            {isWorking ? (
+              <>
+                <span className="h-3 w-3 border-2 border-current border-t-transparent rounded-full animate-spin" />
+                Working…
+              </>
+            ) : (
+              confirmLabel
+            )}
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/frontend/components/ui/select.tsx
+++ b/frontend/components/ui/select.tsx
@@ -1,0 +1,163 @@
+"use client";
+
+import * as React from "react";
+import * as SelectPrimitive from "@radix-ui/react-select";
+import { Check, ChevronDown, ChevronUp } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+const Select = SelectPrimitive.Root;
+const SelectGroup = SelectPrimitive.Group;
+const SelectValue = SelectPrimitive.Value;
+
+const SelectTrigger = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger>
+>(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      "flex h-9 w-full items-center justify-between rounded-md border border-sbi-dark-border/50 bg-sbi-dark px-3 text-sm text-white",
+      "data-[placeholder]:text-sbi-muted-dark/70",
+      "focus:outline-none focus:border-sbi-green/50 data-[state=open]:border-sbi-green/50",
+      "disabled:cursor-not-allowed disabled:opacity-50",
+      "cursor-pointer transition-colors",
+      "[&>span]:line-clamp-1 [&>span]:text-left",
+      className,
+    )}
+    {...props}
+  >
+    {children}
+    <SelectPrimitive.Icon asChild>
+      <ChevronDown
+        className="size-4 text-sbi-muted-dark shrink-0 transition-transform duration-150 data-[state=open]:rotate-180"
+        strokeWidth={1.5}
+      />
+    </SelectPrimitive.Icon>
+  </SelectPrimitive.Trigger>
+));
+SelectTrigger.displayName = SelectPrimitive.Trigger.displayName;
+
+const SelectScrollUpButton = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.ScrollUpButton>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollUpButton>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.ScrollUpButton
+    ref={ref}
+    className={cn("flex cursor-default items-center justify-center py-1 text-sbi-muted-dark", className)}
+    {...props}
+  >
+    <ChevronUp className="size-4" />
+  </SelectPrimitive.ScrollUpButton>
+));
+SelectScrollUpButton.displayName = SelectPrimitive.ScrollUpButton.displayName;
+
+const SelectScrollDownButton = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.ScrollDownButton>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollDownButton>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.ScrollDownButton
+    ref={ref}
+    className={cn("flex cursor-default items-center justify-center py-1 text-sbi-muted-dark", className)}
+    {...props}
+  >
+    <ChevronDown className="size-4" />
+  </SelectPrimitive.ScrollDownButton>
+));
+SelectScrollDownButton.displayName = SelectPrimitive.ScrollDownButton.displayName;
+
+const SelectContent = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
+>(({ className, children, position = "popper", ...props }, ref) => (
+  <SelectPrimitive.Portal>
+    <SelectPrimitive.Content
+      ref={ref}
+      position={position}
+      className={cn(
+        "font-urbanist relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md",
+        "bg-sbi-dark text-white border border-sbi-dark-border/60 shadow-2xl shadow-black/60",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out",
+        "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+        "data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
+        "data-[side=bottom]:slide-in-from-top-1 data-[side=top]:slide-in-from-bottom-1",
+        position === "popper" &&
+          "data-[side=bottom]:translate-y-1 data-[side=top]:-translate-y-1",
+        className,
+      )}
+      {...props}
+    >
+      <SelectScrollUpButton />
+      <SelectPrimitive.Viewport
+        className={cn(
+          "p-1",
+          position === "popper" && "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]",
+        )}
+      >
+        {children}
+      </SelectPrimitive.Viewport>
+      <SelectScrollDownButton />
+    </SelectPrimitive.Content>
+  </SelectPrimitive.Portal>
+));
+SelectContent.displayName = SelectPrimitive.Content.displayName;
+
+const SelectLabel = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Label>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Label>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.Label
+    ref={ref}
+    className={cn("px-2 py-1.5 text-[10px] tracking-[0.2em] uppercase text-sbi-muted-dark", className)}
+    {...props}
+  />
+));
+SelectLabel.displayName = SelectPrimitive.Label.displayName;
+
+const SelectItem = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item>
+>(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Item
+    ref={ref}
+    className={cn(
+      "relative flex w-full cursor-pointer select-none items-center rounded-sm py-1.5 pl-3 pr-8 text-sm outline-none transition-colors",
+      "text-white",
+      "data-[highlighted]:bg-white/[0.05]",
+      "data-[state=checked]:text-sbi-green data-[state=checked]:bg-sbi-green/[0.06]",
+      "data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className,
+    )}
+    {...props}
+  >
+    <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+    <span className="absolute right-2 flex size-3.5 items-center justify-center">
+      <SelectPrimitive.ItemIndicator>
+        <Check className="size-3.5 text-sbi-green" />
+      </SelectPrimitive.ItemIndicator>
+    </span>
+  </SelectPrimitive.Item>
+));
+SelectItem.displayName = SelectPrimitive.Item.displayName;
+
+const SelectSeparator = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.Separator
+    ref={ref}
+    className={cn("-mx-1 my-1 h-px bg-sbi-dark-border/40", className)}
+    {...props}
+  />
+));
+SelectSeparator.displayName = SelectPrimitive.Separator.displayName;
+
+export {
+  Select,
+  SelectGroup,
+  SelectValue,
+  SelectTrigger,
+  SelectContent,
+  SelectLabel,
+  SelectItem,
+  SelectSeparator,
+};

--- a/frontend/lib/notifications.ts
+++ b/frontend/lib/notifications.ts
@@ -1,0 +1,93 @@
+"use client";
+
+import { createElement, type ReactNode } from "react";
+import { toast } from "sonner";
+import { Toast, type ToastKind } from "@/components/dashboard/common/Toast";
+
+function show(
+    kind: ToastKind,
+    durationMs: number,
+    message: ReactNode,
+    title?: string,
+) {
+    toast.custom(
+        () => createElement(Toast, { kind, title, message }),
+        { duration: durationMs },
+    );
+}
+
+export function toastSuccess(message: string, title?: string) {
+    show("success", 4000, message, title);
+}
+
+export function toastError(message: ReactNode, title = "Something went wrong") {
+    show("error", 6000, message, title);
+}
+
+export function toastInfo(message: string, title?: string) {
+    show("info", 3500, message, title);
+}
+
+/**
+ * Quiet one-line confirmation for a completed move with an inline Undo (the
+ * only action, so it carries real contrast). The caller pre-humanizes any
+ * error message. On undo: dismiss, await onUndo, then a follow-up toast.
+ */
+export function toastMoveUndo(
+    name: string,
+    destLabel: string,
+    onUndo: () => Promise<void>,
+): void {
+    toast.custom(
+        (id) =>
+            createElement(Toast, {
+                kind: "success",
+                message: createElement(
+                    "span",
+                    { className: "flex items-center gap-3" },
+                    createElement(
+                        "span",
+                        { className: "min-w-0 flex-1 leading-snug" },
+                        createElement(
+                            "span",
+                            { className: "text-sbi-muted" },
+                            "Moved ",
+                        ),
+                        createElement(
+                            "span",
+                            { className: "font-medium text-white" },
+                            name,
+                        ),
+                        createElement(
+                            "span",
+                            { className: "text-sbi-muted" },
+                            ` to ${destLabel}`,
+                        ),
+                    ),
+                    createElement(
+                        "button",
+                        {
+                            type: "button",
+                            className:
+                                "shrink-0 cursor-pointer rounded-md border border-sbi-green/30 px-2.5 py-1 text-xs font-medium text-sbi-green transition-colors hover:bg-sbi-green/10",
+                            onClick: async () => {
+                                toast.dismiss(id);
+                                try {
+                                    await onUndo();
+                                    toastSuccess("Move undone.");
+                                } catch (err) {
+                                    const msg =
+                                        err instanceof Error
+                                            ? err.message
+                                            : String(err);
+                                    toastError(msg, "Undo failed");
+                                }
+                            },
+                        },
+                        "Undo",
+                    ),
+                ),
+            }),
+        { duration: 6000 },
+    );
+}

--- a/frontend/lib/supabase/middleware.ts
+++ b/frontend/lib/supabase/middleware.ts
@@ -49,6 +49,36 @@ export async function updateSession(request: NextRequest) {
 		return NextResponse.redirect(url);
 	}
 
+	// Already-authenticated users hitting /login: resolve the redirect here at
+	// the edge, before the (static) layout (Navbar + Footer) ever ships. Doing
+	// it at the page level instead leaves a one-frame navbar/footer flash when
+	// the login RSC resolves into a redirect. Mirrors the profile guard in
+	// resolve-actor so an auth session without a profile doesn't loop
+	// (/login -> /dashboard -> /login).
+	if (user && request.nextUrl.pathname.startsWith("/login")) {
+		const { data: profile, error: profileErr } = await supabase
+			.from("profiles")
+			.select("id")
+			.eq("uid", user.sub as string)
+			.maybeSingle();
+
+		if (profile) {
+			const url = request.nextUrl.clone();
+			url.pathname = "/dashboard";
+			return NextResponse.redirect(url);
+		}
+
+		if (!profileErr) {
+			// Confirmed no profile row: clear the orphan session so the
+			// login form is usable instead of bouncing. Falls through to
+			// /login.
+			await supabase.auth.signOut();
+		}
+		// On a transient query error we can't confirm eligibility: fail
+		// open. Don't sign the user out, don't redirect — fall through to
+		// /login so a DB/RLS blip never logs out a valid session.
+	}
+
 	// IMPORTANT: You *must* return the supabaseResponse object as it is.
 	// If you're creating a new response object with NextResponse.next() make sure to:
 	// 1. Pass the request in it, like so:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,9 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@google/model-viewer": "^4.1.0",
     "@mantine/carousel": "^8.3.9",
     "@mantine/charts": "^8.3.9",
@@ -68,6 +71,7 @@
     "react-syntax-highlighter": "^16.1.0",
     "recharts": "^3.5.1",
     "remark-gfm": "^4.0.1",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.4.0",
     "three": "^0.181.2"
   },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -33,6 +33,7 @@
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-icons": "^1.3.2",
     "@radix-ui/react-label": "^2.1.8",
+    "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-separator": "^1.1.8",
     "@radix-ui/react-slot": "^1.2.4",
     "@radix-ui/react-tooltip": "^1.2.8",

--- a/frontend/proxy.ts
+++ b/frontend/proxy.ts
@@ -18,5 +18,7 @@ export const config = {
     "/dashboard/:path*",
     // Match auth routes
     "/auth/:path*",
+    // Match login so authed users are redirected at the edge (no layout flash)
+    "/login",
   ],
 };


### PR DESCRIPTION
## Summary
- Rewrites the **Settings page** as a vertical-nav surface open to every role (Profile / Security / Notifications) with director-only sections gated underneath (Calendar / Team / Accounts).
- Fixes a **silent data-layer bug** where the team member list returned zero rows for every project (PostgREST ambiguous embed against \`project_members → profiles\` after \`assigned_by\` landed).
- Rebuilds **Accounts** as a real searchable + role-filtered table with inline edit and the same containment as the rest of the dashboard.
- Adds a working **owner-assignment flow** with the **root-cause fix in \`createAccount\`** so new clients are linked as owners atomically.

## What changed

### New functionality
- Profile editor (name + department from canonical \`DEPARTMENTS\` list)
- Password change with current-password verification + sign-out-everywhere
- Notification preferences persisted to \`profiles.config.notifications\` (UI plumbing — no sender wired yet, deliberate)
- Account edit modal (name / role / department) with self-role-change blocked
- Searchable + role-filtered Accounts table with live counts, alphabetical sort, edit + delete actions
- Team panel rebuilt: header-aligned Assign-member / Assign-owner, member-count line, inline loading consistent with Accounts
- Custom-styled shadcn \`Select\` everywhere (\`@radix-ui/react-select\`); replaces every native \`<select>\` so the OS popup never breaks the surface
- Sidebar account menu fully wired (Account, Notifications, Settings, Help mailto, Logout)
- Route-level \`loading.tsx\` for the settings route

### Bug fixes (HIGH)
- **FK-disambiguated embed** in \`listProjectMembers\` and the calendar route — \`profiles!project_members_profile_id_fkey(...)\` plus \`assigner:profiles!project_members_assigned_by_fkey(...)\`. Without this Postgres refused the join and returned zero rows, so the team list looked empty for every project.
- **\`createAccount\` rollback**: if the projects insert fails, the auth user is now deleted to prevent burning the email.
- **\`createAccount\` owner link**: clients are now linked as project owners in the same transaction; downstream queries (calendar attendees, team list) stop seeing orphan projects.
- **\`updateAccount\` consistency**: self role-change rejected; on any role change, stale \`project_members\` rows for that profile are cleaned so downstream queries don't see role mismatches.
- **\`removeMemberFromProject\`** rejects non-positive ids defensively (synthetic director rows would otherwise silently no-op).
- **Race-guard** rapid project switching in TeamSection via cancellation in the load effect.
- **Calendar OAuth** now distinguishes never-connected from token-expired (401/403) instead of swallowing both.

### Chrome / a11y
- \`Modal\` adds \`Dialog.Description\` (Radix a11y warning gone) and \`font-urbanist\` so portaled dialog text stays on-brand.
- Dropdowns no longer use the \`<button className=\"fixed inset-0\">\` overlay pattern (which announced as a giant Close-menu button to screen readers); replaced with \`useClickOutside\` + \`useEscapeKey\` hooks.
- Inline loading on Team/Accounts matches the Accounts pattern instead of flashing empty state mid-fetch.
- All five form fields (inputs + selects) pinned to \`h-9\` so they share one baseline.

### Database state (run separately, not in this PR)
- No backfill SQL needed — every existing project already has an owner row.
- One-off data cleanup performed during this session: flipped Shizee's \`profile.role\` to \`client\` (was \`member\` while owning a project), dropped her stale non-owner membership, and deleted the \`Lamester Inc\` test project (with its conversations/messages) per direction from the session.

## Test plan
- [ ] Refresh \`/dashboard/settings\` — vertical nav lands on Profile, all sections reachable
- [ ] **Profile**: edit name and department, save, refresh, verify persisted
- [ ] **Security**: change password with correct + wrong current password; sign out everywhere returns to /login
- [ ] **Notifications**: toggle prefs, save, refresh — toggles preserved
- [ ] **Team**: switch projects, verify members + directors show (was empty before the FK fix); Assign member dropdown searches across name/email/department; Assign owner appears only when project has no owner; counts line shows owner/members/directors correctly
- [ ] **Accounts**: search by name/email; filter chips with counts; create client account → verify owner row created; edit name/role/department on a non-self account; delete account
- [ ] **Sidebar account menu** items navigate to the right settings section
- [ ] **Calendar** section shows "expired, reconnect" hint when token is stale
- [ ] **No console warnings** about missing Dialog.Description or focus traps