### PR TITLE
feat(finances): project budget tracker dashboard

### DIFF
--- a/frontend/app/dashboard/finances/actions.ts
+++ b/frontend/app/dashboard/finances/actions.ts
@@ -146,7 +146,8 @@ export async function logTransaction(
     budget_id: input.budget_id,
     category_id: input.category_id,
     occurred_on: input.occurred_on,
-    description: input.description.trim(),
+    title: input.title.trim(),
+    description: input.description?.trim() || null,
     amount: input.amount,
     created_by: gate.profileId,
   });
@@ -178,8 +179,9 @@ export async function updateTransaction(
     updateRow.category_id = patch.category_id;
   if (patch.occurred_on !== undefined)
     updateRow.occurred_on = patch.occurred_on;
+  if (patch.title !== undefined) updateRow.title = patch.title.trim();
   if (patch.description !== undefined) {
-    updateRow.description = patch.description.trim();
+    updateRow.description = patch.description?.trim() || null;
   }
   if (patch.amount !== undefined) updateRow.amount = patch.amount;
 

--- a/frontend/app/dashboard/finances/actions.ts
+++ b/frontend/app/dashboard/finances/actions.ts
@@ -82,17 +82,19 @@ export async function upsertCategories(
   const gate = await requireDirector(projectId);
   if ("error" in gate) return { error: gate.error };
 
-  const rows = drafts.map((d) => ({
-    id: d.id,
-    budget_id: budgetId,
-    name: d.name.trim(),
-    expected_amount: d.expected_amount,
-    sort_order: d.sort_order,
-  }));
+  const rows = drafts.map((d) => {
+    const base = {
+      budget_id: budgetId,
+      name: d.name.trim(),
+      expected_amount: d.expected_amount,
+      sort_order: d.sort_order,
+    };
+    return d.id !== undefined ? { ...base, id: d.id } : base;
+  });
 
   const { error } = await gate.supabase
     .from("budget_categories")
-    .upsert(rows, { onConflict: "id" });
+    .upsert(rows, { onConflict: "id", defaultToNull: false });
 
   if (error) return { error: error.message };
   revalidatePath(FINANCES_PATH);

--- a/frontend/app/dashboard/finances/actions.ts
+++ b/frontend/app/dashboard/finances/actions.ts
@@ -1,0 +1,216 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import type {
+  ActionResult,
+  CategoryDraft,
+  TransactionInput,
+} from "@/components/dashboard/finances/types";
+import { createClient } from "@/lib/supabase/server";
+
+const FINANCES_PATH = "/dashboard/finances";
+
+async function requireDirector(projectId: number) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+  if (authError || !user) return { error: "Not authenticated" as const };
+
+  const { data: profile, error: profileError } = await supabase
+    .from("profiles")
+    .select("id")
+    .eq("uid", user.id)
+    .single();
+  if (profileError || !profile) {
+    return { error: "Profile not found" as const };
+  }
+
+  const { data: membership, error: memberError } = await supabase
+    .from("project_members")
+    .select("role")
+    .eq("profile_id", profile.id)
+    .eq("project_id", projectId)
+    .maybeSingle();
+  if (memberError) return { error: "Membership lookup failed" as const };
+  if (!membership || membership.role !== "director") {
+    return { error: "Director role required" as const };
+  }
+
+  return { supabase, profileId: profile.id };
+}
+
+async function projectIdForBudget(budgetId: number): Promise<number | null> {
+  const supabase = await createClient();
+  const { data } = await supabase
+    .from("project_budgets")
+    .select("project_id")
+    .eq("id", budgetId)
+    .single();
+  return data?.project_id ?? null;
+}
+
+export async function createBudget(input: {
+  projectId: number;
+  periodStart: string;
+  periodEnd: string;
+  currency?: string;
+}): Promise<ActionResult> {
+  const gate = await requireDirector(input.projectId);
+  if ("error" in gate) return { error: gate.error };
+
+  const { error } = await gate.supabase.from("project_budgets").insert({
+    project_id: input.projectId,
+    period_start: input.periodStart,
+    period_end: input.periodEnd,
+    currency: input.currency ?? "USD",
+    created_by: gate.profileId,
+  });
+
+  if (error) return { error: error.message };
+  revalidatePath(FINANCES_PATH);
+  return {};
+}
+
+export async function upsertCategories(
+  budgetId: number,
+  drafts: CategoryDraft[],
+): Promise<ActionResult> {
+  const projectId = await projectIdForBudget(budgetId);
+  if (!projectId) return { error: "Budget not found" };
+  const gate = await requireDirector(projectId);
+  if ("error" in gate) return { error: gate.error };
+
+  const rows = drafts.map((d) => ({
+    id: d.id,
+    budget_id: budgetId,
+    name: d.name.trim(),
+    expected_amount: d.expected_amount,
+    sort_order: d.sort_order,
+  }));
+
+  const { error } = await gate.supabase
+    .from("budget_categories")
+    .upsert(rows, { onConflict: "id" });
+
+  if (error) return { error: error.message };
+  revalidatePath(FINANCES_PATH);
+  return {};
+}
+
+export async function deleteCategory(
+  categoryId: number,
+): Promise<ActionResult> {
+  const supabase = await createClient();
+  const { data: cat } = await supabase
+    .from("budget_categories")
+    .select("budget_id")
+    .eq("id", categoryId)
+    .single();
+  if (!cat) return { error: "Category not found" };
+
+  const projectId = await projectIdForBudget(cat.budget_id);
+  if (!projectId) return { error: "Budget not found" };
+  const gate = await requireDirector(projectId);
+  if ("error" in gate) return { error: gate.error };
+
+  const { error } = await gate.supabase
+    .from("budget_categories")
+    .delete()
+    .eq("id", categoryId);
+
+  if (error) {
+    if (error.code === "23503") {
+      return {
+        error: "This category has transactions. Reassign or delete them first.",
+      };
+    }
+    return { error: error.message };
+  }
+  revalidatePath(FINANCES_PATH);
+  return {};
+}
+
+export async function logTransaction(
+  input: TransactionInput,
+): Promise<ActionResult> {
+  const projectId = await projectIdForBudget(input.budget_id);
+  if (!projectId) return { error: "Budget not found" };
+  const gate = await requireDirector(projectId);
+  if ("error" in gate) return { error: gate.error };
+
+  const { error } = await gate.supabase.from("budget_transactions").insert({
+    budget_id: input.budget_id,
+    category_id: input.category_id,
+    occurred_on: input.occurred_on,
+    description: input.description.trim(),
+    amount: input.amount,
+    created_by: gate.profileId,
+  });
+
+  if (error) return { error: error.message };
+  revalidatePath(FINANCES_PATH);
+  return {};
+}
+
+export async function updateTransaction(
+  id: number,
+  patch: Partial<TransactionInput>,
+): Promise<ActionResult> {
+  const supabase = await createClient();
+  const { data: tx } = await supabase
+    .from("budget_transactions")
+    .select("budget_id")
+    .eq("id", id)
+    .single();
+  if (!tx) return { error: "Transaction not found" };
+
+  const projectId = await projectIdForBudget(tx.budget_id);
+  if (!projectId) return { error: "Budget not found" };
+  const gate = await requireDirector(projectId);
+  if ("error" in gate) return { error: gate.error };
+
+  const updateRow: Record<string, unknown> = {};
+  if (patch.category_id !== undefined)
+    updateRow.category_id = patch.category_id;
+  if (patch.occurred_on !== undefined)
+    updateRow.occurred_on = patch.occurred_on;
+  if (patch.description !== undefined) {
+    updateRow.description = patch.description.trim();
+  }
+  if (patch.amount !== undefined) updateRow.amount = patch.amount;
+
+  const { error } = await gate.supabase
+    .from("budget_transactions")
+    .update(updateRow)
+    .eq("id", id);
+
+  if (error) return { error: error.message };
+  revalidatePath(FINANCES_PATH);
+  return {};
+}
+
+export async function deleteTransaction(id: number): Promise<ActionResult> {
+  const supabase = await createClient();
+  const { data: tx } = await supabase
+    .from("budget_transactions")
+    .select("budget_id")
+    .eq("id", id)
+    .single();
+  if (!tx) return { error: "Transaction not found" };
+
+  const projectId = await projectIdForBudget(tx.budget_id);
+  if (!projectId) return { error: "Budget not found" };
+  const gate = await requireDirector(projectId);
+  if ("error" in gate) return { error: gate.error };
+
+  const { error } = await gate.supabase
+    .from("budget_transactions")
+    .delete()
+    .eq("id", id);
+
+  if (error) return { error: error.message };
+  revalidatePath(FINANCES_PATH);
+  return {};
+}

--- a/frontend/app/dashboard/finances/page.tsx
+++ b/frontend/app/dashboard/finances/page.tsx
@@ -1,5 +1,102 @@
-import { notFound } from "next/navigation";
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+import { DashboardShell, PageHeader } from "@/components/dashboard/common/ui";
+import { EmptyBudgetState } from "@/components/dashboard/finances/EmptyBudgetState";
+import type { BudgetFetchResult } from "@/components/dashboard/finances/types";
+import { createClient } from "@/lib/supabase/server";
 
-export default function FinancesPage() {
-  notFound();
+export const dynamic = "force-dynamic";
+
+async function fetchFinancesData(
+  projectId: number,
+): Promise<BudgetFetchResult | { redirect: string }> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return { redirect: "/login" };
+
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("id")
+    .eq("uid", user.id)
+    .single();
+  if (!profile) return { redirect: "/login" };
+
+  const { data: membership } = await supabase
+    .from("project_members")
+    .select("role")
+    .eq("profile_id", profile.id)
+    .eq("project_id", projectId)
+    .maybeSingle();
+  const canEdit = membership?.role === "director";
+
+  const { data: budget } = await supabase
+    .from("project_budgets")
+    .select("*")
+    .eq("project_id", projectId)
+    .maybeSingle();
+
+  if (!budget) {
+    return { budget: null, categories: [], transactions: [], canEdit };
+  }
+
+  const [{ data: categories }, { data: transactions }] = await Promise.all([
+    supabase
+      .from("budget_categories")
+      .select("*")
+      .eq("budget_id", budget.id)
+      .order("sort_order", { ascending: true }),
+    supabase
+      .from("budget_transactions")
+      .select("*")
+      .eq("budget_id", budget.id)
+      .order("occurred_on", { ascending: false }),
+  ]);
+
+  return {
+    budget,
+    categories: categories ?? [],
+    transactions: transactions ?? [],
+    canEdit,
+  };
+}
+
+export default async function FinancesPage() {
+  const cookieStore = await cookies();
+  const projectIdRaw = cookieStore.get("active_project_id")?.value;
+  const projectId = projectIdRaw ? parseInt(projectIdRaw, 10) : NaN;
+  if (!Number.isFinite(projectId)) redirect("/dashboard");
+
+  const result = await fetchFinancesData(projectId);
+  if ("redirect" in result) redirect(result.redirect);
+
+  if (!result.budget) {
+    return (
+      <DashboardShell>
+        <PageHeader
+          title="Finances"
+          subtitle="Track your project budget and spending"
+        />
+        <main className="flex-1 overflow-auto dashboard-scrollbar">
+          <EmptyBudgetState canEdit={result.canEdit} />
+        </main>
+      </DashboardShell>
+    );
+  }
+
+  // FinancesView is wired in T14. Placeholder for now so the page is reachable.
+  return (
+    <DashboardShell>
+      <PageHeader
+        title="Finances"
+        subtitle="Track your project budget and spending"
+      />
+      <main className="flex-1 overflow-auto dashboard-scrollbar">
+        <pre className="text-xs text-sbi-muted">
+          {JSON.stringify(result, null, 2)}
+        </pre>
+      </main>
+    </DashboardShell>
+  );
 }

--- a/frontend/app/dashboard/finances/page.tsx
+++ b/frontend/app/dashboard/finances/page.tsx
@@ -72,6 +72,7 @@ export default async function FinancesPage() {
 
   return (
     <FinancesView
+      key={projectId}
       projectId={projectId}
       canEdit={result.canEdit}
       initialBudget={result.budget}

--- a/frontend/app/dashboard/finances/page.tsx
+++ b/frontend/app/dashboard/finances/page.tsx
@@ -1,7 +1,6 @@
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
-import { DashboardShell, PageHeader } from "@/components/dashboard/common/ui";
-import { EmptyBudgetState } from "@/components/dashboard/finances/EmptyBudgetState";
+import { FinancesView } from "@/components/dashboard/finances";
 import type { BudgetFetchResult } from "@/components/dashboard/finances/types";
 import { createClient } from "@/lib/supabase/server";
 
@@ -71,32 +70,13 @@ export default async function FinancesPage() {
   const result = await fetchFinancesData(projectId);
   if ("redirect" in result) redirect(result.redirect);
 
-  if (!result.budget) {
-    return (
-      <DashboardShell>
-        <PageHeader
-          title="Finances"
-          subtitle="Track your project budget and spending"
-        />
-        <main className="flex-1 overflow-auto dashboard-scrollbar">
-          <EmptyBudgetState canEdit={result.canEdit} />
-        </main>
-      </DashboardShell>
-    );
-  }
-
-  // FinancesView is wired in T14. Placeholder for now so the page is reachable.
   return (
-    <DashboardShell>
-      <PageHeader
-        title="Finances"
-        subtitle="Track your project budget and spending"
-      />
-      <main className="flex-1 overflow-auto dashboard-scrollbar">
-        <pre className="text-xs text-sbi-muted">
-          {JSON.stringify(result, null, 2)}
-        </pre>
-      </main>
-    </DashboardShell>
+    <FinancesView
+      projectId={projectId}
+      canEdit={result.canEdit}
+      initialBudget={result.budget}
+      initialCategories={result.categories}
+      initialTransactions={result.transactions}
+    />
   );
 }

--- a/frontend/app/dashboard/layout.tsx
+++ b/frontend/app/dashboard/layout.tsx
@@ -1,12 +1,13 @@
 import { redirect } from "next/navigation";
 import { AppSidebar } from "@/components/dashboard/common/app-sidebar";
 import { ProjectStatusBar } from "@/components/dashboard/common/ProjectStatusBar";
+import { ProjectSwitchOverlay } from "@/components/dashboard/common/ProjectSwitchOverlay";
 import { SidebarTriggerCustom } from "@/components/dashboard/common/SidebarTriggerCustom";
 import { TimeDisplay } from "@/components/dashboard/explore/ui/TimeDisplay";
-import { resolveActor } from "@/lib/project/resolve-actor";
-import { ProjectProvider } from "@/lib/project/project-context";
-import { SidebarProvider } from "@/lib/sidebar/sidebar-context";
 import { ChatProvider } from "@/lib/chat/chat-context";
+import { ProjectProvider } from "@/lib/project/project-context";
+import { resolveActor } from "@/lib/project/resolve-actor";
+import { SidebarProvider } from "@/lib/sidebar/sidebar-context";
 
 interface DashboardLayoutProps {
   children: React.ReactNode;
@@ -21,9 +22,10 @@ export default async function DashboardLayout({
     redirect("/login");
   }
 
-  const activeProject = actor.projects.find(p => p.projectId === actor.activeProjectId)
-    || actor.projects[0]
-    || null;
+  const activeProject =
+    actor.projects.find((p) => p.projectId === actor.activeProjectId) ||
+    actor.projects[0] ||
+    null;
 
   return (
     <ProjectProvider
@@ -56,6 +58,7 @@ export default async function DashboardLayout({
               <div className="flex flex-1 flex-col min-h-0 bg-sbi-dark relative">
                 <div className="absolute top-0 left-0 right-0 h-32 bg-linear-to-b from-sbi-dark-card/20 to-transparent pointer-events-none" />
                 {children}
+                <ProjectSwitchOverlay />
               </div>
             </div>
           </div>

--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -8,6 +8,7 @@
         "@dnd-kit/core": "^6.3.1",
         "@marsidev/react-turnstile": "^1.4.1",
         "@phosphor-icons/react": "^2.1.10",
+        "@radix-ui/colors": "^3.0.0",
         "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-dropdown-menu": "^2.1.16",
@@ -27,6 +28,7 @@
         "clsx": "^2.1.1",
         "googleapis": "^171.4.0",
         "gsap": "^3.13.0",
+        "linkify-it": "^5.0.1",
         "lucide-react": "^0.555.0",
         "motion": "^12.23.25",
         "next": "16.2.6",
@@ -46,6 +48,7 @@
       "devDependencies": {
         "@biomejs/biome": "2.3.8",
         "@tailwindcss/postcss": "^4.1.17",
+        "@types/linkify-it": "^5.0.0",
         "@types/node": "^24.10.1",
         "@types/react": "^19.2.7",
         "@types/react-dom": "^19.2.3",
@@ -184,6 +187,8 @@
     "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@16.2.6", "", { "os": "win32", "cpu": "x64" }, "sha512-F0+4i0h9J6C4eE3EAPWsoCk7UW/dbzOjyzxY0qnDUOYFu6FFmdZ6l97/XdV3/Nz3VYyO7UWjyEJUXkGqcoXfMA=="],
 
     "@phosphor-icons/react": ["@phosphor-icons/react@2.1.10", "", { "peerDependencies": { "react": ">= 16.8", "react-dom": ">= 16.8" } }, "sha512-vt8Tvq8GLjheAZZYa+YG/pW7HDbov8El/MANW8pOAz4eGxrwhnbfrQZq0Cp4q8zBEu8NIhHdnr+r8thnfRSNYA=="],
+
+    "@radix-ui/colors": ["@radix-ui/colors@3.0.0", "", {}, "sha512-FUOsGBkHrYJwCSEtWRCIfQbZG7q1e6DgxCIOe1SUQzDe/7rXXeA47s8yCn6fuTNQAj1Zq4oTFi9Yjp3wzElcxg=="],
 
     "@radix-ui/number": ["@radix-ui/number@1.1.1", "", {}, "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g=="],
 
@@ -340,6 +345,8 @@
     "@types/estree-jsx": ["@types/estree-jsx@1.0.5", "", { "dependencies": { "@types/estree": "*" } }, "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg=="],
 
     "@types/hast": ["@types/hast@3.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ=="],
+
+    "@types/linkify-it": ["@types/linkify-it@5.0.0", "", {}, "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q=="],
 
     "@types/mdast": ["@types/mdast@4.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA=="],
 
@@ -627,6 +634,8 @@
 
     "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.30.2", "", { "os": "win32", "cpu": "x64" }, "sha512-5g1yc73p+iAkid5phb4oVFMB45417DkRevRbt/El/gKXJk4jid+vPFF/AXbxn05Aky8PapwzZrdJShv5C0avjw=="],
 
+    "linkify-it": ["linkify-it@5.0.1", "", { "dependencies": { "uc.micro": "^2.0.0" } }, "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg=="],
+
     "longest-streak": ["longest-streak@3.1.0", "", {}, "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="],
 
     "lowlight": ["lowlight@1.20.0", "", { "dependencies": { "fault": "^1.0.0", "highlight.js": "~10.7.0" } }, "sha512-8Ktj+prEb1RoCPkEOrPMYUN/nCggB7qAWe3a7OpMjWQkh3l2RD5wKRQ+o8Q8YuI9RG/xs95waaI/E6ym/7NsTw=="],
@@ -886,6 +895,8 @@
     "tw-animate-css": ["tw-animate-css@1.4.0", "", {}, "sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "uc.micro": ["uc.micro@2.1.0", "", {}, "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A=="],
 
     "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 

--- a/frontend/components/dashboard/common/ProjectSwitchOverlay.tsx
+++ b/frontend/components/dashboard/common/ProjectSwitchOverlay.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { useProject } from "@/lib/project/project-context";
+
+/**
+ * Renders a loading overlay over the main content area while a project switch
+ * is re-running server components. Must be placed inside a `relative` ancestor
+ * that wraps only the content area (not the sidebar or header).
+ */
+export function ProjectSwitchOverlay() {
+  const { isSwitching } = useProject();
+  if (!isSwitching) return null;
+
+  return (
+    <div className="absolute inset-0 z-40 flex items-center justify-center bg-sbi-dark/60 backdrop-blur-sm">
+      <div className="flex items-center gap-3 rounded-md border border-sbi-dark-border/60 bg-sbi-dark-card/80 px-4 py-2.5">
+        <span className="h-3 w-3 rounded-full border-2 border-sbi-green border-t-transparent animate-spin" />
+        <span className="text-xs uppercase tracking-[0.18em] text-sbi-muted">
+          Switching project…
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/dashboard/common/ui.tsx
+++ b/frontend/components/dashboard/common/ui.tsx
@@ -67,9 +67,7 @@ export function PageHeader({
         <h1 className="text-2xl md:text-3xl font-light tracking-tight text-white mb-2">
           {title}
         </h1>
-        {subtitle ? (
-          <p className="text-sbi-muted text-sm">{subtitle}</p>
-        ) : null}
+        {subtitle ? <p className="text-sbi-muted text-sm">{subtitle}</p> : null}
       </div>
       {action ? <div className="shrink-0">{action}</div> : null}
     </div>
@@ -137,27 +135,49 @@ export function StatTile({
   sublabel,
   icon,
   accent = false,
+  tone,
 }: {
   label: string;
   value: ReactNode;
   sublabel?: string;
   icon?: ReactNode;
   accent?: boolean;
+  tone?: "default" | "accent" | "warning";
 }) {
+  const resolvedTone: "default" | "accent" | "warning" =
+    tone ?? (accent ? "accent" : "default");
+
   return (
-    <div className="bg-sbi-dark-card/40 border border-sbi-dark-border/50 rounded-xl p-5">
+    <div
+      className={cn(
+        "bg-sbi-dark-card/40 border rounded-xl p-5 transition-colors",
+        resolvedTone === "warning"
+          ? "border-amber-400/40"
+          : "border-sbi-dark-border/50",
+      )}
+    >
       <div className="flex items-start justify-between mb-3">
         <span className="text-[0.7rem] tracking-[0.2em] uppercase text-sbi-muted-dark">
           {label}
         </span>
         {icon ? (
-          <span className="text-sbi-muted-dark">{icon}</span>
+          <span
+            className={cn(
+              resolvedTone === "warning"
+                ? "text-amber-400"
+                : "text-sbi-muted-dark",
+            )}
+          >
+            {icon}
+          </span>
         ) : null}
       </div>
       <div
         className={cn(
           "text-4xl font-thin tracking-tight tabular-nums",
-          accent ? "text-sbi-green" : "text-white",
+          resolvedTone === "accent" && "text-sbi-green",
+          resolvedTone === "warning" && "text-amber-400",
+          resolvedTone === "default" && "text-white",
         )}
       >
         {value}

--- a/frontend/components/dashboard/finances/CategoryEditorDrawer.tsx
+++ b/frontend/components/dashboard/finances/CategoryEditorDrawer.tsx
@@ -2,7 +2,10 @@
 
 import { Plus, Trash2 } from "lucide-react";
 import { useEffect, useState } from "react";
-import { upsertCategories } from "@/app/dashboard/finances/actions";
+import {
+  deleteCategory,
+  upsertCategories,
+} from "@/app/dashboard/finances/actions";
 import { btnGhost, btnPrimary, Modal } from "@/components/dashboard/common/ui";
 import type { BudgetCategory, CategoryDraft } from "./types";
 
@@ -11,6 +14,7 @@ interface CategoryEditorDrawerProps {
   onClose: () => void;
   budgetId: number;
   categories: BudgetCategory[];
+  txCountByCategory: Map<number, number>;
   onSaved: () => void | Promise<void>;
 }
 
@@ -25,6 +29,7 @@ export function CategoryEditorDrawer({
   onClose,
   budgetId,
   categories,
+  txCountByCategory,
   onSaved,
 }: CategoryEditorDrawerProps) {
   const [rows, setRows] = useState<DraftRow[]>([]);
@@ -69,6 +74,27 @@ export function CategoryEditorDrawer({
   async function onSubmit() {
     setSubmitting(true);
     setError(null);
+
+    // Categories that existed when the drawer opened but are no longer in the
+    // row list have been removed by the user and should be deleted on save.
+    const keptIds = new Set(
+      rows.map((r) => r.id).filter((id): id is number => id !== undefined),
+    );
+    const removed = categories.filter((c) => !keptIds.has(c.id));
+
+    // Never delete a category that still has transactions.
+    const blocked = removed.filter(
+      (c) => (txCountByCategory.get(c.id) ?? 0) > 0,
+    );
+    if (blocked.length > 0) {
+      const names = blocked.map((c) => `"${c.name}"`).join(", ");
+      setError(
+        `Can't remove ${names} — ${blocked.length === 1 ? "it has" : "they have"} transactions. Reassign or delete those first.`,
+      );
+      setSubmitting(false);
+      return;
+    }
+
     const drafts: CategoryDraft[] = rows
       .filter((r) => r.name.trim().length > 0)
       .map((r, i) => ({
@@ -78,18 +104,25 @@ export function CategoryEditorDrawer({
         sort_order: i,
       }));
 
-    if (drafts.length === 0) {
-      setError("Add at least one category.");
-      setSubmitting(false);
-      return;
+    if (drafts.length > 0) {
+      const result = await upsertCategories(budgetId, drafts);
+      if (result.error) {
+        setError(result.error);
+        setSubmitting(false);
+        return;
+      }
     }
 
-    const result = await upsertCategories(budgetId, drafts);
-    setSubmitting(false);
-    if (result.error) {
-      setError(result.error);
-      return;
+    for (const c of removed) {
+      const del = await deleteCategory(c.id);
+      if (del.error) {
+        setError(del.error);
+        setSubmitting(false);
+        return;
+      }
     }
+
+    setSubmitting(false);
     onClose();
     await onSaved();
   }
@@ -104,49 +137,63 @@ export function CategoryEditorDrawer({
       <div className="flex flex-col gap-3">
         <p className="text-sm text-sbi-muted">
           Each category has an expected amount. Actual is computed from
-          transactions.
+          transactions. Categories with transactions can't be removed here —
+          clear their transactions first.
         </p>
 
         <div className="flex flex-col gap-2">
-          <div className="grid grid-cols-[minmax(0,1fr)_140px_32px] gap-2 text-[10px] tracking-[0.2em] uppercase text-sbi-muted-dark px-1">
+          <div className="grid grid-cols-[minmax(0,1fr)_140px_40px] gap-2 text-[10px] tracking-[0.2em] uppercase text-sbi-muted-dark px-1">
             <div>Name</div>
             <div className="text-right">Expected ($)</div>
             <div />
           </div>
-          {rows.map((row) => (
-            <div
-              key={row._key}
-              className="grid grid-cols-[minmax(0,1fr)_140px_32px] gap-2 items-center"
-            >
-              <input
-                type="text"
-                value={row.name}
-                placeholder="e.g. Design & Development"
-                onChange={(e) => updateRow(row._key, { name: e.target.value })}
-                className="px-3 h-9 text-sm bg-sbi-dark-card/40 border border-sbi-dark-border/50 rounded text-white placeholder:text-sbi-muted-dark focus:outline-none focus:border-sbi-green/40"
-              />
-              <input
-                type="number"
-                min={0}
-                step="0.01"
-                value={row.expected_amount}
-                onChange={(e) =>
-                  updateRow(row._key, {
-                    expected_amount: Number(e.target.value),
-                  })
-                }
-                className="px-3 h-9 text-sm bg-sbi-dark-card/40 border border-sbi-dark-border/50 rounded text-white text-right tabular-nums focus:outline-none focus:border-sbi-green/40"
-              />
-              <button
-                type="button"
-                onClick={() => removeRow(row._key)}
-                className="p-2 text-sbi-muted hover:text-rose-400 rounded"
-                aria-label="Remove row"
+          {rows.map((row) => {
+            const txCount =
+              row.id !== undefined ? (txCountByCategory.get(row.id) ?? 0) : 0;
+            const locked = txCount > 0;
+            return (
+              <div
+                key={row._key}
+                className="grid grid-cols-[minmax(0,1fr)_140px_40px] gap-2 items-center"
               >
-                <Trash2 className="h-4 w-4" />
-              </button>
-            </div>
-          ))}
+                <input
+                  type="text"
+                  value={row.name}
+                  placeholder="e.g. Design & Development"
+                  onChange={(e) =>
+                    updateRow(row._key, { name: e.target.value })
+                  }
+                  className="px-3 h-9 text-sm bg-sbi-dark-card/40 border border-sbi-dark-border/50 rounded text-white placeholder:text-sbi-muted-dark focus:outline-none focus:border-sbi-green/40"
+                />
+                <input
+                  type="number"
+                  min={0}
+                  step="0.01"
+                  value={row.expected_amount}
+                  onChange={(e) =>
+                    updateRow(row._key, {
+                      expected_amount: Number(e.target.value),
+                    })
+                  }
+                  className="px-3 h-9 text-sm bg-sbi-dark-card/40 border border-sbi-dark-border/50 rounded text-white text-right tabular-nums focus:outline-none focus:border-sbi-green/40"
+                />
+                <button
+                  type="button"
+                  onClick={() => removeRow(row._key)}
+                  disabled={locked}
+                  title={
+                    locked
+                      ? `Has ${txCount} transaction${txCount === 1 ? "" : "s"} — reassign or delete them before removing this category`
+                      : "Remove category"
+                  }
+                  className="flex h-9 items-center justify-center rounded text-sbi-muted hover:text-rose-400 disabled:text-sbi-muted-dark/40 disabled:hover:text-sbi-muted-dark/40 disabled:cursor-not-allowed"
+                  aria-label="Remove category"
+                >
+                  <Trash2 className="h-4 w-4" />
+                </button>
+              </div>
+            );
+          })}
           <button
             type="button"
             onClick={addRow}

--- a/frontend/components/dashboard/finances/CategoryEditorDrawer.tsx
+++ b/frontend/components/dashboard/finances/CategoryEditorDrawer.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+import { Plus, Trash2 } from "lucide-react";
+import { useEffect, useState } from "react";
+import { upsertCategories } from "@/app/dashboard/finances/actions";
+import { btnGhost, btnPrimary, Modal } from "@/components/dashboard/common/ui";
+import type { BudgetCategory, CategoryDraft } from "./types";
+
+interface CategoryEditorDrawerProps {
+  open: boolean;
+  onClose: () => void;
+  budgetId: number;
+  categories: BudgetCategory[];
+  onSaved: () => void | Promise<void>;
+}
+
+type DraftRow = CategoryDraft & { _key: string };
+
+function makeKey() {
+  return `new-${Math.random().toString(36).slice(2, 9)}`;
+}
+
+export function CategoryEditorDrawer({
+  open,
+  onClose,
+  budgetId,
+  categories,
+  onSaved,
+}: CategoryEditorDrawerProps) {
+  const [rows, setRows] = useState<DraftRow[]>([]);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (open) {
+      setRows(
+        categories.map((c) => ({
+          _key: String(c.id),
+          id: c.id,
+          name: c.name,
+          expected_amount: Number(c.expected_amount),
+          sort_order: c.sort_order,
+        })),
+      );
+      setError(null);
+    }
+  }, [open, categories]);
+
+  function updateRow(key: string, patch: Partial<DraftRow>) {
+    setRows((rs) => rs.map((r) => (r._key === key ? { ...r, ...patch } : r)));
+  }
+
+  function removeRow(key: string) {
+    setRows((rs) => rs.filter((r) => r._key !== key));
+  }
+
+  function addRow() {
+    setRows((rs) => [
+      ...rs,
+      {
+        _key: makeKey(),
+        name: "",
+        expected_amount: 0,
+        sort_order: rs.length,
+      },
+    ]);
+  }
+
+  async function onSubmit() {
+    setSubmitting(true);
+    setError(null);
+    const drafts: CategoryDraft[] = rows
+      .filter((r) => r.name.trim().length > 0)
+      .map((r, i) => ({
+        id: r.id,
+        name: r.name,
+        expected_amount: Number(r.expected_amount) || 0,
+        sort_order: i,
+      }));
+
+    if (drafts.length === 0) {
+      setError("Add at least one category.");
+      setSubmitting(false);
+      return;
+    }
+
+    const result = await upsertCategories(budgetId, drafts);
+    setSubmitting(false);
+    if (result.error) {
+      setError(result.error);
+      return;
+    }
+    onClose();
+    await onSaved();
+  }
+
+  return (
+    <Modal
+      opened={open}
+      onClose={onClose}
+      title="Edit budget categories"
+      size="lg"
+    >
+      <div className="flex flex-col gap-3">
+        <p className="text-sm text-sbi-muted">
+          Each category has an expected amount. Actual is computed from
+          transactions.
+        </p>
+
+        <div className="flex flex-col gap-2">
+          <div className="grid grid-cols-[minmax(0,1fr)_140px_32px] gap-2 text-[10px] tracking-[0.2em] uppercase text-sbi-muted-dark px-1">
+            <div>Name</div>
+            <div className="text-right">Expected ($)</div>
+            <div />
+          </div>
+          {rows.map((row) => (
+            <div
+              key={row._key}
+              className="grid grid-cols-[minmax(0,1fr)_140px_32px] gap-2 items-center"
+            >
+              <input
+                type="text"
+                value={row.name}
+                placeholder="e.g. Design & Development"
+                onChange={(e) => updateRow(row._key, { name: e.target.value })}
+                className="px-3 h-9 text-sm bg-sbi-dark-card/40 border border-sbi-dark-border/50 rounded text-white placeholder:text-sbi-muted-dark focus:outline-none focus:border-sbi-green/40"
+              />
+              <input
+                type="number"
+                min={0}
+                step="0.01"
+                value={row.expected_amount}
+                onChange={(e) =>
+                  updateRow(row._key, {
+                    expected_amount: Number(e.target.value),
+                  })
+                }
+                className="px-3 h-9 text-sm bg-sbi-dark-card/40 border border-sbi-dark-border/50 rounded text-white text-right tabular-nums focus:outline-none focus:border-sbi-green/40"
+              />
+              <button
+                type="button"
+                onClick={() => removeRow(row._key)}
+                className="p-2 text-sbi-muted hover:text-rose-400 rounded"
+                aria-label="Remove row"
+              >
+                <Trash2 className="h-4 w-4" />
+              </button>
+            </div>
+          ))}
+          <button
+            type="button"
+            onClick={addRow}
+            className="self-start inline-flex items-center gap-1 text-xs text-sbi-green hover:text-sbi-green/80 mt-1"
+          >
+            <Plus className="h-3.5 w-3.5" /> Add category
+          </button>
+        </div>
+
+        {error ? <p className="text-sm text-rose-400">{error}</p> : null}
+
+        <div className="flex items-center justify-end gap-2 pt-2">
+          <button
+            type="button"
+            className={btnGhost}
+            onClick={onClose}
+            disabled={submitting}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            className={btnPrimary}
+            onClick={onSubmit}
+            disabled={submitting}
+          >
+            {submitting ? "Saving…" : "Save"}
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/frontend/components/dashboard/finances/CategoryGrid.tsx
+++ b/frontend/components/dashboard/finances/CategoryGrid.tsx
@@ -47,8 +47,8 @@ export function CategoryGrid({
   );
 
   return (
-    <div className="border border-sbi-dark-border/30 rounded-md overflow-hidden">
-      <div className="grid grid-cols-[minmax(0,1fr)_110px_110px_110px_64px] gap-3 px-4 py-2 text-[10px] tracking-[0.2em] uppercase text-sbi-muted-dark border-b border-sbi-dark-border/50">
+    <div className="rounded-lg border border-white/[0.06] bg-sbi-dark-card overflow-hidden">
+      <div className="grid grid-cols-[minmax(0,1fr)_120px_120px_130px_56px] gap-4 px-5 py-2.5 text-[10px] tracking-[0.2em] uppercase text-sbi-muted-dark bg-sbi-dark-btn/50 border-b border-white/[0.04]">
         <div>Category</div>
         <div className="text-right">Expected</div>
         <div className="text-right">Actual</div>
@@ -64,9 +64,11 @@ export function CategoryGrid({
         return (
           <div
             key={cat.id}
-            className="group grid grid-cols-[minmax(0,1fr)_110px_110px_110px_64px] gap-3 items-center px-4 py-2.5 border-b border-sbi-dark-border/15 last:border-b-0 hover:bg-white/[0.015]"
+            className="group grid grid-cols-[minmax(0,1fr)_120px_120px_130px_56px] gap-4 items-center px-5 py-3 border-b border-white/[0.04] transition-colors hover:bg-white/[0.04]"
           >
-            <div className="text-sm text-white truncate">{cat.name}</div>
+            <div className="text-sm font-medium text-white truncate">
+              {cat.name}
+            </div>
             <div className="text-sm text-sbi-muted text-right tabular-nums">
               {formatCurrency(expected)}
             </div>
@@ -102,8 +104,10 @@ export function CategoryGrid({
           </div>
         );
       })}
-      <div className="grid grid-cols-[minmax(0,1fr)_110px_110px_110px_64px] gap-3 items-center px-4 py-3 border-t border-sbi-dark-border/50 bg-sbi-green/[0.03]">
-        <div className="text-sm text-white font-medium">Total</div>
+      <div className="grid grid-cols-[minmax(0,1fr)_120px_120px_130px_56px] gap-4 items-center px-5 py-3 bg-sbi-dark-btn/30">
+        <div className="text-[11px] tracking-[0.15em] uppercase text-sbi-muted">
+          Total
+        </div>
         <div className="text-sm text-white text-right tabular-nums">
           {formatCurrency(totalExpected)}
         </div>
@@ -111,7 +115,7 @@ export function CategoryGrid({
           {formatCurrency(totalActual)}
         </div>
         <div
-          className={`text-sm text-right tabular-nums ${
+          className={`text-sm font-medium text-right tabular-nums ${
             totalExpected - totalActual >= 0
               ? "text-emerald-400"
               : "text-rose-400"

--- a/frontend/components/dashboard/finances/CategoryGrid.tsx
+++ b/frontend/components/dashboard/finances/CategoryGrid.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import { Pencil, Tag, Trash2 } from "lucide-react";
+import { EmptyState, Panel } from "@/components/dashboard/common/ui";
+import type { BudgetCategory } from "./types";
+
+interface CategoryGridProps {
+  categories: BudgetCategory[];
+  actualByCategory: Map<number, number>;
+  formatCurrency: (n: number) => string;
+  canEdit: boolean;
+  onEdit?: () => void;
+  onDeleteCategory?: (id: number) => void;
+}
+
+export function CategoryGrid({
+  categories,
+  actualByCategory,
+  formatCurrency,
+  canEdit,
+  onEdit,
+  onDeleteCategory,
+}: CategoryGridProps) {
+  if (categories.length === 0) {
+    return (
+      <Panel>
+        <EmptyState
+          icon={<Tag className="h-6 w-6" />}
+          title="No categories yet"
+          description={
+            canEdit
+              ? "Add categories to start defining your budget allocation."
+              : "Categories will appear here once your director sets them up."
+          }
+        />
+      </Panel>
+    );
+  }
+
+  const totalExpected = categories.reduce(
+    (s, c) => s + Number(c.expected_amount),
+    0,
+  );
+  const totalActual = categories.reduce(
+    (s, c) => s + (actualByCategory.get(c.id) ?? 0),
+    0,
+  );
+
+  return (
+    <div className="border border-sbi-dark-border/30 rounded-md overflow-hidden">
+      <div className="grid grid-cols-[minmax(0,1fr)_110px_110px_110px_64px] gap-3 px-4 py-2 text-[10px] tracking-[0.2em] uppercase text-sbi-muted-dark border-b border-sbi-dark-border/50">
+        <div>Category</div>
+        <div className="text-right">Expected</div>
+        <div className="text-right">Actual</div>
+        <div className="text-right">Variance</div>
+        <div />
+      </div>
+      {categories.map((cat) => {
+        const expected = Number(cat.expected_amount);
+        const actual = actualByCategory.get(cat.id) ?? 0;
+        const variance = expected - actual;
+        const varClass = variance >= 0 ? "text-emerald-400" : "text-rose-400";
+        const sign = variance >= 0 ? "+" : "−";
+        return (
+          <div
+            key={cat.id}
+            className="group grid grid-cols-[minmax(0,1fr)_110px_110px_110px_64px] gap-3 items-center px-4 py-2.5 border-b border-sbi-dark-border/15 last:border-b-0 hover:bg-white/[0.015]"
+          >
+            <div className="text-sm text-white truncate">{cat.name}</div>
+            <div className="text-sm text-sbi-muted text-right tabular-nums">
+              {formatCurrency(expected)}
+            </div>
+            <div className="text-sm text-white text-right tabular-nums">
+              {formatCurrency(actual)}
+            </div>
+            <div className={`text-sm text-right tabular-nums ${varClass}`}>
+              {sign}
+              {formatCurrency(Math.abs(variance))}
+            </div>
+            <div className="flex items-center justify-end gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+              {canEdit && onEdit ? (
+                <button
+                  type="button"
+                  onClick={onEdit}
+                  className="p-1 text-sbi-muted hover:text-white rounded"
+                  aria-label={`Edit ${cat.name}`}
+                >
+                  <Pencil className="h-3.5 w-3.5" />
+                </button>
+              ) : null}
+              {canEdit && onDeleteCategory ? (
+                <button
+                  type="button"
+                  onClick={() => onDeleteCategory(cat.id)}
+                  className="p-1 text-sbi-muted hover:text-rose-400 rounded"
+                  aria-label={`Delete ${cat.name}`}
+                >
+                  <Trash2 className="h-3.5 w-3.5" />
+                </button>
+              ) : null}
+            </div>
+          </div>
+        );
+      })}
+      <div className="grid grid-cols-[minmax(0,1fr)_110px_110px_110px_64px] gap-3 items-center px-4 py-3 border-t border-sbi-dark-border/50 bg-sbi-green/[0.03]">
+        <div className="text-sm text-white font-medium">Total</div>
+        <div className="text-sm text-white text-right tabular-nums">
+          {formatCurrency(totalExpected)}
+        </div>
+        <div className="text-sm text-white text-right tabular-nums">
+          {formatCurrency(totalActual)}
+        </div>
+        <div
+          className={`text-sm text-right tabular-nums ${
+            totalExpected - totalActual >= 0
+              ? "text-emerald-400"
+              : "text-rose-400"
+          }`}
+        >
+          {totalExpected - totalActual >= 0 ? "+" : "−"}
+          {formatCurrency(Math.abs(totalExpected - totalActual))}
+        </div>
+        <div />
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/dashboard/finances/EmptyBudgetState.tsx
+++ b/frontend/components/dashboard/finances/EmptyBudgetState.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { Wallet } from "lucide-react";
+import { btnPrimary, EmptyState } from "@/components/dashboard/common/ui";
+
+interface EmptyBudgetStateProps {
+  canEdit: boolean;
+  onSetUp?: () => void;
+}
+
+export function EmptyBudgetState({ canEdit, onSetUp }: EmptyBudgetStateProps) {
+  return (
+    <EmptyState
+      icon={<Wallet className="h-6 w-6" />}
+      title="No budget set up yet"
+      description={
+        canEdit
+          ? "Set the budget period and currency to start tracking spend."
+          : "Your project budget hasn't been set up yet. Check back soon."
+      }
+      action={
+        canEdit && onSetUp ? (
+          <button type="button" onClick={onSetUp} className={btnPrimary}>
+            Set Up Budget
+          </button>
+        ) : null
+      }
+    />
+  );
+}

--- a/frontend/components/dashboard/finances/FinancesView.tsx
+++ b/frontend/components/dashboard/finances/FinancesView.tsx
@@ -81,6 +81,14 @@ export function FinancesView({
     return map;
   }, [transactions]);
 
+  const txCountByCategory = useMemo(() => {
+    const map = new Map<number, number>();
+    for (const tx of transactions) {
+      map.set(tx.category_id, (map.get(tx.category_id) ?? 0) + 1);
+    }
+    return map;
+  }, [transactions]);
+
   const totalExpected = useMemo(
     () => categories.reduce((s, c) => s + Number(c.expected_amount), 0),
     [categories],
@@ -220,6 +228,7 @@ export function FinancesView({
         onClose={() => setCategoryEditorOpen(false)}
         budgetId={budget.id}
         categories={categories}
+        txCountByCategory={txCountByCategory}
         onSaved={refetch}
       />
 

--- a/frontend/components/dashboard/finances/FinancesView.tsx
+++ b/frontend/components/dashboard/finances/FinancesView.tsx
@@ -1,0 +1,271 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import {
+  deleteCategory,
+  deleteTransaction,
+} from "@/app/dashboard/finances/actions";
+import {
+  btnGhost,
+  btnPrimary,
+  DashboardShell,
+  PageHeader,
+  SectionLabel,
+} from "@/components/dashboard/common/ui";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+import { CategoryEditorDrawer } from "./CategoryEditorDrawer";
+import { CategoryGrid } from "./CategoryGrid";
+import { EmptyBudgetState } from "./EmptyBudgetState";
+import { useBudget } from "./hooks/useBudget";
+import { LogTransactionDrawer } from "./LogTransactionDrawer";
+import { OverviewTiles } from "./OverviewTiles";
+import { SetupBudgetDrawer } from "./SetupBudgetDrawer";
+import { SpendChart } from "./SpendChart";
+import { TransactionsTable } from "./TransactionsTable";
+import type { BudgetCategory, BudgetTransaction, ProjectBudget } from "./types";
+
+interface FinancesViewProps {
+  projectId: number;
+  canEdit: boolean;
+  initialBudget: ProjectBudget | null;
+  initialCategories: BudgetCategory[];
+  initialTransactions: BudgetTransaction[];
+}
+
+const wholeCurrency = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+  maximumFractionDigits: 0,
+});
+
+function formatCurrency(n: number) {
+  return wholeCurrency.format(n);
+}
+
+const xAxisFmt = new Intl.DateTimeFormat("en-US", {
+  month: "short",
+  year: "2-digit",
+});
+
+export function FinancesView({
+  projectId,
+  canEdit,
+  initialBudget,
+  initialCategories,
+  initialTransactions,
+}: FinancesViewProps) {
+  const { budget, categories, transactions, refetch } = useBudget({
+    initialBudget,
+    initialCategories,
+    initialTransactions,
+    projectId,
+  });
+
+  const [setupOpen, setSetupOpen] = useState(false);
+  const [categoryEditorOpen, setCategoryEditorOpen] = useState(false);
+  const [logTxOpen, setLogTxOpen] = useState(false);
+  const [editingTx, setEditingTx] = useState<BudgetTransaction | null>(null);
+  const [pendingDeleteCategory, setPendingDeleteCategory] =
+    useState<BudgetCategory | null>(null);
+  const [pendingDeleteTx, setPendingDeleteTx] =
+    useState<BudgetTransaction | null>(null);
+
+  const actualByCategory = useMemo(() => {
+    const map = new Map<number, number>();
+    for (const tx of transactions) {
+      map.set(
+        tx.category_id,
+        (map.get(tx.category_id) ?? 0) + Number(tx.amount),
+      );
+    }
+    return map;
+  }, [transactions]);
+
+  const totalExpected = useMemo(
+    () => categories.reduce((s, c) => s + Number(c.expected_amount), 0),
+    [categories],
+  );
+  const totalActual = useMemo(
+    () => transactions.reduce((s, t) => s + Number(t.amount), 0),
+    [transactions],
+  );
+
+  const cumulativeByDate = useMemo(() => {
+    if (transactions.length === 0) return [];
+    const sorted = [...transactions].sort(
+      (a, b) =>
+        new Date(a.occurred_on).getTime() - new Date(b.occurred_on).getTime(),
+    );
+    let running = 0;
+    return sorted.map((t) => {
+      running += Number(t.amount);
+      return {
+        date: xAxisFmt.format(new Date(t.occurred_on)),
+        cumulative: running,
+      };
+    });
+  }, [transactions]);
+
+  if (!budget) {
+    return (
+      <DashboardShell>
+        <PageHeader
+          title="Finances"
+          subtitle="Track your project budget and spending"
+        />
+        <main className="flex-1 overflow-auto dashboard-scrollbar">
+          <EmptyBudgetState
+            canEdit={canEdit}
+            onSetUp={() => setSetupOpen(true)}
+          />
+        </main>
+        <SetupBudgetDrawer
+          open={setupOpen}
+          onClose={() => setSetupOpen(false)}
+          projectId={projectId}
+          onCreated={refetch}
+        />
+      </DashboardShell>
+    );
+  }
+
+  return (
+    <DashboardShell>
+      <PageHeader
+        title="Finances"
+        subtitle="Track your project budget and spending"
+        action={
+          canEdit ? (
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={() => setCategoryEditorOpen(true)}
+                className={btnGhost}
+              >
+                Edit Categories
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  setEditingTx(null);
+                  setLogTxOpen(true);
+                }}
+                className={btnPrimary}
+              >
+                Log Transaction
+              </button>
+            </div>
+          ) : null
+        }
+      />
+      <main className="flex-1 overflow-auto dashboard-scrollbar">
+        <div className="flex flex-col gap-8 pb-8">
+          <OverviewTiles
+            totalBudget={totalExpected}
+            totalSpent={totalActual}
+            periodStart={budget.period_start}
+            periodEnd={budget.period_end}
+            formatCurrency={formatCurrency}
+          />
+
+          <SpendChart
+            totalBudget={totalExpected}
+            cumulativeByDate={cumulativeByDate}
+            formatCurrency={formatCurrency}
+          />
+
+          <div>
+            <SectionLabel>Spending by Category</SectionLabel>
+            <CategoryGrid
+              categories={categories}
+              actualByCategory={actualByCategory}
+              formatCurrency={formatCurrency}
+              canEdit={canEdit}
+              onEdit={() => setCategoryEditorOpen(true)}
+              onDeleteCategory={(id) => {
+                const cat = categories.find((c) => c.id === id);
+                if (cat) setPendingDeleteCategory(cat);
+              }}
+            />
+          </div>
+
+          <div>
+            <SectionLabel>Recent Transactions</SectionLabel>
+            <TransactionsTable
+              transactions={transactions}
+              categories={categories}
+              formatCurrency={formatCurrency}
+              canEdit={canEdit}
+              onEditTransaction={(tx) => {
+                setEditingTx(tx);
+                setLogTxOpen(true);
+              }}
+              onDeleteTransaction={(id) => {
+                const tx = transactions.find((t) => t.id === id);
+                if (tx) setPendingDeleteTx(tx);
+              }}
+            />
+          </div>
+        </div>
+      </main>
+
+      <CategoryEditorDrawer
+        open={categoryEditorOpen}
+        onClose={() => setCategoryEditorOpen(false)}
+        budgetId={budget.id}
+        categories={categories}
+        onSaved={refetch}
+      />
+
+      <LogTransactionDrawer
+        open={logTxOpen}
+        onClose={() => {
+          setLogTxOpen(false);
+          setEditingTx(null);
+        }}
+        budget={budget}
+        categories={categories}
+        editingTransaction={editingTx}
+        onSaved={refetch}
+      />
+
+      <ConfirmDialog
+        opened={pendingDeleteCategory !== null}
+        onClose={() => setPendingDeleteCategory(null)}
+        title={`Delete category "${pendingDeleteCategory?.name ?? ""}"?`}
+        description="This will fail if the category has transactions attached."
+        confirmLabel="Delete"
+        danger
+        onConfirm={async () => {
+          if (!pendingDeleteCategory) return;
+          const result = await deleteCategory(pendingDeleteCategory.id);
+          setPendingDeleteCategory(null);
+          if (result.error) {
+            window.alert(result.error);
+          }
+          await refetch();
+        }}
+      />
+
+      <ConfirmDialog
+        opened={pendingDeleteTx !== null}
+        onClose={() => setPendingDeleteTx(null)}
+        title="Delete this transaction?"
+        description={
+          pendingDeleteTx
+            ? `${pendingDeleteTx.description} — ${formatCurrency(Number(pendingDeleteTx.amount))}`
+            : ""
+        }
+        confirmLabel="Delete"
+        danger
+        onConfirm={async () => {
+          if (!pendingDeleteTx) return;
+          const result = await deleteTransaction(pendingDeleteTx.id);
+          setPendingDeleteTx(null);
+          if (result.error) window.alert(result.error);
+          await refetch();
+        }}
+      />
+    </DashboardShell>
+  );
+}

--- a/frontend/components/dashboard/finances/FinancesView.tsx
+++ b/frontend/components/dashboard/finances/FinancesView.tsx
@@ -106,6 +106,12 @@ export function FinancesView({
     });
   }, [transactions]);
 
+  const pendingDeleteCategoryTxCount = pendingDeleteCategory
+    ? transactions.filter((t) => t.category_id === pendingDeleteCategory.id)
+        .length
+    : 0;
+  const deleteCategoryBlocked = pendingDeleteCategoryTxCount > 0;
+
   if (!budget) {
     return (
       <DashboardShell>
@@ -232,12 +238,27 @@ export function FinancesView({
       <ConfirmDialog
         opened={pendingDeleteCategory !== null}
         onClose={() => setPendingDeleteCategory(null)}
-        title={`Delete category "${pendingDeleteCategory?.name ?? ""}"?`}
-        description="This will fail if the category has transactions attached."
-        confirmLabel="Delete"
-        danger
+        title={
+          deleteCategoryBlocked
+            ? `Can't delete "${pendingDeleteCategory?.name ?? ""}"`
+            : `Delete category "${pendingDeleteCategory?.name ?? ""}"?`
+        }
+        description={
+          deleteCategoryBlocked
+            ? `This category has ${pendingDeleteCategoryTxCount} transaction${
+                pendingDeleteCategoryTxCount === 1 ? "" : "s"
+              }. Reassign or delete them first, then you can remove the category.`
+            : "This permanently removes the category. This can't be undone."
+        }
+        confirmLabel={deleteCategoryBlocked ? "Got it" : "Delete"}
+        cancelLabel={deleteCategoryBlocked ? "Close" : "Cancel"}
+        danger={!deleteCategoryBlocked}
         onConfirm={async () => {
           if (!pendingDeleteCategory) return;
+          if (deleteCategoryBlocked) {
+            setPendingDeleteCategory(null);
+            return;
+          }
           const result = await deleteCategory(pendingDeleteCategory.id);
           setPendingDeleteCategory(null);
           if (result.error) {

--- a/frontend/components/dashboard/finances/FinancesView.tsx
+++ b/frontend/components/dashboard/finances/FinancesView.tsx
@@ -253,7 +253,7 @@ export function FinancesView({
         title="Delete this transaction?"
         description={
           pendingDeleteTx
-            ? `${pendingDeleteTx.description} — ${formatCurrency(Number(pendingDeleteTx.amount))}`
+            ? `${pendingDeleteTx.title} — ${formatCurrency(Number(pendingDeleteTx.amount))}`
             : ""
         }
         confirmLabel="Delete"

--- a/frontend/components/dashboard/finances/LogTransactionDrawer.tsx
+++ b/frontend/components/dashboard/finances/LogTransactionDrawer.tsx
@@ -1,0 +1,205 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  logTransaction,
+  updateTransaction,
+} from "@/app/dashboard/finances/actions";
+import { btnGhost, btnPrimary, Modal } from "@/components/dashboard/common/ui";
+import { SearchableDropdown } from "@/components/ui/searchable-dropdown";
+import type { BudgetCategory, BudgetTransaction, ProjectBudget } from "./types";
+
+interface LogTransactionDrawerProps {
+  open: boolean;
+  onClose: () => void;
+  budget: ProjectBudget;
+  categories: BudgetCategory[];
+  editingTransaction: BudgetTransaction | null;
+  onSaved: () => void | Promise<void>;
+}
+
+const todayIso = () => new Date().toISOString().slice(0, 10);
+
+function parseAmount(input: string): number {
+  const cleaned = input.replace(/[^\d.-]/g, "");
+  const n = Number(cleaned);
+  return Number.isFinite(n) && n >= 0 ? n : 0;
+}
+
+export function LogTransactionDrawer({
+  open,
+  onClose,
+  budget,
+  categories,
+  editingTransaction,
+  onSaved,
+}: LogTransactionDrawerProps) {
+  const [occurredOn, setOccurredOn] = useState(todayIso());
+  const [description, setDescription] = useState("");
+  const [categoryId, setCategoryId] = useState<number | null>(null);
+  const [amountStr, setAmountStr] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    if (editingTransaction) {
+      setOccurredOn(editingTransaction.occurred_on);
+      setDescription(editingTransaction.description);
+      setCategoryId(editingTransaction.category_id);
+      setAmountStr(String(editingTransaction.amount));
+    } else {
+      setOccurredOn(todayIso());
+      setDescription("");
+      setCategoryId(categories[0]?.id ?? null);
+      setAmountStr("");
+    }
+    setError(null);
+  }, [open, editingTransaction, categories]);
+
+  const outOfPeriod =
+    occurredOn < budget.period_start || occurredOn > budget.period_end;
+
+  async function onSubmit() {
+    setSubmitting(true);
+    setError(null);
+    const amount = parseAmount(amountStr);
+    if (!description.trim()) {
+      setError("Add a description.");
+      setSubmitting(false);
+      return;
+    }
+    if (!categoryId) {
+      setError("Pick a category.");
+      setSubmitting(false);
+      return;
+    }
+    if (!Number.isFinite(amount) || amount <= 0) {
+      setError("Amount must be greater than 0.");
+      setSubmitting(false);
+      return;
+    }
+
+    const result = editingTransaction
+      ? await updateTransaction(editingTransaction.id, {
+          category_id: categoryId,
+          occurred_on: occurredOn,
+          description,
+          amount,
+        })
+      : await logTransaction({
+          budget_id: budget.id,
+          category_id: categoryId,
+          occurred_on: occurredOn,
+          description,
+          amount,
+        });
+
+    setSubmitting(false);
+    if (result.error) {
+      setError(result.error);
+      return;
+    }
+    onClose();
+    await onSaved();
+  }
+
+  return (
+    <Modal
+      opened={open}
+      onClose={onClose}
+      title={editingTransaction ? "Edit transaction" : "Log transaction"}
+    >
+      <div className="flex flex-col gap-4">
+        <label className="flex flex-col gap-1">
+          <span className="text-[10px] tracking-[0.2em] uppercase text-sbi-muted-dark">
+            Date
+          </span>
+          <input
+            type="date"
+            value={occurredOn}
+            onChange={(e) => setOccurredOn(e.target.value)}
+            className="px-3 h-9 text-sm bg-sbi-dark-card/40 border border-sbi-dark-border/50 rounded text-white focus:outline-none focus:border-sbi-green/40"
+          />
+          {outOfPeriod ? (
+            <span className="text-[11px] text-amber-400">
+              Date is outside the budget period ({budget.period_start} →{" "}
+              {budget.period_end}). Saving anyway.
+            </span>
+          ) : null}
+        </label>
+
+        <label className="flex flex-col gap-1">
+          <span className="text-[10px] tracking-[0.2em] uppercase text-sbi-muted-dark">
+            Description
+          </span>
+          <input
+            type="text"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            placeholder="e.g. Figma annual subscription"
+            className="px-3 h-9 text-sm bg-sbi-dark-card/40 border border-sbi-dark-border/50 rounded text-white placeholder:text-sbi-muted-dark focus:outline-none focus:border-sbi-green/40"
+          />
+        </label>
+
+        <div className="flex flex-col gap-1">
+          <span className="text-[10px] tracking-[0.2em] uppercase text-sbi-muted-dark">
+            Category
+          </span>
+          <SearchableDropdown
+            value={categoryId ? String(categoryId) : ""}
+            onChange={(v) => setCategoryId(v ? Number(v) : null)}
+            options={categories.map((c) => ({
+              value: String(c.id),
+              label: c.name,
+            }))}
+            placeholder="Select a category"
+            className="w-full"
+          />
+        </div>
+
+        <label className="flex flex-col gap-1">
+          <span className="text-[10px] tracking-[0.2em] uppercase text-sbi-muted-dark">
+            Amount (USD)
+          </span>
+          <div className="flex items-center gap-1">
+            <span className="text-sm text-sbi-muted">$</span>
+            <input
+              type="text"
+              inputMode="decimal"
+              value={amountStr}
+              onChange={(e) => setAmountStr(e.target.value)}
+              placeholder="0.00"
+              className="px-3 h-9 text-sm bg-sbi-dark-card/40 border border-sbi-dark-border/50 rounded text-white text-right tabular-nums w-full focus:outline-none focus:border-sbi-green/40"
+            />
+          </div>
+        </label>
+
+        {error ? <p className="text-sm text-rose-400">{error}</p> : null}
+
+        <div className="flex items-center justify-end gap-2 pt-2">
+          <button
+            type="button"
+            className={btnGhost}
+            onClick={onClose}
+            disabled={submitting}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            className={btnPrimary}
+            onClick={onSubmit}
+            disabled={submitting}
+          >
+            {submitting
+              ? "Saving…"
+              : editingTransaction
+                ? "Save"
+                : "Log Transaction"}
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/frontend/components/dashboard/finances/LogTransactionDrawer.tsx
+++ b/frontend/components/dashboard/finances/LogTransactionDrawer.tsx
@@ -35,6 +35,7 @@ export function LogTransactionDrawer({
   onSaved,
 }: LogTransactionDrawerProps) {
   const [occurredOn, setOccurredOn] = useState(todayIso());
+  const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
   const [categoryId, setCategoryId] = useState<number | null>(null);
   const [amountStr, setAmountStr] = useState("");
@@ -45,11 +46,13 @@ export function LogTransactionDrawer({
     if (!open) return;
     if (editingTransaction) {
       setOccurredOn(editingTransaction.occurred_on);
-      setDescription(editingTransaction.description);
+      setTitle(editingTransaction.title);
+      setDescription(editingTransaction.description ?? "");
       setCategoryId(editingTransaction.category_id);
       setAmountStr(String(editingTransaction.amount));
     } else {
       setOccurredOn(todayIso());
+      setTitle("");
       setDescription("");
       setCategoryId(categories[0]?.id ?? null);
       setAmountStr("");
@@ -64,8 +67,8 @@ export function LogTransactionDrawer({
     setSubmitting(true);
     setError(null);
     const amount = parseAmount(amountStr);
-    if (!description.trim()) {
-      setError("Add a description.");
+    if (!title.trim()) {
+      setError("Add a title.");
       setSubmitting(false);
       return;
     }
@@ -84,6 +87,7 @@ export function LogTransactionDrawer({
       ? await updateTransaction(editingTransaction.id, {
           category_id: categoryId,
           occurred_on: occurredOn,
+          title,
           description,
           amount,
         })
@@ -91,6 +95,7 @@ export function LogTransactionDrawer({
           budget_id: budget.id,
           category_id: categoryId,
           occurred_on: occurredOn,
+          title,
           description,
           amount,
         });
@@ -131,14 +136,30 @@ export function LogTransactionDrawer({
 
         <label className="flex flex-col gap-1">
           <span className="text-[10px] tracking-[0.2em] uppercase text-sbi-muted-dark">
-            Description
+            Title
           </span>
           <input
             type="text"
-            value={description}
-            onChange={(e) => setDescription(e.target.value)}
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
             placeholder="e.g. Figma annual subscription"
             className="px-3 h-9 text-sm bg-sbi-dark-card/40 border border-sbi-dark-border/50 rounded text-white placeholder:text-sbi-muted-dark focus:outline-none focus:border-sbi-green/40"
+          />
+        </label>
+
+        <label className="flex flex-col gap-1">
+          <span className="text-[10px] tracking-[0.2em] uppercase text-sbi-muted-dark">
+            Description{" "}
+            <span className="text-sbi-muted-dark/60 normal-case tracking-normal">
+              (optional)
+            </span>
+          </span>
+          <textarea
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            placeholder="Additional detail about this expense"
+            rows={2}
+            className="px-3 py-2 text-sm bg-sbi-dark-card/40 border border-sbi-dark-border/50 rounded text-white placeholder:text-sbi-muted-dark focus:outline-none focus:border-sbi-green/40 resize-none"
           />
         </label>
 

--- a/frontend/components/dashboard/finances/OverviewTiles.tsx
+++ b/frontend/components/dashboard/finances/OverviewTiles.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { Flame, PiggyBank, TrendingUp, Wallet } from "lucide-react";
+import { motion } from "motion/react";
+import { StatTile } from "@/components/dashboard/common/ui";
+
+interface OverviewTilesProps {
+  totalBudget: number;
+  totalSpent: number;
+  periodStart: string;
+  periodEnd: string;
+  formatCurrency: (n: number) => string;
+}
+
+export function OverviewTiles({
+  totalBudget,
+  totalSpent,
+  periodStart,
+  periodEnd,
+  formatCurrency,
+}: OverviewTilesProps) {
+  const remaining = Math.max(totalBudget - totalSpent, 0);
+  const overBy = Math.max(totalSpent - totalBudget, 0);
+  const spentPercent =
+    totalBudget > 0 ? Math.round((totalSpent / totalBudget) * 100) : 0;
+  const remainingTone: "accent" | "warning" =
+    totalSpent > totalBudget ? "warning" : "accent";
+
+  const burnRate = (() => {
+    const start = new Date(periodStart).getTime();
+    const end = new Date(periodEnd).getTime();
+    const now = Math.min(Date.now(), end);
+    if (Number.isNaN(start) || now < start) return null;
+    const months = Math.max(
+      1,
+      Math.ceil((now - start) / (1000 * 60 * 60 * 24 * 30)),
+    );
+    return Math.round(totalSpent / months);
+  })();
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.4, ease: [0.22, 1, 0.36, 1] }}
+      className="grid grid-cols-2 md:grid-cols-4 gap-4"
+    >
+      <StatTile
+        label="Total Budget"
+        value={formatCurrency(totalBudget)}
+        sublabel="Project allocation"
+        icon={<Wallet className="h-4 w-4" />}
+      />
+      <StatTile
+        label="Spent"
+        value={formatCurrency(totalSpent)}
+        sublabel={`${spentPercent}% of budget`}
+        icon={<Flame className="h-4 w-4" />}
+      />
+      <StatTile
+        label={overBy > 0 ? "Over Budget" : "Remaining"}
+        value={
+          overBy > 0 ? `+${formatCurrency(overBy)}` : formatCurrency(remaining)
+        }
+        sublabel={
+          overBy > 0
+            ? `${spentPercent}% of budget`
+            : `${Math.max(100 - spentPercent, 0)}% left`
+        }
+        icon={<PiggyBank className="h-4 w-4" />}
+        tone={remainingTone}
+      />
+      <StatTile
+        label="Avg. Burn Rate"
+        value={burnRate !== null ? formatCurrency(burnRate) : "—"}
+        sublabel="Per month so far"
+        icon={<TrendingUp className="h-4 w-4" />}
+      />
+    </motion.div>
+  );
+}

--- a/frontend/components/dashboard/finances/SetupBudgetDrawer.tsx
+++ b/frontend/components/dashboard/finances/SetupBudgetDrawer.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { createBudget } from "@/app/dashboard/finances/actions";
+import {
+  btnGhost,
+  btnPrimary,
+  Modal,
+  TextField,
+} from "@/components/dashboard/common/ui";
+
+interface SetupBudgetDrawerProps {
+  open: boolean;
+  onClose: () => void;
+  projectId: number;
+  onCreated: () => void | Promise<void>;
+}
+
+const todayIso = () => new Date().toISOString().slice(0, 10);
+const oneYearFromIso = (iso: string) => {
+  const d = new Date(iso);
+  d.setFullYear(d.getFullYear() + 1);
+  return d.toISOString().slice(0, 10);
+};
+
+export function SetupBudgetDrawer({
+  open,
+  onClose,
+  projectId,
+  onCreated,
+}: SetupBudgetDrawerProps) {
+  const [periodStart, setPeriodStart] = useState(todayIso());
+  const [periodEnd, setPeriodEnd] = useState(oneYearFromIso(todayIso()));
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (open) {
+      const today = todayIso();
+      setPeriodStart(today);
+      setPeriodEnd(oneYearFromIso(today));
+      setError(null);
+    }
+  }, [open]);
+
+  async function onSubmit() {
+    setSubmitting(true);
+    setError(null);
+    const result = await createBudget({
+      projectId,
+      periodStart,
+      periodEnd,
+      currency: "USD",
+    });
+    setSubmitting(false);
+    if (result.error) {
+      setError(result.error);
+      return;
+    }
+    onClose();
+    await onCreated();
+  }
+
+  return (
+    <Modal opened={open} onClose={onClose} title="Set up project budget">
+      <div className="flex flex-col gap-4">
+        <p className="text-sm text-sbi-muted">
+          Define the budget period. You can add categories and log transactions
+          after.
+        </p>
+        <TextField
+          label="Period start"
+          type="date"
+          value={periodStart}
+          onChange={setPeriodStart}
+        />
+        <TextField
+          label="Period end"
+          type="date"
+          value={periodEnd}
+          onChange={setPeriodEnd}
+        />
+        <p className="text-xs text-sbi-muted-dark">
+          Currency: USD (multi-currency comes later.)
+        </p>
+
+        {error ? <p className="text-sm text-rose-400">{error}</p> : null}
+
+        <div className="flex items-center justify-end gap-2 pt-2">
+          <button
+            type="button"
+            className={btnGhost}
+            onClick={onClose}
+            disabled={submitting}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            className={btnPrimary}
+            onClick={onSubmit}
+            disabled={submitting || periodEnd < periodStart}
+          >
+            {submitting ? "Creating…" : "Create Budget"}
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/frontend/components/dashboard/finances/SpendChart.tsx
+++ b/frontend/components/dashboard/finances/SpendChart.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import { TrendingUp } from "lucide-react";
+import {
+  Area,
+  AreaChart,
+  CartesianGrid,
+  ReferenceLine,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+} from "recharts";
+import { Panel } from "@/components/dashboard/common/ui";
+
+interface SpendChartProps {
+  totalBudget: number;
+  cumulativeByDate: Array<{ date: string; cumulative: number }>;
+  formatCurrency: (n: number) => string;
+}
+
+interface ChartTooltipProps {
+  active?: boolean;
+  label?: string;
+  payload?: Array<{ value?: number | string }>;
+  totalBudget: number;
+  formatCurrency: (n: number) => string;
+}
+
+function ChartTooltip({
+  active,
+  payload,
+  label,
+  totalBudget,
+  formatCurrency,
+}: ChartTooltipProps) {
+  if (!active || !payload?.length) return null;
+  const raw = payload[0]?.value ?? 0;
+  const value = typeof raw === "number" ? raw : Number(raw) || 0;
+  const pct = totalBudget > 0 ? Math.round((value / totalBudget) * 100) : 0;
+  return (
+    <div className="rounded-lg border border-sbi-dark-border/60 bg-sbi-dark-card/95 backdrop-blur px-3 py-2 shadow-lg shadow-black/40">
+      <p className="text-[10px] uppercase tracking-[0.15em] text-sbi-muted-dark mb-0.5">
+        {label}
+      </p>
+      <p className="text-sm text-white tabular-nums">
+        {formatCurrency(value)}{" "}
+        <span className="text-sbi-muted-dark">
+          / {formatCurrency(totalBudget)} ({pct}%)
+        </span>
+      </p>
+    </div>
+  );
+}
+
+export function SpendChart({
+  totalBudget,
+  cumulativeByDate,
+  formatCurrency,
+}: SpendChartProps) {
+  const isOver =
+    cumulativeByDate.length > 0 &&
+    cumulativeByDate[cumulativeByDate.length - 1].cumulative > totalBudget;
+  const lineColor = isOver ? "#f59e0b" : "#22c55e";
+
+  return (
+    <Panel className="flex flex-col h-[260px]">
+      <div className="flex items-start justify-between mb-4">
+        <div>
+          <h3 className="text-xs tracking-[0.15em] uppercase text-sbi-muted font-medium flex items-center gap-2 mb-1">
+            <TrendingUp className="w-4 h-4 text-sbi-green" /> Cumulative Spend
+          </h3>
+          <p className="text-[10px] text-sbi-muted-dark uppercase tracking-[0.15em] font-medium">
+            Against budget cap of {formatCurrency(totalBudget)}
+          </p>
+        </div>
+      </div>
+      <div className="flex-1 min-h-0">
+        {cumulativeByDate.length === 0 ? (
+          <div className="h-full flex items-center justify-center">
+            <p className="text-sm text-sbi-muted">No spend recorded yet.</p>
+          </div>
+        ) : (
+          <ResponsiveContainer width="100%" height="100%">
+            <AreaChart
+              data={cumulativeByDate}
+              margin={{ top: 10, right: 10, left: -20, bottom: 0 }}
+            >
+              <defs>
+                <linearGradient id="spendGradient" x1="0" y1="0" x2="0" y2="1">
+                  <stop offset="5%" stopColor={lineColor} stopOpacity={0.25} />
+                  <stop offset="95%" stopColor={lineColor} stopOpacity={0} />
+                </linearGradient>
+              </defs>
+              <CartesianGrid
+                strokeDasharray="3 3"
+                stroke="#ffffff05"
+                vertical={false}
+              />
+              <XAxis
+                dataKey="date"
+                tick={{
+                  fill: "#8a9a93",
+                  fontSize: 10,
+                  letterSpacing: "0.05em",
+                }}
+                axisLine={false}
+                tickLine={false}
+                dy={10}
+              />
+              <ReferenceLine
+                y={totalBudget}
+                stroke="#8a9a93"
+                strokeDasharray="4 4"
+                label={{
+                  value: "Budget cap",
+                  fill: "#8a9a93",
+                  fontSize: 10,
+                  position: "insideTopRight",
+                }}
+              />
+              <Tooltip
+                content={
+                  <ChartTooltip
+                    totalBudget={totalBudget}
+                    formatCurrency={formatCurrency}
+                  />
+                }
+                cursor={{ stroke: "#ffffff10", strokeWidth: 1 }}
+              />
+              <Area
+                type="monotone"
+                dataKey="cumulative"
+                stroke={lineColor}
+                strokeWidth={3}
+                fillOpacity={1}
+                fill="url(#spendGradient)"
+                dot={false}
+                activeDot={{ r: 6, strokeWidth: 0, fill: lineColor }}
+              />
+            </AreaChart>
+          </ResponsiveContainer>
+        )}
+      </div>
+    </Panel>
+  );
+}

--- a/frontend/components/dashboard/finances/TransactionDetailModal.tsx
+++ b/frontend/components/dashboard/finances/TransactionDetailModal.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { Pencil, Trash2 } from "lucide-react";
+import { btnGhost, btnPrimary, Modal } from "@/components/dashboard/common/ui";
+import type { BudgetTransaction } from "./types";
+
+interface TransactionDetailModalProps {
+  transaction: BudgetTransaction | null;
+  categoryName: string;
+  formatCurrency: (n: number) => string;
+  canEdit: boolean;
+  onClose: () => void;
+  onEdit: (tx: BudgetTransaction) => void;
+  onDelete: (id: number) => void;
+}
+
+const dateFormatter = new Intl.DateTimeFormat("en-US", {
+  year: "numeric",
+  month: "long",
+  day: "numeric",
+});
+
+export function TransactionDetailModal({
+  transaction,
+  categoryName,
+  formatCurrency,
+  canEdit,
+  onClose,
+  onEdit,
+  onDelete,
+}: TransactionDetailModalProps) {
+  return (
+    <Modal
+      opened={transaction !== null}
+      onClose={onClose}
+      title={transaction?.title ?? "Transaction"}
+      uppercaseTitle={false}
+      footer={
+        canEdit && transaction ? (
+          <div className="flex items-center justify-end gap-2">
+            <button
+              type="button"
+              className={btnGhost}
+              onClick={() => onDelete(transaction.id)}
+            >
+              <Trash2 className="h-3.5 w-3.5" /> Delete
+            </button>
+            <button
+              type="button"
+              className={btnPrimary}
+              onClick={() => onEdit(transaction)}
+            >
+              <Pencil className="h-3.5 w-3.5" /> Edit
+            </button>
+          </div>
+        ) : null
+      }
+    >
+      {transaction ? (
+        <div className="flex flex-col gap-5">
+          <div>
+            <div className="text-3xl font-thin tracking-tight tabular-nums text-white">
+              {formatCurrency(Number(transaction.amount))}
+            </div>
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <div className="text-[10px] tracking-[0.2em] uppercase text-sbi-muted-dark mb-1">
+                Date
+              </div>
+              <div className="text-sm text-white tabular-nums">
+                {dateFormatter.format(new Date(transaction.occurred_on))}
+              </div>
+            </div>
+            <div>
+              <div className="text-[10px] tracking-[0.2em] uppercase text-sbi-muted-dark mb-1">
+                Category
+              </div>
+              <span className="inline-block text-[10px] uppercase tracking-[0.15em] px-2 py-0.5 rounded border border-sbi-dark-border/60 text-sbi-muted">
+                {categoryName}
+              </span>
+            </div>
+          </div>
+
+          <div>
+            <div className="text-[10px] tracking-[0.2em] uppercase text-sbi-muted-dark mb-1">
+              Description
+            </div>
+            {transaction.description ? (
+              <p className="text-sm text-sbi-muted whitespace-pre-wrap leading-relaxed">
+                {transaction.description}
+              </p>
+            ) : (
+              <p className="text-sm text-sbi-muted-dark italic">
+                No description.
+              </p>
+            )}
+          </div>
+        </div>
+      ) : null}
+    </Modal>
+  );
+}

--- a/frontend/components/dashboard/finances/TransactionsTable.tsx
+++ b/frontend/components/dashboard/finances/TransactionsTable.tsx
@@ -42,10 +42,19 @@ export function TransactionsTable({
       ),
     },
     {
-      accessor: "description",
-      header: "Description",
+      accessor: "title",
+      header: "Transaction",
       sortable: true,
-      render: (v) => <span className="text-white">{String(v)}</span>,
+      render: (_v, row) => (
+        <div className="flex flex-col">
+          <span className="text-white">{row.title}</span>
+          {row.description ? (
+            <span className="text-xs text-sbi-muted-dark truncate">
+              {row.description}
+            </span>
+          ) : null}
+        </div>
+      ),
     },
     {
       accessor: "category_id",
@@ -116,7 +125,7 @@ export function TransactionsTable({
       columns={columns}
       rowKey="id"
       searchable
-      searchKeys={["description"]}
+      searchKeys={["title", "description"]}
       searchPlaceholder="Search transactions…"
       pageSize={10}
     />

--- a/frontend/components/dashboard/finances/TransactionsTable.tsx
+++ b/frontend/components/dashboard/finances/TransactionsTable.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import { Pencil, Trash2 } from "lucide-react";
+import { useState } from "react";
 import { type ColumnDef, DataTable } from "@/components/data-table";
+import { TransactionDetailModal } from "./TransactionDetailModal";
 import type { BudgetCategory, BudgetTransaction } from "./types";
 
 interface TransactionsTableProps {
@@ -19,6 +21,14 @@ const dateFormatter = new Intl.DateTimeFormat("en-US", {
   day: "numeric",
 });
 
+/** First line of the description; appends an ellipsis if more lines follow. */
+function descriptionPreview(description: string | null): string | null {
+  if (!description) return null;
+  const [first, ...rest] = description.split("\n");
+  const hasMore = rest.some((line) => line.trim().length > 0);
+  return hasMore ? `${first}…` : first;
+}
+
 export function TransactionsTable({
   transactions,
   categories,
@@ -28,6 +38,7 @@ export function TransactionsTable({
   onDeleteTransaction,
 }: TransactionsTableProps) {
   const categoryById = new Map(categories.map((c) => [c.id, c.name] as const));
+  const [selectedTx, setSelectedTx] = useState<BudgetTransaction | null>(null);
 
   const columns: ColumnDef<BudgetTransaction>[] = [
     {
@@ -45,16 +56,19 @@ export function TransactionsTable({
       accessor: "title",
       header: "Transaction",
       sortable: true,
-      render: (_v, row) => (
-        <div className="flex flex-col">
-          <span className="text-white">{row.title}</span>
-          {row.description ? (
-            <span className="text-xs text-sbi-muted-dark truncate">
-              {row.description}
-            </span>
-          ) : null}
-        </div>
-      ),
+      render: (_v, row) => {
+        const preview = descriptionPreview(row.description);
+        return (
+          <div className="flex flex-col min-w-0 max-w-[420px]">
+            <span className="text-white truncate">{row.title}</span>
+            {preview ? (
+              <span className="text-xs text-sbi-muted-dark truncate">
+                {preview}
+              </span>
+            ) : null}
+          </div>
+        );
+      },
     },
     {
       accessor: "category_id",
@@ -120,14 +134,36 @@ export function TransactionsTable({
   }
 
   return (
-    <DataTable<BudgetTransaction>
-      data={transactions}
-      columns={columns}
-      rowKey="id"
-      searchable
-      searchKeys={["title", "description"]}
-      searchPlaceholder="Search transactions…"
-      pageSize={10}
-    />
+    <>
+      <DataTable<BudgetTransaction>
+        data={transactions}
+        columns={columns}
+        rowKey="id"
+        searchable
+        searchKeys={["title", "description"]}
+        searchPlaceholder="Search transactions…"
+        pageSize={10}
+        primaryColumn="title"
+        onRowClick={(row) => setSelectedTx(row)}
+      />
+
+      <TransactionDetailModal
+        transaction={selectedTx}
+        categoryName={
+          selectedTx ? (categoryById.get(selectedTx.category_id) ?? "—") : "—"
+        }
+        formatCurrency={formatCurrency}
+        canEdit={canEdit}
+        onClose={() => setSelectedTx(null)}
+        onEdit={(tx) => {
+          setSelectedTx(null);
+          onEditTransaction?.(tx);
+        }}
+        onDelete={(id) => {
+          setSelectedTx(null);
+          onDeleteTransaction?.(id);
+        }}
+      />
+    </>
   );
 }

--- a/frontend/components/dashboard/finances/TransactionsTable.tsx
+++ b/frontend/components/dashboard/finances/TransactionsTable.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { Pencil, Trash2 } from "lucide-react";
+import { type ColumnDef, DataTable } from "@/components/data-table";
+import type { BudgetCategory, BudgetTransaction } from "./types";
+
+interface TransactionsTableProps {
+  transactions: BudgetTransaction[];
+  categories: BudgetCategory[];
+  formatCurrency: (n: number) => string;
+  canEdit: boolean;
+  onEditTransaction?: (tx: BudgetTransaction) => void;
+  onDeleteTransaction?: (id: number) => void;
+}
+
+const dateFormatter = new Intl.DateTimeFormat("en-US", {
+  year: "numeric",
+  month: "short",
+  day: "numeric",
+});
+
+export function TransactionsTable({
+  transactions,
+  categories,
+  formatCurrency,
+  canEdit,
+  onEditTransaction,
+  onDeleteTransaction,
+}: TransactionsTableProps) {
+  const categoryById = new Map(categories.map((c) => [c.id, c.name] as const));
+
+  const columns: ColumnDef<BudgetTransaction>[] = [
+    {
+      accessor: "occurred_on",
+      header: "Date",
+      sortable: true,
+      width: "w-32",
+      render: (v) => (
+        <span className="text-sbi-muted tabular-nums">
+          {dateFormatter.format(new Date(String(v)))}
+        </span>
+      ),
+    },
+    {
+      accessor: "description",
+      header: "Description",
+      sortable: true,
+      render: (v) => <span className="text-white">{String(v)}</span>,
+    },
+    {
+      accessor: "category_id",
+      header: "Category",
+      width: "w-44",
+      render: (v) => (
+        <span className="text-[10px] uppercase tracking-[0.15em] px-2 py-0.5 rounded border border-sbi-dark-border/60 text-sbi-muted">
+          {categoryById.get(Number(v)) ?? "—"}
+        </span>
+      ),
+    },
+    {
+      accessor: "amount",
+      header: "Amount",
+      sortable: true,
+      align: "right",
+      width: "w-32",
+      render: (v) => (
+        <span className="text-white tabular-nums">
+          {formatCurrency(Number(v))}
+        </span>
+      ),
+    },
+  ];
+
+  if (canEdit) {
+    columns.push({
+      accessor: "id",
+      header: "",
+      width: "w-20",
+      align: "right",
+      render: (_v, row) => (
+        <div className="flex items-center justify-end gap-1">
+          {onEditTransaction ? (
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                onEditTransaction(row);
+              }}
+              className="p-1 text-sbi-muted hover:text-white rounded"
+              aria-label="Edit transaction"
+            >
+              <Pencil className="h-3.5 w-3.5" />
+            </button>
+          ) : null}
+          {onDeleteTransaction ? (
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                onDeleteTransaction(row.id);
+              }}
+              className="p-1 text-sbi-muted hover:text-rose-400 rounded"
+              aria-label="Delete transaction"
+            >
+              <Trash2 className="h-3.5 w-3.5" />
+            </button>
+          ) : null}
+        </div>
+      ),
+    });
+  }
+
+  return (
+    <DataTable<BudgetTransaction>
+      data={transactions}
+      columns={columns}
+      rowKey="id"
+      searchable
+      searchKeys={["description"]}
+      searchPlaceholder="Search transactions…"
+      pageSize={10}
+    />
+  );
+}

--- a/frontend/components/dashboard/finances/hooks/useBudget.ts
+++ b/frontend/components/dashboard/finances/hooks/useBudget.ts
@@ -1,0 +1,73 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { createClient } from "@/lib/supabase/client";
+import type {
+  BudgetCategory,
+  BudgetTransaction,
+  ProjectBudget,
+} from "../types";
+
+interface UseBudgetArgs {
+  initialBudget: ProjectBudget | null;
+  initialCategories: BudgetCategory[];
+  initialTransactions: BudgetTransaction[];
+  projectId: number;
+}
+
+interface UseBudgetReturn {
+  budget: ProjectBudget | null;
+  categories: BudgetCategory[];
+  transactions: BudgetTransaction[];
+  refetch: () => Promise<void>;
+}
+
+export function useBudget(args: UseBudgetArgs): UseBudgetReturn {
+  const [budget, setBudget] = useState(args.initialBudget);
+  const [categories, setCategories] = useState(args.initialCategories);
+  const [transactions, setTransactions] = useState(args.initialTransactions);
+
+  const refetch = useCallback(async () => {
+    const supabase = createClient();
+
+    const { data: budgetRow } = await supabase
+      .from("project_budgets")
+      .select("*")
+      .eq("project_id", args.projectId)
+      .maybeSingle();
+
+    if (!budgetRow) {
+      setBudget(null);
+      setCategories([]);
+      setTransactions([]);
+      return;
+    }
+
+    const [{ data: cats }, { data: txs }] = await Promise.all([
+      supabase
+        .from("budget_categories")
+        .select("*")
+        .eq("budget_id", budgetRow.id)
+        .order("sort_order", { ascending: true }),
+      supabase
+        .from("budget_transactions")
+        .select("*")
+        .eq("budget_id", budgetRow.id)
+        .order("occurred_on", { ascending: false }),
+    ]);
+
+    setBudget(budgetRow);
+    setCategories(cats ?? []);
+    setTransactions(txs ?? []);
+  }, [args.projectId]);
+
+  useEffect(() => {
+    const onFocus = () => {
+      void refetch();
+    };
+    window.addEventListener("focus", onFocus);
+    return () => window.removeEventListener("focus", onFocus);
+  }, [refetch]);
+
+  return { budget, categories, transactions, refetch };
+}

--- a/frontend/components/dashboard/finances/index.tsx
+++ b/frontend/components/dashboard/finances/index.tsx
@@ -1,0 +1,1 @@
+export { FinancesView } from "./FinancesView";

--- a/frontend/components/dashboard/finances/types.ts
+++ b/frontend/components/dashboard/finances/types.ts
@@ -1,0 +1,31 @@
+import type { Database } from "@/lib/supabase/database.types";
+
+type Tables = Database["public"]["Tables"];
+
+export type ProjectBudget = Tables["project_budgets"]["Row"];
+export type BudgetCategory = Tables["budget_categories"]["Row"];
+export type BudgetTransaction = Tables["budget_transactions"]["Row"];
+
+export type CategoryDraft = {
+  id?: number;
+  name: string;
+  expected_amount: number;
+  sort_order: number;
+};
+
+export type TransactionInput = {
+  budget_id: number;
+  category_id: number;
+  occurred_on: string;
+  description: string;
+  amount: number;
+};
+
+export type BudgetFetchResult = {
+  budget: ProjectBudget | null;
+  categories: BudgetCategory[];
+  transactions: BudgetTransaction[];
+  canEdit: boolean;
+};
+
+export type ActionResult = { error?: string };

--- a/frontend/components/dashboard/finances/types.ts
+++ b/frontend/components/dashboard/finances/types.ts
@@ -17,7 +17,8 @@ export type TransactionInput = {
   budget_id: number;
   category_id: number;
   occurred_on: string;
-  description: string;
+  title: string;
+  description?: string | null;
   amount: number;
 };
 

--- a/frontend/lib/project/project-context.tsx
+++ b/frontend/lib/project/project-context.tsx
@@ -1,20 +1,28 @@
-'use client';
+"use client";
 
-import { createContext, useContext, useState, useEffect, type ReactNode } from 'react';
-import { createClient } from '@/lib/supabase/client';
+import { useRouter } from "next/navigation";
+import {
+  createContext,
+  type ReactNode,
+  useContext,
+  useEffect,
+  useState,
+  useTransition,
+} from "react";
+import { createClient } from "@/lib/supabase/client";
 
 export interface ProjectData {
   projectId: number;
   projectSlug: string;
   companyName: string;
-  role: 'owner' | 'director' | 'member';
+  role: "owner" | "director" | "member";
 }
 
 export interface UserProfile {
   id: number;
   name: string;
   email: string;
-  role: 'client' | 'director' | 'member';
+  role: "client" | "director" | "member";
   initials: string;
   department: string | null;
 }
@@ -24,6 +32,8 @@ interface ProjectContextType {
   activeProject: ProjectData | null;
   projects: ProjectData[];
   isLoading: boolean;
+  /** True while a project switch is re-running server components. */
+  isSwitching: boolean;
   error: string | null;
   switchProject: (projectId: number) => void;
   refetch: () => Promise<void>;
@@ -31,19 +41,21 @@ interface ProjectContextType {
 
 const ProjectContext = createContext<ProjectContextType | undefined>(undefined);
 
-const ACTIVE_PROJECT_COOKIE = 'active_project_id';
+const ACTIVE_PROJECT_COOKIE = "active_project_id";
 
 function getInitials(name: string): string {
   const parts = name.trim().split(/\s+/);
   if (parts.length >= 2) {
     return `${parts[0][0]}${parts[parts.length - 1][0]}`.toUpperCase();
   }
-  return parts[0]?.substring(0, 2).toUpperCase() || '??';
+  return parts[0]?.substring(0, 2).toUpperCase() || "??";
 }
 
 function getActiveProjectId(): number | null {
-  if (typeof document === 'undefined') return null;
-  const match = document.cookie.match(new RegExp(`${ACTIVE_PROJECT_COOKIE}=(\\d+)`));
+  if (typeof document === "undefined") return null;
+  const match = document.cookie.match(
+    new RegExp(`${ACTIVE_PROJECT_COOKIE}=(\\d+)`),
+  );
   return match ? parseInt(match[1], 10) : null;
 }
 
@@ -65,18 +77,31 @@ export function ProjectProvider({
   initialActiveProjectId,
 }: ProjectProviderProps) {
   const [user, setUser] = useState<UserProfile | null>(initialUser || null);
-  const [projects, setProjects] = useState<ProjectData[]>(initialProjects || []);
+  const [projects, setProjects] = useState<ProjectData[]>(
+    initialProjects || [],
+  );
   const [activeProjectId, setActiveProjectIdState] = useState<number | null>(
-    initialActiveProjectId || getActiveProjectId()
+    initialActiveProjectId || getActiveProjectId(),
   );
   const [isLoading, setIsLoading] = useState(!initialUser);
   const [error, setError] = useState<string | null>(null);
+  const router = useRouter();
+  const [isSwitching, startSwitching] = useTransition();
 
-  const activeProject = projects.find(p => p.projectId === activeProjectId) || projects[0] || null;
+  const activeProject =
+    projects.find((p) => p.projectId === activeProjectId) ||
+    projects[0] ||
+    null;
 
   const switchProject = (projectId: number) => {
+    if (projectId === activeProjectId) return;
     setActiveProjectIdState(projectId);
     setActiveProjectId(projectId);
+    // Re-run server components so every dashboard page re-fetches against the
+    // new project. isSwitching stays true until the new render resolves.
+    startSwitching(() => {
+      router.refresh();
+    });
   };
 
   const fetchData = async () => {
@@ -85,23 +110,26 @@ export function ProjectProvider({
 
     try {
       const supabase = createClient();
-      const { data: { user: authUser }, error: authError } = await supabase.auth.getUser();
+      const {
+        data: { user: authUser },
+        error: authError,
+      } = await supabase.auth.getUser();
 
       if (authError || !authUser) {
-        setError('Not authenticated');
+        setError("Not authenticated");
         setIsLoading(false);
         return;
       }
 
       // Fetch profile
       const { data: profile } = await supabase
-        .from('profiles')
-        .select('id, name, email, role, department')
-        .eq('uid', authUser.id)
+        .from("profiles")
+        .select("id, name, email, role, department")
+        .eq("uid", authUser.id)
         .single();
 
       if (!profile) {
-        setError('Profile not found');
+        setError("Profile not found");
         setIsLoading(false);
         return;
       }
@@ -109,17 +137,17 @@ export function ProjectProvider({
       setUser({
         id: profile.id,
         name: profile.name,
-        email: profile.email || authUser.email || '',
-        role: profile.role as UserProfile['role'],
+        email: profile.email || authUser.email || "",
+        role: profile.role as UserProfile["role"],
         initials: getInitials(profile.name),
         department: profile.department ?? null,
       });
 
       // Fetch projects via project_members
       const { data: memberships } = await supabase
-        .from('project_members')
-        .select('role, project_id, projects(id, url_slug, company_name)')
-        .eq('profile_id', profile.id);
+        .from("project_members")
+        .select("role, project_id, projects(id, url_slug, company_name)")
+        .eq("profile_id", profile.id);
 
       if (memberships && memberships.length > 0) {
         const projectList: ProjectData[] = memberships
@@ -128,14 +156,14 @@ export function ProjectProvider({
             projectId: m.projects.id,
             projectSlug: m.projects.url_slug,
             companyName: m.projects.company_name,
-            role: m.role as ProjectData['role'],
+            role: m.role as ProjectData["role"],
           }));
 
         setProjects(projectList);
 
         // Set active project from cookie or default to first
         const savedId = getActiveProjectId();
-        const validSaved = projectList.find(p => p.projectId === savedId);
+        const validSaved = projectList.find((p) => p.projectId === savedId);
         if (validSaved) {
           setActiveProjectIdState(savedId);
         } else if (projectList.length > 0) {
@@ -144,8 +172,8 @@ export function ProjectProvider({
         }
       }
     } catch (err) {
-      setError('Failed to fetch project data');
-      console.error('Project data fetch error:', err);
+      setError("Failed to fetch project data");
+      console.error("Project data fetch error:", err);
     } finally {
       setIsLoading(false);
     }
@@ -164,6 +192,7 @@ export function ProjectProvider({
         activeProject,
         projects,
         isLoading,
+        isSwitching,
         error,
         switchProject,
         refetch: fetchData,
@@ -177,7 +206,7 @@ export function ProjectProvider({
 export function useProject() {
   const context = useContext(ProjectContext);
   if (context === undefined) {
-    throw new Error('useProject must be used within a ProjectProvider');
+    throw new Error("useProject must be used within a ProjectProvider");
   }
   return context;
 }
@@ -189,7 +218,7 @@ export function useProject() {
 export function useRequiredProject() {
   const { activeProject, isLoading } = useProject();
   if (!isLoading && !activeProject) {
-    throw new Error('No active project selected');
+    throw new Error("No active project selected");
   }
   return activeProject;
 }

--- a/frontend/lib/supabase/database.types.ts
+++ b/frontend/lib/supabase/database.types.ts
@@ -59,9 +59,10 @@ export type Database = {
           category_id: number;
           created_at: string;
           created_by: number | null;
-          description: string;
+          description: string | null;
           id: number;
           occurred_on: string;
+          title: string;
           updated_at: string;
         };
         Insert: {
@@ -70,9 +71,10 @@ export type Database = {
           category_id: number;
           created_at?: string;
           created_by?: number | null;
-          description: string;
+          description?: string | null;
           id?: number;
           occurred_on: string;
+          title: string;
           updated_at?: string;
         };
         Update: {
@@ -81,9 +83,10 @@ export type Database = {
           category_id?: number;
           created_at?: string;
           created_by?: number | null;
-          description?: string;
+          description?: string | null;
           id?: number;
           occurred_on?: string;
+          title?: string;
           updated_at?: string;
         };
         Relationships: [

--- a/frontend/lib/supabase/database.types.ts
+++ b/frontend/lib/supabase/database.types.ts
@@ -4,442 +4,538 @@ export type Json =
   | boolean
   | null
   | { [key: string]: Json | undefined }
-  | Json[]
+  | Json[];
 
 export type Database = {
   // Allows to automatically instantiate createClient with right options
   // instead of createClient<Database, { PostgrestVersion: 'XX' }>(URL, KEY)
   __InternalSupabase: {
-    PostgrestVersion: "13.0.5"
-  }
+    PostgrestVersion: "13.0.5";
+  };
   public: {
     Tables: {
+      budget_categories: {
+        Row: {
+          budget_id: number;
+          created_at: string;
+          expected_amount: number;
+          id: number;
+          name: string;
+          sort_order: number;
+          updated_at: string;
+        };
+        Insert: {
+          budget_id: number;
+          created_at?: string;
+          expected_amount?: number;
+          id?: number;
+          name: string;
+          sort_order?: number;
+          updated_at?: string;
+        };
+        Update: {
+          budget_id?: number;
+          created_at?: string;
+          expected_amount?: number;
+          id?: number;
+          name?: string;
+          sort_order?: number;
+          updated_at?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "budget_categories_budget_id_fkey";
+            columns: ["budget_id"];
+            isOneToOne: false;
+            referencedRelation: "project_budgets";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
+      budget_transactions: {
+        Row: {
+          amount: number;
+          budget_id: number;
+          category_id: number;
+          created_at: string;
+          created_by: number | null;
+          description: string;
+          id: number;
+          occurred_on: string;
+          updated_at: string;
+        };
+        Insert: {
+          amount: number;
+          budget_id: number;
+          category_id: number;
+          created_at?: string;
+          created_by?: number | null;
+          description: string;
+          id?: number;
+          occurred_on: string;
+          updated_at?: string;
+        };
+        Update: {
+          amount?: number;
+          budget_id?: number;
+          category_id?: number;
+          created_at?: string;
+          created_by?: number | null;
+          description?: string;
+          id?: number;
+          occurred_on?: string;
+          updated_at?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "budget_transactions_budget_id_fkey";
+            columns: ["budget_id"];
+            isOneToOne: false;
+            referencedRelation: "project_budgets";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "budget_transactions_category_id_fkey";
+            columns: ["category_id"];
+            isOneToOne: false;
+            referencedRelation: "budget_categories";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "budget_transactions_created_by_fkey";
+            columns: ["created_by"];
+            isOneToOne: false;
+            referencedRelation: "profiles";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
       client_chat_messages: {
         Row: {
-          attachments: Json | null
-          content: string
-          created_at: string
-          id: number
-          is_cancelled: boolean
-          model_preference: string | null
-          role: string
-          session_id: number
-          sources: Json | null
-        }
+          attachments: Json | null;
+          content: string;
+          created_at: string;
+          id: number;
+          is_cancelled: boolean;
+          model_preference: string | null;
+          role: string;
+          session_id: number;
+          sources: Json | null;
+        };
         Insert: {
-          attachments?: Json | null
-          content: string
-          created_at?: string
-          id?: number
-          is_cancelled?: boolean
-          model_preference?: string | null
-          role: string
-          session_id: number
-          sources?: Json | null
-        }
+          attachments?: Json | null;
+          content: string;
+          created_at?: string;
+          id?: number;
+          is_cancelled?: boolean;
+          model_preference?: string | null;
+          role: string;
+          session_id: number;
+          sources?: Json | null;
+        };
         Update: {
-          attachments?: Json | null
-          content?: string
-          created_at?: string
-          id?: number
-          is_cancelled?: boolean
-          model_preference?: string | null
-          role?: string
-          session_id?: number
-          sources?: Json | null
-        }
+          attachments?: Json | null;
+          content?: string;
+          created_at?: string;
+          id?: number;
+          is_cancelled?: boolean;
+          model_preference?: string | null;
+          role?: string;
+          session_id?: number;
+          sources?: Json | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "client_chat_messages_session_id_fkey"
-            columns: ["session_id"]
-            isOneToOne: false
-            referencedRelation: "client_chat_sessions"
-            referencedColumns: ["id"]
+            foreignKeyName: "client_chat_messages_session_id_fkey";
+            columns: ["session_id"];
+            isOneToOne: false;
+            referencedRelation: "client_chat_sessions";
+            referencedColumns: ["id"];
           },
-        ]
-      }
+        ];
+      };
       client_chat_sessions: {
         Row: {
-          created_at: string
-          id: number
-          metadata: Json | null
-          project_id: number | null
-          title: string | null
-          uid: string | null
-          updated_at: string | null
-        }
+          created_at: string;
+          id: number;
+          metadata: Json | null;
+          project_id: number | null;
+          title: string | null;
+          uid: string | null;
+          updated_at: string | null;
+        };
         Insert: {
-          created_at?: string
-          id?: number
-          metadata?: Json | null
-          project_id?: number | null
-          title?: string | null
-          uid?: string | null
-          updated_at?: string | null
-        }
+          created_at?: string;
+          id?: number;
+          metadata?: Json | null;
+          project_id?: number | null;
+          title?: string | null;
+          uid?: string | null;
+          updated_at?: string | null;
+        };
         Update: {
-          created_at?: string
-          id?: number
-          metadata?: Json | null
-          project_id?: number | null
-          title?: string | null
-          uid?: string | null
-          updated_at?: string | null
-        }
+          created_at?: string;
+          id?: number;
+          metadata?: Json | null;
+          project_id?: number | null;
+          title?: string | null;
+          uid?: string | null;
+          updated_at?: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "client_chat_sessions_project_id_fkey"
-            columns: ["project_id"]
-            isOneToOne: false
-            referencedRelation: "projects"
-            referencedColumns: ["id"]
+            foreignKeyName: "client_chat_sessions_project_id_fkey";
+            columns: ["project_id"];
+            isOneToOne: false;
+            referencedRelation: "projects";
+            referencedColumns: ["id"];
           },
-        ]
-      }
+        ];
+      };
       client_files: {
         Row: {
-          created_at: string
-          file_name: string
-          file_size: number | null
-          file_type: string | null
-          id: number
-          metadata: Json | null
-          storage_path: string
-          uid: string | null
-        }
+          created_at: string;
+          file_name: string;
+          file_size: number | null;
+          file_type: string | null;
+          id: number;
+          metadata: Json | null;
+          storage_path: string;
+          uid: string | null;
+        };
         Insert: {
-          created_at?: string
-          file_name: string
-          file_size?: number | null
-          file_type?: string | null
-          id?: number
-          metadata?: Json | null
-          storage_path: string
-          uid?: string | null
-        }
+          created_at?: string;
+          file_name: string;
+          file_size?: number | null;
+          file_type?: string | null;
+          id?: number;
+          metadata?: Json | null;
+          storage_path: string;
+          uid?: string | null;
+        };
         Update: {
-          created_at?: string
-          file_name?: string
-          file_size?: number | null
-          file_type?: string | null
-          id?: number
-          metadata?: Json | null
-          storage_path?: string
-          uid?: string | null
-        }
-        Relationships: []
-      }
+          created_at?: string;
+          file_name?: string;
+          file_size?: number | null;
+          file_type?: string | null;
+          id?: number;
+          metadata?: Json | null;
+          storage_path?: string;
+          uid?: string | null;
+        };
+        Relationships: [];
+      };
       client_knowledge: {
         Row: {
-          content: string
-          created_at: string
-          embedding: string | null
-          id: number
-          metadata: Json | null
-          uid: string
-        }
+          content: string;
+          created_at: string;
+          embedding: string | null;
+          id: number;
+          metadata: Json | null;
+          uid: string;
+        };
         Insert: {
-          content: string
-          created_at?: string
-          embedding?: string | null
-          id?: number
-          metadata?: Json | null
-          uid?: string
-        }
+          content: string;
+          created_at?: string;
+          embedding?: string | null;
+          id?: number;
+          metadata?: Json | null;
+          uid?: string;
+        };
         Update: {
-          content?: string
-          created_at?: string
-          embedding?: string | null
-          id?: number
-          metadata?: Json | null
-          uid?: string
-        }
-        Relationships: []
-      }
+          content?: string;
+          created_at?: string;
+          embedding?: string | null;
+          id?: number;
+          metadata?: Json | null;
+          uid?: string;
+        };
+        Relationships: [];
+      };
       conversation_reads: {
         Row: {
-          conversation_id: number
-          last_read_at: string
-          profile_id: number
-        }
+          conversation_id: number;
+          last_read_at: string;
+          profile_id: number;
+        };
         Insert: {
-          conversation_id: number
-          last_read_at?: string
-          profile_id: number
-        }
+          conversation_id: number;
+          last_read_at?: string;
+          profile_id: number;
+        };
         Update: {
-          conversation_id?: number
-          last_read_at?: string
-          profile_id?: number
-        }
+          conversation_id?: number;
+          last_read_at?: string;
+          profile_id?: number;
+        };
         Relationships: [
           {
-            foreignKeyName: "conversation_reads_conversation_id_fkey"
-            columns: ["conversation_id"]
-            isOneToOne: false
-            referencedRelation: "conversations"
-            referencedColumns: ["id"]
+            foreignKeyName: "conversation_reads_conversation_id_fkey";
+            columns: ["conversation_id"];
+            isOneToOne: false;
+            referencedRelation: "conversations";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "conversation_reads_profile_id_fkey"
-            columns: ["profile_id"]
-            isOneToOne: false
-            referencedRelation: "profiles"
-            referencedColumns: ["id"]
+            foreignKeyName: "conversation_reads_profile_id_fkey";
+            columns: ["profile_id"];
+            isOneToOne: false;
+            referencedRelation: "profiles";
+            referencedColumns: ["id"];
           },
-        ]
-      }
+        ];
+      };
       conversations: {
         Row: {
-          client_profile_id: number | null
-          created_at: string
-          director_profile_id: number | null
-          id: number
-          project_id: number | null
-        }
+          client_profile_id: number | null;
+          created_at: string;
+          director_profile_id: number | null;
+          id: number;
+          project_id: number | null;
+        };
         Insert: {
-          client_profile_id?: number | null
-          created_at?: string
-          director_profile_id?: number | null
-          id?: number
-          project_id?: number | null
-        }
+          client_profile_id?: number | null;
+          created_at?: string;
+          director_profile_id?: number | null;
+          id?: number;
+          project_id?: number | null;
+        };
         Update: {
-          client_profile_id?: number | null
-          created_at?: string
-          director_profile_id?: number | null
-          id?: number
-          project_id?: number | null
-        }
+          client_profile_id?: number | null;
+          created_at?: string;
+          director_profile_id?: number | null;
+          id?: number;
+          project_id?: number | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "conversations_client_profile_id_fkey"
-            columns: ["client_profile_id"]
-            isOneToOne: false
-            referencedRelation: "profiles"
-            referencedColumns: ["id"]
+            foreignKeyName: "conversations_client_profile_id_fkey";
+            columns: ["client_profile_id"];
+            isOneToOne: false;
+            referencedRelation: "profiles";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "conversations_director_profile_id_fkey"
-            columns: ["director_profile_id"]
-            isOneToOne: false
-            referencedRelation: "profiles"
-            referencedColumns: ["id"]
+            foreignKeyName: "conversations_director_profile_id_fkey";
+            columns: ["director_profile_id"];
+            isOneToOne: false;
+            referencedRelation: "profiles";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "conversations_project_id_fkey"
-            columns: ["project_id"]
-            isOneToOne: false
-            referencedRelation: "projects"
-            referencedColumns: ["id"]
+            foreignKeyName: "conversations_project_id_fkey";
+            columns: ["project_id"];
+            isOneToOne: false;
+            referencedRelation: "projects";
+            referencedColumns: ["id"];
           },
-        ]
-      }
+        ];
+      };
       custom_form_schemas: {
         Row: {
-          assigned_to: string[] | null
-          created_at: string
-          created_by: string | null
-          description: string | null
-          fields: Json
-          id: number
-          is_active: boolean | null
-          title: string
-          updated_at: string | null
-        }
+          assigned_to: string[] | null;
+          created_at: string;
+          created_by: string | null;
+          description: string | null;
+          fields: Json;
+          id: number;
+          is_active: boolean | null;
+          title: string;
+          updated_at: string | null;
+        };
         Insert: {
-          assigned_to?: string[] | null
-          created_at?: string
-          created_by?: string | null
-          description?: string | null
-          fields?: Json
-          id?: number
-          is_active?: boolean | null
-          title: string
-          updated_at?: string | null
-        }
+          assigned_to?: string[] | null;
+          created_at?: string;
+          created_by?: string | null;
+          description?: string | null;
+          fields?: Json;
+          id?: number;
+          is_active?: boolean | null;
+          title: string;
+          updated_at?: string | null;
+        };
         Update: {
-          assigned_to?: string[] | null
-          created_at?: string
-          created_by?: string | null
-          description?: string | null
-          fields?: Json
-          id?: number
-          is_active?: boolean | null
-          title?: string
-          updated_at?: string | null
-        }
-        Relationships: []
-      }
+          assigned_to?: string[] | null;
+          created_at?: string;
+          created_by?: string | null;
+          description?: string | null;
+          fields?: Json;
+          id?: number;
+          is_active?: boolean | null;
+          title?: string;
+          updated_at?: string | null;
+        };
+        Relationships: [];
+      };
       custom_form_submissions: {
         Row: {
-          created_at: string | null
-          data: Json
-          form_id: number
-          id: number
-          project_id: number | null
-          updated_at: string | null
-          user_id: string
-        }
+          created_at: string | null;
+          data: Json;
+          form_id: number;
+          id: number;
+          project_id: number | null;
+          updated_at: string | null;
+          user_id: string;
+        };
         Insert: {
-          created_at?: string | null
-          data?: Json
-          form_id: number
-          id?: number
-          project_id?: number | null
-          updated_at?: string | null
-          user_id?: string
-        }
+          created_at?: string | null;
+          data?: Json;
+          form_id: number;
+          id?: number;
+          project_id?: number | null;
+          updated_at?: string | null;
+          user_id?: string;
+        };
         Update: {
-          created_at?: string | null
-          data?: Json
-          form_id?: number
-          id?: number
-          project_id?: number | null
-          updated_at?: string | null
-          user_id?: string
-        }
+          created_at?: string | null;
+          data?: Json;
+          form_id?: number;
+          id?: number;
+          project_id?: number | null;
+          updated_at?: string | null;
+          user_id?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "custom_form_submissions_form_id_fkey"
-            columns: ["form_id"]
-            isOneToOne: false
-            referencedRelation: "custom_form_schemas"
-            referencedColumns: ["id"]
+            foreignKeyName: "custom_form_submissions_form_id_fkey";
+            columns: ["form_id"];
+            isOneToOne: false;
+            referencedRelation: "custom_form_schemas";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "custom_form_submissions_project_id_fkey"
-            columns: ["project_id"]
-            isOneToOne: false
-            referencedRelation: "projects"
-            referencedColumns: ["id"]
+            foreignKeyName: "custom_form_submissions_project_id_fkey";
+            columns: ["project_id"];
+            isOneToOne: false;
+            referencedRelation: "projects";
+            referencedColumns: ["id"];
           },
-        ]
-      }
+        ];
+      };
       finances: {
         Row: {
-          created_at: string
-          id: number
-        }
+          created_at: string;
+          id: number;
+        };
         Insert: {
-          created_at?: string
-          id?: number
-        }
+          created_at?: string;
+          id?: number;
+        };
         Update: {
-          created_at?: string
-          id?: number
-        }
-        Relationships: []
-      }
+          created_at?: string;
+          id?: number;
+        };
+        Relationships: [];
+      };
       legal_documents: {
         Row: {
-          content: string | null
-          embedding: string | null
-          id: number
-          metadata: Json | null
-        }
+          content: string | null;
+          embedding: string | null;
+          id: number;
+          metadata: Json | null;
+        };
         Insert: {
-          content?: string | null
-          embedding?: string | null
-          id?: number
-          metadata?: Json | null
-        }
+          content?: string | null;
+          embedding?: string | null;
+          id?: number;
+          metadata?: Json | null;
+        };
         Update: {
-          content?: string | null
-          embedding?: string | null
-          id?: number
-          metadata?: Json | null
-        }
-        Relationships: []
-      }
+          content?: string | null;
+          embedding?: string | null;
+          id?: number;
+          metadata?: Json | null;
+        };
+        Relationships: [];
+      };
       lifecycle_projects: {
         Row: {
-          completed: boolean
-          created_at: string
-          id: number
-          image: string | null
-          project_id: number
-          title: string
-          updated_at: string
-        }
+          completed: boolean;
+          created_at: string;
+          id: number;
+          image: string | null;
+          project_id: number;
+          title: string;
+          updated_at: string;
+        };
         Insert: {
-          completed?: boolean
-          created_at?: string
-          id?: number
-          image?: string | null
-          project_id: number
-          title: string
-          updated_at?: string
-        }
+          completed?: boolean;
+          created_at?: string;
+          id?: number;
+          image?: string | null;
+          project_id: number;
+          title: string;
+          updated_at?: string;
+        };
         Update: {
-          completed?: boolean
-          created_at?: string
-          id?: number
-          image?: string | null
-          project_id?: number
-          title?: string
-          updated_at?: string
-        }
+          completed?: boolean;
+          created_at?: string;
+          id?: number;
+          image?: string | null;
+          project_id?: number;
+          title?: string;
+          updated_at?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "lifecycle_projects_project_id_fkey"
-            columns: ["project_id"]
-            isOneToOne: false
-            referencedRelation: "projects"
-            referencedColumns: ["id"]
+            foreignKeyName: "lifecycle_projects_project_id_fkey";
+            columns: ["project_id"];
+            isOneToOne: false;
+            referencedRelation: "projects";
+            referencedColumns: ["id"];
           },
-        ]
-      }
+        ];
+      };
       lifecycle_task_assignees: {
         Row: {
-          created_at: string
-          id: number
-          profile_id: number
-          task_id: number
-        }
+          created_at: string;
+          id: number;
+          profile_id: number;
+          task_id: number;
+        };
         Insert: {
-          created_at?: string
-          id?: number
-          profile_id: number
-          task_id: number
-        }
+          created_at?: string;
+          id?: number;
+          profile_id: number;
+          task_id: number;
+        };
         Update: {
-          created_at?: string
-          id?: number
-          profile_id?: number
-          task_id?: number
-        }
+          created_at?: string;
+          id?: number;
+          profile_id?: number;
+          task_id?: number;
+        };
         Relationships: [
           {
-            foreignKeyName: "lifecycle_task_assignees_profile_id_fkey"
-            columns: ["profile_id"]
-            isOneToOne: false
-            referencedRelation: "profiles"
-            referencedColumns: ["id"]
+            foreignKeyName: "lifecycle_task_assignees_profile_id_fkey";
+            columns: ["profile_id"];
+            isOneToOne: false;
+            referencedRelation: "profiles";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "lifecycle_task_assignees_task_id_fkey"
-            columns: ["task_id"]
-            isOneToOne: false
-            referencedRelation: "lifecycle_tasks"
-            referencedColumns: ["id"]
+            foreignKeyName: "lifecycle_task_assignees_task_id_fkey";
+            columns: ["task_id"];
+            isOneToOne: false;
+            referencedRelation: "lifecycle_tasks";
+            referencedColumns: ["id"];
           },
-        ]
-      }
+        ];
+      };
       lifecycle_tasks: {
         Row: {
-          assigned_by: number | null
-          created_at: string
-          description: string | null
-          due_date: string
-          id: number
-          lifecycle_project_id: number
-          priority: "extreme" | "high" | "medium" | "low" | "stretch"
+          assigned_by: number | null;
+          created_at: string;
+          description: string | null;
+          due_date: string;
+          id: number;
+          lifecycle_project_id: number;
+          priority: "extreme" | "high" | "medium" | "low" | "stretch";
           status:
             | "not_started"
             | "in_progress"
             | "pending_approval"
-            | "completed"
+            | "completed";
           team:
             | "technology"
             | "architecture"
@@ -448,24 +544,24 @@ export type Database = {
             | "finance"
             | "research"
             | "legal"
-            | "executive"
-          tentative: boolean
-          title: string
-          updated_at: string
-        }
+            | "executive";
+          tentative: boolean;
+          title: string;
+          updated_at: string;
+        };
         Insert: {
-          assigned_by?: number | null
-          created_at?: string
-          description?: string | null
-          due_date: string
-          id?: number
-          lifecycle_project_id: number
-          priority?: "extreme" | "high" | "medium" | "low" | "stretch"
+          assigned_by?: number | null;
+          created_at?: string;
+          description?: string | null;
+          due_date: string;
+          id?: number;
+          lifecycle_project_id: number;
+          priority?: "extreme" | "high" | "medium" | "low" | "stretch";
           status?:
             | "not_started"
             | "in_progress"
             | "pending_approval"
-            | "completed"
+            | "completed";
           team:
             | "technology"
             | "architecture"
@@ -474,24 +570,24 @@ export type Database = {
             | "finance"
             | "research"
             | "legal"
-            | "executive"
-          tentative?: boolean
-          title: string
-          updated_at?: string
-        }
+            | "executive";
+          tentative?: boolean;
+          title: string;
+          updated_at?: string;
+        };
         Update: {
-          assigned_by?: number | null
-          created_at?: string
-          description?: string | null
-          due_date?: string
-          id?: number
-          lifecycle_project_id?: number
-          priority?: "extreme" | "high" | "medium" | "low" | "stretch"
+          assigned_by?: number | null;
+          created_at?: string;
+          description?: string | null;
+          due_date?: string;
+          id?: number;
+          lifecycle_project_id?: number;
+          priority?: "extreme" | "high" | "medium" | "low" | "stretch";
           status?:
             | "not_started"
             | "in_progress"
             | "pending_approval"
-            | "completed"
+            | "completed";
           team?:
             | "technology"
             | "architecture"
@@ -500,505 +596,559 @@ export type Database = {
             | "finance"
             | "research"
             | "legal"
-            | "executive"
-          tentative?: boolean
-          title?: string
-          updated_at?: string
-        }
+            | "executive";
+          tentative?: boolean;
+          title?: string;
+          updated_at?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "lifecycle_tasks_assigned_by_fkey"
-            columns: ["assigned_by"]
-            isOneToOne: false
-            referencedRelation: "profiles"
-            referencedColumns: ["id"]
+            foreignKeyName: "lifecycle_tasks_assigned_by_fkey";
+            columns: ["assigned_by"];
+            isOneToOne: false;
+            referencedRelation: "profiles";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "lifecycle_tasks_lifecycle_project_id_fkey"
-            columns: ["lifecycle_project_id"]
-            isOneToOne: false
-            referencedRelation: "lifecycle_projects"
-            referencedColumns: ["id"]
+            foreignKeyName: "lifecycle_tasks_lifecycle_project_id_fkey";
+            columns: ["lifecycle_project_id"];
+            isOneToOne: false;
+            referencedRelation: "lifecycle_projects";
+            referencedColumns: ["id"];
           },
-        ]
-      }
+        ];
+      };
       message_attachments: {
         Row: {
-          created_at: string
-          id: number
-          message_id: number
-          meta: Json | null
-          mime_type: string | null
-          name: string
-          path: string
-          sort_index: number
-        }
+          created_at: string;
+          id: number;
+          message_id: number;
+          meta: Json | null;
+          mime_type: string | null;
+          name: string;
+          path: string;
+          sort_index: number;
+        };
         Insert: {
-          created_at?: string
-          id?: number
-          message_id: number
-          meta?: Json | null
-          mime_type?: string | null
-          name: string
-          path: string
-          sort_index?: number
-        }
+          created_at?: string;
+          id?: number;
+          message_id: number;
+          meta?: Json | null;
+          mime_type?: string | null;
+          name: string;
+          path: string;
+          sort_index?: number;
+        };
         Update: {
-          created_at?: string
-          id?: number
-          message_id?: number
-          meta?: Json | null
-          mime_type?: string | null
-          name?: string
-          path?: string
-          sort_index?: number
-        }
+          created_at?: string;
+          id?: number;
+          message_id?: number;
+          meta?: Json | null;
+          mime_type?: string | null;
+          name?: string;
+          path?: string;
+          sort_index?: number;
+        };
         Relationships: [
           {
-            foreignKeyName: "message_attachments_message_id_fkey"
-            columns: ["message_id"]
-            isOneToOne: false
-            referencedRelation: "messages"
-            referencedColumns: ["id"]
+            foreignKeyName: "message_attachments_message_id_fkey";
+            columns: ["message_id"];
+            isOneToOne: false;
+            referencedRelation: "messages";
+            referencedColumns: ["id"];
           },
-        ]
-      }
+        ];
+      };
       message_unfurls: {
         Row: {
-          description: string | null
-          fetched_at: string
-          image_url: string | null
-          message_id: number
-          site_name: string | null
-          title: string | null
-          url: string
-        }
+          description: string | null;
+          fetched_at: string;
+          image_url: string | null;
+          message_id: number;
+          site_name: string | null;
+          title: string | null;
+          url: string;
+        };
         Insert: {
-          description?: string | null
-          fetched_at?: string
-          image_url?: string | null
-          message_id: number
-          site_name?: string | null
-          title?: string | null
-          url: string
-        }
+          description?: string | null;
+          fetched_at?: string;
+          image_url?: string | null;
+          message_id: number;
+          site_name?: string | null;
+          title?: string | null;
+          url: string;
+        };
         Update: {
-          description?: string | null
-          fetched_at?: string
-          image_url?: string | null
-          message_id?: number
-          site_name?: string | null
-          title?: string | null
-          url?: string
-        }
+          description?: string | null;
+          fetched_at?: string;
+          image_url?: string | null;
+          message_id?: number;
+          site_name?: string | null;
+          title?: string | null;
+          url?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "message_unfurls_message_id_fkey"
-            columns: ["message_id"]
-            isOneToOne: true
-            referencedRelation: "messages"
-            referencedColumns: ["id"]
+            foreignKeyName: "message_unfurls_message_id_fkey";
+            columns: ["message_id"];
+            isOneToOne: true;
+            referencedRelation: "messages";
+            referencedColumns: ["id"];
           },
-        ]
-      }
+        ];
+      };
       messages: {
         Row: {
-          content: string | null
-          conversation_id: number | null
-          created_at: string
-          edited_at: string | null
-          id: number
-          is_pinned: boolean
-          pinned_at: string | null
-          reply_to_id: number | null
-          sender_profile_id: number | null
-          sender_role: string
-          sender_uid: string | null
-        }
+          content: string | null;
+          conversation_id: number | null;
+          created_at: string;
+          edited_at: string | null;
+          id: number;
+          is_pinned: boolean;
+          pinned_at: string | null;
+          reply_to_id: number | null;
+          sender_profile_id: number | null;
+          sender_role: string;
+          sender_uid: string | null;
+        };
         Insert: {
-          content?: string | null
-          conversation_id?: number | null
-          created_at?: string
-          edited_at?: string | null
-          id?: number
-          is_pinned?: boolean
-          pinned_at?: string | null
-          reply_to_id?: number | null
-          sender_profile_id?: number | null
-          sender_role: string
-          sender_uid?: string | null
-        }
+          content?: string | null;
+          conversation_id?: number | null;
+          created_at?: string;
+          edited_at?: string | null;
+          id?: number;
+          is_pinned?: boolean;
+          pinned_at?: string | null;
+          reply_to_id?: number | null;
+          sender_profile_id?: number | null;
+          sender_role: string;
+          sender_uid?: string | null;
+        };
         Update: {
-          content?: string | null
-          conversation_id?: number | null
-          created_at?: string
-          edited_at?: string | null
-          id?: number
-          is_pinned?: boolean
-          pinned_at?: string | null
-          reply_to_id?: number | null
-          sender_profile_id?: number | null
-          sender_role?: string
-          sender_uid?: string | null
-        }
+          content?: string | null;
+          conversation_id?: number | null;
+          created_at?: string;
+          edited_at?: string | null;
+          id?: number;
+          is_pinned?: boolean;
+          pinned_at?: string | null;
+          reply_to_id?: number | null;
+          sender_profile_id?: number | null;
+          sender_role?: string;
+          sender_uid?: string | null;
+        };
         Relationships: [
           {
-            foreignKeyName: "messages_conversation_id_fkey"
-            columns: ["conversation_id"]
-            isOneToOne: false
-            referencedRelation: "conversations"
-            referencedColumns: ["id"]
+            foreignKeyName: "messages_conversation_id_fkey";
+            columns: ["conversation_id"];
+            isOneToOne: false;
+            referencedRelation: "conversations";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "messages_reply_to_id_fkey"
-            columns: ["reply_to_id"]
-            isOneToOne: false
-            referencedRelation: "messages"
-            referencedColumns: ["id"]
+            foreignKeyName: "messages_reply_to_id_fkey";
+            columns: ["reply_to_id"];
+            isOneToOne: false;
+            referencedRelation: "messages";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "messages_sender_profile_id_fkey"
-            columns: ["sender_profile_id"]
-            isOneToOne: false
-            referencedRelation: "profiles"
-            referencedColumns: ["id"]
+            foreignKeyName: "messages_sender_profile_id_fkey";
+            columns: ["sender_profile_id"];
+            isOneToOne: false;
+            referencedRelation: "profiles";
+            referencedColumns: ["id"];
           },
-        ]
-      }
+        ];
+      };
       profiles: {
         Row: {
-          config: Json | null
-          created_at: string
-          department: string | null
-          discord_id: number | null
-          eid: string | null
-          email: string | null
-          graduation: number | null
-          id: number
-          name: string
-          role: "client" | "director" | "member"
-          uid: string
-          updated_at: string
-        }
+          config: Json | null;
+          created_at: string;
+          department: string | null;
+          discord_id: number | null;
+          eid: string | null;
+          email: string | null;
+          graduation: number | null;
+          id: number;
+          name: string;
+          role: "client" | "director" | "member";
+          uid: string;
+          updated_at: string;
+        };
         Insert: {
-          config?: Json | null
-          created_at?: string
-          department?: string | null
-          discord_id?: number | null
-          eid?: string | null
-          email?: string | null
-          graduation?: number | null
-          id?: number
-          name: string
-          role: "client" | "director" | "member"
-          uid: string
-          updated_at?: string
-        }
+          config?: Json | null;
+          created_at?: string;
+          department?: string | null;
+          discord_id?: number | null;
+          eid?: string | null;
+          email?: string | null;
+          graduation?: number | null;
+          id?: number;
+          name: string;
+          role: "client" | "director" | "member";
+          uid: string;
+          updated_at?: string;
+        };
         Update: {
-          config?: Json | null
-          created_at?: string
-          department?: string | null
-          discord_id?: number | null
-          eid?: string | null
-          email?: string | null
-          graduation?: number | null
-          id?: number
-          name?: string
-          role?: "client" | "director" | "member"
-          uid?: string
-          updated_at?: string
-        }
-        Relationships: []
-      }
+          config?: Json | null;
+          created_at?: string;
+          department?: string | null;
+          discord_id?: number | null;
+          eid?: string | null;
+          email?: string | null;
+          graduation?: number | null;
+          id?: number;
+          name?: string;
+          role?: "client" | "director" | "member";
+          uid?: string;
+          updated_at?: string;
+        };
+        Relationships: [];
+      };
+      project_budgets: {
+        Row: {
+          created_at: string;
+          created_by: number | null;
+          currency: string;
+          id: number;
+          period_end: string;
+          period_start: string;
+          project_id: number;
+          updated_at: string;
+        };
+        Insert: {
+          created_at?: string;
+          created_by?: number | null;
+          currency?: string;
+          id?: number;
+          period_end: string;
+          period_start: string;
+          project_id: number;
+          updated_at?: string;
+        };
+        Update: {
+          created_at?: string;
+          created_by?: number | null;
+          currency?: string;
+          id?: number;
+          period_end?: string;
+          period_start?: string;
+          project_id?: number;
+          updated_at?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "project_budgets_created_by_fkey";
+            columns: ["created_by"];
+            isOneToOne: false;
+            referencedRelation: "profiles";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "project_budgets_project_id_fkey";
+            columns: ["project_id"];
+            isOneToOne: true;
+            referencedRelation: "projects";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
       project_members: {
         Row: {
-          assigned_by: number | null
-          created_at: string
-          id: number
-          profile_id: number
-          project_id: number
-          role: "owner" | "director" | "member"
-        }
+          assigned_by: number | null;
+          created_at: string;
+          id: number;
+          profile_id: number;
+          project_id: number;
+          role: "owner" | "director" | "member";
+        };
         Insert: {
-          assigned_by?: number | null
-          created_at?: string
-          id?: number
-          profile_id: number
-          project_id: number
-          role: "owner" | "director" | "member"
-        }
+          assigned_by?: number | null;
+          created_at?: string;
+          id?: number;
+          profile_id: number;
+          project_id: number;
+          role: "owner" | "director" | "member";
+        };
         Update: {
-          assigned_by?: number | null
-          created_at?: string
-          id?: number
-          profile_id?: number
-          project_id?: number
-          role?: "owner" | "director" | "member"
-        }
+          assigned_by?: number | null;
+          created_at?: string;
+          id?: number;
+          profile_id?: number;
+          project_id?: number;
+          role?: "owner" | "director" | "member";
+        };
         Relationships: [
           {
-            foreignKeyName: "project_members_assigned_by_fkey"
-            columns: ["assigned_by"]
-            isOneToOne: false
-            referencedRelation: "profiles"
-            referencedColumns: ["id"]
+            foreignKeyName: "project_members_assigned_by_fkey";
+            columns: ["assigned_by"];
+            isOneToOne: false;
+            referencedRelation: "profiles";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "project_members_profile_id_fkey"
-            columns: ["profile_id"]
-            isOneToOne: false
-            referencedRelation: "profiles"
-            referencedColumns: ["id"]
+            foreignKeyName: "project_members_profile_id_fkey";
+            columns: ["profile_id"];
+            isOneToOne: false;
+            referencedRelation: "profiles";
+            referencedColumns: ["id"];
           },
           {
-            foreignKeyName: "project_members_project_id_fkey"
-            columns: ["project_id"]
-            isOneToOne: false
-            referencedRelation: "projects"
-            referencedColumns: ["id"]
+            foreignKeyName: "project_members_project_id_fkey";
+            columns: ["project_id"];
+            isOneToOne: false;
+            referencedRelation: "projects";
+            referencedColumns: ["id"];
           },
-        ]
-      }
+        ];
+      };
       projects: {
         Row: {
-          company_name: string
-          config: Json | null
-          created_at: string
-          created_by: number | null
-          id: number
-          updated_at: string
-          url_slug: string
-        }
+          company_name: string;
+          config: Json | null;
+          created_at: string;
+          created_by: number | null;
+          id: number;
+          updated_at: string;
+          url_slug: string;
+        };
         Insert: {
-          company_name: string
-          config?: Json | null
-          created_at?: string
-          created_by?: number | null
-          id?: number
-          updated_at?: string
-          url_slug: string
-        }
+          company_name: string;
+          config?: Json | null;
+          created_at?: string;
+          created_by?: number | null;
+          id?: number;
+          updated_at?: string;
+          url_slug: string;
+        };
         Update: {
-          company_name?: string
-          config?: Json | null
-          created_at?: string
-          created_by?: number | null
-          id?: number
-          updated_at?: string
-          url_slug?: string
-        }
+          company_name?: string;
+          config?: Json | null;
+          created_at?: string;
+          created_by?: number | null;
+          id?: number;
+          updated_at?: string;
+          url_slug?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "projects_created_by_fkey"
-            columns: ["created_by"]
-            isOneToOne: false
-            referencedRelation: "profiles"
-            referencedColumns: ["id"]
+            foreignKeyName: "projects_created_by_fkey";
+            columns: ["created_by"];
+            isOneToOne: false;
+            referencedRelation: "profiles";
+            referencedColumns: ["id"];
           },
-        ]
-      }
+        ];
+      };
       questionnaire_responses: {
         Row: {
-          created_at: string
-          id: number
-          responses: Json
-          submitted_forms: string[]
-          uid: string
-          updated_at: string
-        }
+          created_at: string;
+          id: number;
+          responses: Json;
+          submitted_forms: string[];
+          uid: string;
+          updated_at: string;
+        };
         Insert: {
-          created_at?: string
-          id?: number
-          responses?: Json
-          submitted_forms?: string[]
-          uid: string
-          updated_at?: string
-        }
+          created_at?: string;
+          id?: number;
+          responses?: Json;
+          submitted_forms?: string[];
+          uid: string;
+          updated_at?: string;
+        };
         Update: {
-          created_at?: string
-          id?: number
-          responses?: Json
-          submitted_forms?: string[]
-          uid?: string
-          updated_at?: string
-        }
-        Relationships: []
-      }
+          created_at?: string;
+          id?: number;
+          responses?: Json;
+          submitted_forms?: string[];
+          uid?: string;
+          updated_at?: string;
+        };
+        Relationships: [];
+      };
       tickets: {
         Row: {
-          assign_to: string | null
-          attachments: Json | null
-          created_at: string
-          customer_id: string | null
-          department: string | null
-          director: string | null
-          email: string | null
-          id: number
-          message: string
-          name: string | null
-          numid: string | null
-          project: string | null
-          project_id: number | null
-          status: "pending" | "denied" | "in-progress" | "done" | null
-          subject: string
-          ticket_type: "report" | "request"
-          title: string | null
-          uid: string | null
-          updated_at: string
-        }
+          assign_to: string | null;
+          attachments: Json | null;
+          created_at: string;
+          customer_id: string | null;
+          department: string | null;
+          director: string | null;
+          email: string | null;
+          id: number;
+          message: string;
+          name: string | null;
+          numid: string | null;
+          project: string | null;
+          project_id: number | null;
+          status: "pending" | "denied" | "in-progress" | "done" | null;
+          subject: string;
+          ticket_type: "report" | "request";
+          title: string | null;
+          uid: string | null;
+          updated_at: string;
+        };
         Insert: {
-          assign_to?: string | null
-          attachments?: Json | null
-          created_at?: string
-          customer_id?: string | null
-          department?: string | null
-          director?: string | null
-          email?: string | null
-          id?: number
-          message: string
-          name?: string | null
-          numid?: string | null
-          project?: string | null
-          project_id?: number | null
-          status?: "pending" | "denied" | "in-progress" | "done" | null
-          subject: string
-          ticket_type: "report" | "request"
-          title?: string | null
-          uid?: string | null
-          updated_at?: string
-        }
+          assign_to?: string | null;
+          attachments?: Json | null;
+          created_at?: string;
+          customer_id?: string | null;
+          department?: string | null;
+          director?: string | null;
+          email?: string | null;
+          id?: number;
+          message: string;
+          name?: string | null;
+          numid?: string | null;
+          project?: string | null;
+          project_id?: number | null;
+          status?: "pending" | "denied" | "in-progress" | "done" | null;
+          subject: string;
+          ticket_type: "report" | "request";
+          title?: string | null;
+          uid?: string | null;
+          updated_at?: string;
+        };
         Update: {
-          assign_to?: string | null
-          attachments?: Json | null
-          created_at?: string
-          customer_id?: string | null
-          department?: string | null
-          director?: string | null
-          email?: string | null
-          id?: number
-          message?: string
-          name?: string | null
-          numid?: string | null
-          project?: string | null
-          project_id?: number | null
-          status?: "pending" | "denied" | "in-progress" | "done" | null
-          subject?: string
-          ticket_type?: "report" | "request"
-          title?: string | null
-          uid?: string | null
-          updated_at?: string
-        }
+          assign_to?: string | null;
+          attachments?: Json | null;
+          created_at?: string;
+          customer_id?: string | null;
+          department?: string | null;
+          director?: string | null;
+          email?: string | null;
+          id?: number;
+          message?: string;
+          name?: string | null;
+          numid?: string | null;
+          project?: string | null;
+          project_id?: number | null;
+          status?: "pending" | "denied" | "in-progress" | "done" | null;
+          subject?: string;
+          ticket_type?: "report" | "request";
+          title?: string | null;
+          uid?: string | null;
+          updated_at?: string;
+        };
         Relationships: [
           {
-            foreignKeyName: "tickets_project_id_fkey"
-            columns: ["project_id"]
-            isOneToOne: false
-            referencedRelation: "projects"
-            referencedColumns: ["id"]
+            foreignKeyName: "tickets_project_id_fkey";
+            columns: ["project_id"];
+            isOneToOne: false;
+            referencedRelation: "projects";
+            referencedColumns: ["id"];
           },
-        ]
-      }
+        ];
+      };
       website_forms: {
         Row: {
-          created_at: string
-          email: string | null
-          id: number
-          ip_address: string | null
-          message: string | null
-          name: string | null
-          subject: string | null
-        }
+          created_at: string;
+          email: string | null;
+          id: number;
+          ip_address: string | null;
+          message: string | null;
+          name: string | null;
+          subject: string | null;
+        };
         Insert: {
-          created_at?: string
-          email?: string | null
-          id?: number
-          ip_address?: string | null
-          message?: string | null
-          name?: string | null
-          subject?: string | null
-        }
+          created_at?: string;
+          email?: string | null;
+          id?: number;
+          ip_address?: string | null;
+          message?: string | null;
+          name?: string | null;
+          subject?: string | null;
+        };
         Update: {
-          created_at?: string
-          email?: string | null
-          id?: number
-          ip_address?: string | null
-          message?: string | null
-          name?: string | null
-          subject?: string | null
-        }
-        Relationships: []
-      }
-    }
+          created_at?: string;
+          email?: string | null;
+          id?: number;
+          ip_address?: string | null;
+          message?: string | null;
+          name?: string | null;
+          subject?: string | null;
+        };
+        Relationships: [];
+      };
+    };
     Views: {
-      [_ in never]: never
-    }
+      [_ in never]: never;
+    };
     Functions: {
+      current_user_role: { Args: never; Returns: string };
       hybrid_search: {
         Args: {
-          _filter_client_id?: string
-          _full_text_weight?: number
-          _match_count?: number
-          _query_embedding: string
-          _query_text: string
-          _semantic_weight?: number
-        }
+          _filter_client_id?: string;
+          _full_text_weight?: number;
+          _match_count?: number;
+          _query_embedding: string;
+          _query_text: string;
+          _semantic_weight?: number;
+        };
         Returns: {
-          content: string
-          id: number
-          metadata: Json
-          similarity: number
-        }[]
-      }
-      is_director: { Args: { check_uid: string }; Returns: boolean }
+          content: string;
+          id: number;
+          metadata: Json;
+          similarity: number;
+        }[];
+      };
+      is_director: { Args: { check_uid: string }; Returns: boolean };
+      is_project_director: { Args: { _project_id: number }; Returns: boolean };
+      is_project_member: { Args: { _project_id: number }; Returns: boolean };
       mark_conversation_read: {
-        Args: { p_conversation_id: number }
-        Returns: undefined
-      }
+        Args: { p_conversation_id: number };
+        Returns: undefined;
+      };
       match_client_knowledge: {
         Args: {
-          _filter_uid?: string
-          _match_count?: number
-          _query_embedding: string
-          _similarity_threshold?: number
-        }
+          _filter_uid?: string;
+          _match_count?: number;
+          _query_embedding: string;
+          _similarity_threshold?: number;
+        };
         Returns: {
-          content: string
-          id: number
-          metadata: Json
-          similarity: number
-        }[]
-      }
-      user_profile_id: { Args: { check_uid: string }; Returns: number }
-    }
+          content: string;
+          id: number;
+          metadata: Json;
+          similarity: number;
+        }[];
+      };
+      user_profile_id: { Args: { check_uid: string }; Returns: number };
+    };
     Enums: {
-      [_ in never]: never
-    }
+      [_ in never]: never;
+    };
     CompositeTypes: {
-      [_ in never]: never
-    }
-  }
-}
+      [_ in never]: never;
+    };
+  };
+};
 
-type DatabaseWithoutInternals = Omit<Database, "__InternalSupabase">
+type DatabaseWithoutInternals = Omit<Database, "__InternalSupabase">;
 
-type DefaultSchema = DatabaseWithoutInternals[Extract<keyof Database, "public">]
+type DefaultSchema = DatabaseWithoutInternals[Extract<
+  keyof Database,
+  "public"
+>];
 
 export type Tables<
   DefaultSchemaTableNameOrOptions extends
     | keyof (DefaultSchema["Tables"] & DefaultSchema["Views"])
     | { schema: keyof DatabaseWithoutInternals },
   TableName extends DefaultSchemaTableNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals
+    schema: keyof DatabaseWithoutInternals;
   }
     ? keyof (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
         DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])
     : never = never,
 > = DefaultSchemaTableNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals
+  schema: keyof DatabaseWithoutInternals;
 }
   ? (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
       DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])[TableName] extends {
-      Row: infer R
+      Row: infer R;
     }
     ? R
     : never
@@ -1006,98 +1156,98 @@ export type Tables<
         DefaultSchema["Views"])
     ? (DefaultSchema["Tables"] &
         DefaultSchema["Views"])[DefaultSchemaTableNameOrOptions] extends {
-        Row: infer R
+        Row: infer R;
       }
       ? R
       : never
-    : never
+    : never;
 
 export type TablesInsert<
   DefaultSchemaTableNameOrOptions extends
     | keyof DefaultSchema["Tables"]
     | { schema: keyof DatabaseWithoutInternals },
   TableName extends DefaultSchemaTableNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals
+    schema: keyof DatabaseWithoutInternals;
   }
     ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
     : never = never,
 > = DefaultSchemaTableNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals
+  schema: keyof DatabaseWithoutInternals;
 }
   ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
-      Insert: infer I
+      Insert: infer I;
     }
     ? I
     : never
   : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
     ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
-        Insert: infer I
+        Insert: infer I;
       }
       ? I
       : never
-    : never
+    : never;
 
 export type TablesUpdate<
   DefaultSchemaTableNameOrOptions extends
     | keyof DefaultSchema["Tables"]
     | { schema: keyof DatabaseWithoutInternals },
   TableName extends DefaultSchemaTableNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals
+    schema: keyof DatabaseWithoutInternals;
   }
     ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
     : never = never,
 > = DefaultSchemaTableNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals
+  schema: keyof DatabaseWithoutInternals;
 }
   ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
-      Update: infer U
+      Update: infer U;
     }
     ? U
     : never
   : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
     ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
-        Update: infer U
+        Update: infer U;
       }
       ? U
       : never
-    : never
+    : never;
 
 export type Enums<
   DefaultSchemaEnumNameOrOptions extends
     | keyof DefaultSchema["Enums"]
     | { schema: keyof DatabaseWithoutInternals },
   EnumName extends DefaultSchemaEnumNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals
+    schema: keyof DatabaseWithoutInternals;
   }
     ? keyof DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"]
     : never = never,
 > = DefaultSchemaEnumNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals
+  schema: keyof DatabaseWithoutInternals;
 }
   ? DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"][EnumName]
   : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema["Enums"]
     ? DefaultSchema["Enums"][DefaultSchemaEnumNameOrOptions]
-    : never
+    : never;
 
 export type CompositeTypes<
   PublicCompositeTypeNameOrOptions extends
     | keyof DefaultSchema["CompositeTypes"]
     | { schema: keyof DatabaseWithoutInternals },
   CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals
+    schema: keyof DatabaseWithoutInternals;
   }
     ? keyof DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
     : never = never,
 > = PublicCompositeTypeNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals
+  schema: keyof DatabaseWithoutInternals;
 }
   ? DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
   : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema["CompositeTypes"]
     ? DefaultSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
-    : never
+    : never;
 
 export const Constants = {
   public: {
     Enums: {},
   },
-} as const
+} as const;

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -5,6 +5,14 @@ const nextConfig: NextConfig = {
   // (consumed by frontend/Dockerfile). No-op for `next dev`.
   output: "standalone",
 
+  // Cross-origin hosts allowed to hit the dev server (Tailscale, etc.).
+  // No-op in production.
+  allowedDevOrigins: [
+    "galileo",
+    "galileo.bear-ling.ts.net",
+    "100.68.183.80",
+  ],
+
   images: {
     remotePatterns: [
       {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
     "@dnd-kit/core": "^6.3.1",
     "@marsidev/react-turnstile": "^1.4.1",
     "@phosphor-icons/react": "^2.1.10",
+    "@radix-ui/colors": "^3.0.0",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
@@ -32,6 +33,7 @@
     "clsx": "^2.1.1",
     "googleapis": "^171.4.0",
     "gsap": "^3.13.0",
+    "linkify-it": "^5.0.1",
     "lucide-react": "^0.555.0",
     "motion": "^12.23.25",
     "next": "16.2.6",
@@ -51,6 +53,7 @@
   "devDependencies": {
     "@biomejs/biome": "2.3.8",
     "@tailwindcss/postcss": "^4.1.17",
+    "@types/linkify-it": "^5.0.0",
     "@types/node": "^24.10.1",
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",

--- a/supabase/migrations/20260526000000_create_finance_tables.sql
+++ b/supabase/migrations/20260526000000_create_finance_tables.sql
@@ -45,14 +45,17 @@ CREATE TABLE public.budget_transactions (
 CREATE INDEX idx_budget_tx_budget_date ON public.budget_transactions (budget_id, occurred_on);
 CREATE INDEX idx_budget_tx_category    ON public.budget_transactions (category_id);
 
--- 4. updated_at triggers (mirror project pattern) ----------------------
+-- 4. updated_at trigger (shared helper) --------------------------------
 CREATE OR REPLACE FUNCTION public.set_updated_at()
-RETURNS TRIGGER AS $$
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SET search_path TO 'pg_catalog', 'pg_temp'
+AS $$
 BEGIN
   NEW.updated_at = now();
   RETURN NEW;
 END;
-$$ LANGUAGE plpgsql;
+$$;
 
 CREATE TRIGGER trg_project_budgets_updated_at
   BEFORE UPDATE ON public.project_budgets
@@ -71,23 +74,20 @@ ALTER TABLE public.project_budgets      ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public.budget_categories    ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public.budget_transactions  ENABLE ROW LEVEL SECURITY;
 
--- Helper: is auth.uid() a member of the given project?
-CREATE OR REPLACE FUNCTION public.is_project_member(target_project_id bigint)
-RETURNS boolean LANGUAGE sql STABLE SECURITY DEFINER AS $$
-  SELECT EXISTS (
-    SELECT 1 FROM public.project_members pm
-    JOIN public.profiles p ON p.id = pm.profile_id
-    WHERE pm.project_id = target_project_id AND p.uid = auth.uid()
-  );
-$$;
+-- Reuse existing public.is_project_member(_project_id bigint) — already in DB.
 
--- Helper: is auth.uid() a director on the given project?
-CREATE OR REPLACE FUNCTION public.is_project_director(target_project_id bigint)
-RETURNS boolean LANGUAGE sql STABLE SECURITY DEFINER AS $$
+-- New helper: is auth.uid() a director on the given project?
+-- Matches the convention of the existing is_project_member: SECURITY DEFINER + search_path hardening.
+CREATE OR REPLACE FUNCTION public.is_project_director(_project_id bigint)
+RETURNS boolean
+LANGUAGE sql
+STABLE SECURITY DEFINER
+SET search_path TO 'pg_catalog', 'pg_temp'
+AS $$
   SELECT EXISTS (
     SELECT 1 FROM public.project_members pm
     JOIN public.profiles p ON p.id = pm.profile_id
-    WHERE pm.project_id = target_project_id
+    WHERE pm.project_id = _project_id
       AND pm.role = 'director'
       AND p.uid = auth.uid()
   );

--- a/supabase/migrations/20260526000000_create_finance_tables.sql
+++ b/supabase/migrations/20260526000000_create_finance_tables.sql
@@ -1,0 +1,135 @@
+-- =====================================================================
+-- Finances dashboard schema
+-- Spec: docs/superpowers/specs/2026-05-26-finances-redesign-design.md
+-- =====================================================================
+
+-- 1. project_budgets ---------------------------------------------------
+CREATE TABLE public.project_budgets (
+  id              bigserial PRIMARY KEY,
+  project_id      bigint NOT NULL REFERENCES public.projects(id) ON DELETE CASCADE,
+  period_start    date NOT NULL,
+  period_end      date NOT NULL,
+  currency        text NOT NULL DEFAULT 'USD',
+  created_at      timestamptz NOT NULL DEFAULT now(),
+  updated_at      timestamptz NOT NULL DEFAULT now(),
+  created_by      bigint REFERENCES public.profiles(id),
+  CONSTRAINT project_budgets_period_check CHECK (period_end >= period_start),
+  CONSTRAINT project_budgets_project_unique UNIQUE (project_id)
+);
+
+-- 2. budget_categories -------------------------------------------------
+CREATE TABLE public.budget_categories (
+  id              bigserial PRIMARY KEY,
+  budget_id       bigint NOT NULL REFERENCES public.project_budgets(id) ON DELETE CASCADE,
+  name            text NOT NULL,
+  expected_amount numeric(14,2) NOT NULL DEFAULT 0 CHECK (expected_amount >= 0),
+  sort_order      integer NOT NULL DEFAULT 0,
+  created_at      timestamptz NOT NULL DEFAULT now(),
+  updated_at      timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT budget_categories_budget_name_unique UNIQUE (budget_id, name)
+);
+
+-- 3. budget_transactions -----------------------------------------------
+CREATE TABLE public.budget_transactions (
+  id              bigserial PRIMARY KEY,
+  budget_id       bigint NOT NULL REFERENCES public.project_budgets(id) ON DELETE CASCADE,
+  category_id     bigint NOT NULL REFERENCES public.budget_categories(id) ON DELETE RESTRICT,
+  occurred_on     date NOT NULL,
+  description     text NOT NULL,
+  amount          numeric(14,2) NOT NULL CHECK (amount >= 0),
+  created_at      timestamptz NOT NULL DEFAULT now(),
+  created_by      bigint REFERENCES public.profiles(id),
+  updated_at      timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_budget_tx_budget_date ON public.budget_transactions (budget_id, occurred_on);
+CREATE INDEX idx_budget_tx_category    ON public.budget_transactions (category_id);
+
+-- 4. updated_at triggers (mirror project pattern) ----------------------
+CREATE OR REPLACE FUNCTION public.set_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_project_budgets_updated_at
+  BEFORE UPDATE ON public.project_budgets
+  FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+CREATE TRIGGER trg_budget_categories_updated_at
+  BEFORE UPDATE ON public.budget_categories
+  FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+CREATE TRIGGER trg_budget_transactions_updated_at
+  BEFORE UPDATE ON public.budget_transactions
+  FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+-- 5. RLS ---------------------------------------------------------------
+ALTER TABLE public.project_budgets      ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.budget_categories    ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.budget_transactions  ENABLE ROW LEVEL SECURITY;
+
+-- Helper: is auth.uid() a member of the given project?
+CREATE OR REPLACE FUNCTION public.is_project_member(target_project_id bigint)
+RETURNS boolean LANGUAGE sql STABLE SECURITY DEFINER AS $$
+  SELECT EXISTS (
+    SELECT 1 FROM public.project_members pm
+    JOIN public.profiles p ON p.id = pm.profile_id
+    WHERE pm.project_id = target_project_id AND p.uid = auth.uid()
+  );
+$$;
+
+-- Helper: is auth.uid() a director on the given project?
+CREATE OR REPLACE FUNCTION public.is_project_director(target_project_id bigint)
+RETURNS boolean LANGUAGE sql STABLE SECURITY DEFINER AS $$
+  SELECT EXISTS (
+    SELECT 1 FROM public.project_members pm
+    JOIN public.profiles p ON p.id = pm.profile_id
+    WHERE pm.project_id = target_project_id
+      AND pm.role = 'director'
+      AND p.uid = auth.uid()
+  );
+$$;
+
+-- project_budgets policies
+CREATE POLICY budget_read ON public.project_budgets
+  FOR SELECT USING (public.is_project_member(project_id));
+CREATE POLICY budget_insert ON public.project_budgets
+  FOR INSERT WITH CHECK (public.is_project_director(project_id));
+CREATE POLICY budget_update ON public.project_budgets
+  FOR UPDATE USING (public.is_project_director(project_id))
+                WITH CHECK (public.is_project_director(project_id));
+CREATE POLICY budget_delete ON public.project_budgets
+  FOR DELETE USING (public.is_project_director(project_id));
+
+-- budget_categories policies (join through project_budgets)
+CREATE POLICY cat_read ON public.budget_categories
+  FOR SELECT USING (
+    EXISTS (SELECT 1 FROM public.project_budgets b
+            WHERE b.id = budget_id AND public.is_project_member(b.project_id))
+  );
+CREATE POLICY cat_write ON public.budget_categories
+  FOR ALL USING (
+    EXISTS (SELECT 1 FROM public.project_budgets b
+            WHERE b.id = budget_id AND public.is_project_director(b.project_id))
+  ) WITH CHECK (
+    EXISTS (SELECT 1 FROM public.project_budgets b
+            WHERE b.id = budget_id AND public.is_project_director(b.project_id))
+  );
+
+-- budget_transactions policies (same join pattern)
+CREATE POLICY tx_read ON public.budget_transactions
+  FOR SELECT USING (
+    EXISTS (SELECT 1 FROM public.project_budgets b
+            WHERE b.id = budget_id AND public.is_project_member(b.project_id))
+  );
+CREATE POLICY tx_write ON public.budget_transactions
+  FOR ALL USING (
+    EXISTS (SELECT 1 FROM public.project_budgets b
+            WHERE b.id = budget_id AND public.is_project_director(b.project_id))
+  ) WITH CHECK (
+    EXISTS (SELECT 1 FROM public.project_budgets b
+            WHERE b.id = budget_id AND public.is_project_director(b.project_id))
+  );

--- a/supabase/migrations/20260526000100_add_transaction_title.sql
+++ b/supabase/migrations/20260526000100_add_transaction_title.sql
@@ -1,0 +1,6 @@
+-- Transactions get a required title (short label) and an optional description
+-- (longer supplementary detail). Backfill title from the existing description.
+ALTER TABLE public.budget_transactions ADD COLUMN title text;
+UPDATE public.budget_transactions SET title = description WHERE title IS NULL;
+ALTER TABLE public.budget_transactions ALTER COLUMN title SET NOT NULL;
+ALTER TABLE public.budget_transactions ALTER COLUMN description DROP NOT NULL;


### PR DESCRIPTION
## Summary

Replaces the `notFound()` stub at `/dashboard/finances` with a real, project-scoped budget tracker backed by Supabase. Directors maintain the data in-app; clients and members get a read-only view. No mock data ships.

Supersedes the deleted `claude/finance-dashboard-empty-page-*` mock-data approach. Spec + plan in `docs/superpowers/` (untracked, local).

## What's included

**Database** (3 new tables, RLS, applied to the `sbi` Supabase project)
- `project_budgets` (one per project), `budget_categories` (expected amounts), `budget_transactions` (actuals, with `title` + optional `description`)
- RLS: reads gated to project members, writes to directors only; reuses existing `is_project_member`, adds hardened `is_project_director`
- Migrations in `supabase/migrations/` (already applied via MCP)

**Frontend**
- Server-fetched, project-scoped page; renders `EmptyBudgetState` until a director sets up a budget
- `OverviewTiles` (budget / spent / remaining-or-over / burn rate; Remaining tile flips amber when over)
- `SpendChart` — Recharts cumulative-spend area + dashed budget-cap line (amber when over)
- `CategoryGrid` — hairline Expected | Actual | Variance rows + total
- `TransactionsTable` — `DataTable` with search/sort/pagination; title primary + description subtext
- Director drawers: Set Up Budget, Edit Categories (batch upsert), Log Transaction (create/edit, outside-period warning)
- `StatTile` gains a backward-compatible `tone="warning"` variant

**Dashboard-wide**
- Project switching now re-runs server components globally (`switchProject` → `router.refresh()` in a transition) so every page re-fetches on switch
- `ProjectSwitchOverlay` shows a loading overlay scoped to the content area (not sidebar/header)

**Deps / config**
- Declares `@radix-ui/colors`, `linkify-it`, `@types/linkify-it` (imported but previously undeclared — broke a clean install)
- `allowedDevOrigins` for Tailscale dev access

## Test plan
- [ ] As a director: set up budget → add categories → log transactions (title-only and title+description) → verify chart/grid/tiles agree
- [ ] Trigger over-budget: Remaining tile + chart gradient go amber
- [ ] Delete a category that has transactions → RESTRICT message
- [ ] As a client/member: same data, no edit affordances
- [ ] Switch projects → content-area overlay shows, finances reflects the new project
- [ ] `bun run build` passes

## Notes
- Deferred to v2 (per spec): multi-budget per project, lifecycle integration, multi-currency UI, CSV/Sheets import, receipts, audit log, notifications, inline-grid editing
- Project-switch refresh is wired globally but only finances re-fetches meaningfully today; other server-fetching pages benefit automatically