### PR TITLE
fix(backend): remove auth bypass in get_current_user_id

### DIFF
--- a/backend/app/explore/api/deps.py
+++ b/backend/app/explore/api/deps.py
@@ -1,44 +1,50 @@
 from typing import Optional
-from fastapi import Depends, HTTPException, status, Header
+from fastapi import HTTPException, status, Header
 from app.explore.db.supabase import supabase
 
 
 async def get_current_user_id(authorization: Optional[str] = Header(None)) -> str:
-    """Get the current authenticated user ID from Supabase Auth."""
-    if not authorization:
-        # Return test user ID from claude.md
-        return "ed13b878-b87d-4b34-a138-7e51994fa0f8"
-    
-    try:
-        if not authorization.startswith("Bearer "):
-            raise HTTPException(
-                status_code=status.HTTP_401_UNAUTHORIZED,
-                detail="Invalid authorization header format"
-            )
-        
-        token = authorization.replace("Bearer ", "")
-        
-        user_response = supabase.auth.get_user(token)
-        
-        if not user_response or not user_response.user:
-            raise HTTPException(
-                status_code=status.HTTP_401_UNAUTHORIZED,
-                detail="Invalid or expired token"
-            )
-        
-        return user_response.user.id
-        
-    except HTTPException:
-        raise
-    except Exception as e:
+    """Resolve the authenticated user ID from the Supabase access token.
+
+    Requires a valid ``Authorization: Bearer <token>`` header and raises 401
+    otherwise. The Next.js proxy always forwards the caller's Supabase token
+    (see frontend/app/api/chat/route.ts), so there is no anonymous path.
+    """
+    if not authorization or not authorization.startswith("Bearer "):
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            detail=f"Authentication failed: {str(e)}"
+            detail="Missing or malformed Authorization header",
         )
 
+    token = authorization.removeprefix("Bearer ").strip()
+    if not token:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Missing or malformed Authorization header",
+        )
 
-async def get_optional_user_id(authorization: Optional[str] = Header(None)) -> Optional[str]:
-    """Get the current user ID if authenticated."""
+    try:
+        user_response = supabase.auth.get_user(token)
+    except Exception:
+        # Don't surface GoTrue internals to the caller; log-and-generic.
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or expired token",
+        )
+
+    if not user_response or not user_response.user:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or expired token",
+        )
+
+    return user_response.user.id
+
+
+async def get_optional_user_id(
+    authorization: Optional[str] = Header(None),
+) -> Optional[str]:
+    """User ID when a valid token is present, otherwise ``None`` (no error)."""
     try:
         return await get_current_user_id(authorization)
     except HTTPException:


### PR DESCRIPTION
## Summary

`backend/app/explore/api/deps.py` returned a **hardcoded test user UUID** (`ed13b878-…`) whenever the `Authorization` header was missing. Every endpoint guarded by `get_current_user_id` (chat, chat extract-text, documents upload/list) would therefore treat an **unauthenticated** request as that user — a silent auth bypass on the Explore backend.

## Changes
- Remove the hardcoded-UUID fallback; require a valid `Authorization: Bearer <token>` and raise **401** otherwise.
- Strip the prefix with `removeprefix("Bearer ")` (not `.replace`, which could corrupt a token containing the substring) and reject an empty token.
- Stop echoing the raw GoTrue exception string in the 401 `detail` (was leaking internals).
- Remove the now-unused `Depends` import.

## Why this is safe
The browser never calls the backend directly. The Next.js proxy (`frontend/app/api/chat/route.ts`, `chat/extract/route.ts`) calls `supabase.auth.getSession()`, **401s if there's no session**, and forwards `Authorization: Bearer ${session.access_token}` on every backend request. So the real flow always carries a valid token — only the anonymous bypass path is removed.

## Test plan
- [x] `python -m py_compile` clean · `ruff check` passes
- [ ] Authenticated chat/extract/documents still work end-to-end through the Next.js proxy.
- [ ] A direct backend request with no/`invalid` `Authorization` header now returns 401 (previously 200 as the test user).

## Note
Local backend testing that previously hit the API with no auth now needs a real Supabase token (the frontend already always sends one). If a dev shortcut is wanted, we can add an env-gated bypass that is never set in production — intentionally omitted here to keep the default secure.