### PR TITLE
refactor(login): unify loaders on the branded bar

### DIFF
--- a/frontend/app/(static)/login/loading.tsx
+++ b/frontend/app/(static)/login/loading.tsx
@@ -1,25 +1,7 @@
+import { BrandLoader } from "@/components/brand-loader";
+
+// Route-level Suspense fallback: covers the static layout's navbar + footer
+// while the server component decides whether to redirect or render the form.
 export default function LoginLoading() {
-  // Fixed full-screen overlay covers the static layout's navbar + footer
-  // while the server component decides whether to redirect or render the form.
-  return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-sbi-dark">
-      <div className="flex flex-col items-center gap-5">
-        <span className="text-3xl font-light tracking-tight text-white">
-          <span className="text-sbi-green">S</span>BI
-        </span>
-        <span className="h-px w-12 overflow-hidden bg-white/10">
-          <span
-            className="block h-full w-1/2 bg-sbi-green"
-            style={{ animation: "loadingBar 1s ease-in-out infinite" }}
-          />
-        </span>
-      </div>
-      <style>{`
-        @keyframes loadingBar {
-          0% { transform: translateX(-100%); }
-          100% { transform: translateX(200%); }
-        }
-      `}</style>
-    </div>
-  );
+  return <BrandLoader />;
 }

--- a/frontend/app/(static)/login/page.tsx
+++ b/frontend/app/(static)/login/page.tsx
@@ -8,6 +8,7 @@ import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 
 import bg from "@/assets/images/login.jpg";
+import { BrandLoader } from "@/components/brand-loader";
 import { loginAction, checkAuthAction } from "./actions";
 
 const portalTypes = ["Client", "Member", "Sponsor"];
@@ -106,24 +107,7 @@ export default function LoginPage() {
   };
 
   if (isCheckingAuth) {
-    return (
-      <div className="min-h-screen bg-sbi-dark flex items-center justify-center">
-        <motion.div
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          className="flex flex-col items-center gap-4"
-        >
-          <motion.div
-            animate={{ rotate: 360 }}
-            transition={{ duration: 1, repeat: Infinity, ease: "linear" }}
-            className="w-8 h-8 border-2 border-sbi-green border-t-transparent rounded-full"
-          />
-          <span className="text-sbi-muted text-sm tracking-wider uppercase">
-            Loading...
-          </span>
-        </motion.div>
-      </div>
-    );
+    return <BrandLoader />;
   }
 
   return (

--- a/frontend/components/brand-loader.tsx
+++ b/frontend/components/brand-loader.tsx
@@ -1,0 +1,29 @@
+/**
+ * Full-screen branded loading overlay: the SBI wordmark above a thin
+ * sliding green bar. Shared by the login route's Suspense fallback
+ * (app/(static)/login/loading.tsx) and the in-page auth-check state in
+ * the login page, so "entering login" shows one consistent loader.
+ */
+export function BrandLoader() {
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-sbi-dark">
+      <div className="flex flex-col items-center gap-5">
+        <span className="text-3xl font-light tracking-tight text-white">
+          <span className="text-sbi-green">S</span>BI
+        </span>
+        <span className="h-px w-12 overflow-hidden bg-white/10">
+          <span
+            className="block h-full w-1/2 bg-sbi-green"
+            style={{ animation: "loadingBar 1s ease-in-out infinite" }}
+          />
+        </span>
+      </div>
+      <style>{`
+        @keyframes loadingBar {
+          0% { transform: translateX(-100%); }
+          100% { transform: translateX(200%); }
+        }
+      `}</style>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

The login route had **two** full-screen loaders for the same "entering login" moment, so users saw bar-then-circle:
- The branded sliding green bar in `app/(static)/login/loading.tsx` (the route-level Suspense fallback).
- A generic spinning circle in `app/(static)/login/page.tsx` (the client `isCheckingAuth` state).

This extracts the bar into a shared `<BrandLoader>` and uses it for both, so it's one consistent branded loader throughout.

## Changes
- Add `components/brand-loader.tsx` (SBI wordmark + sliding green bar).
- `login/loading.tsx` → renders `<BrandLoader />`.
- `login/page.tsx` `isCheckingAuth` → renders `<BrandLoader />` (was the spinning circle + "Loading…").
- The small in-button submit spinner is left as-is (it's a different, inline element).

## Test plan
- [x] `bun run build` passes
- [x] biome clean on changed files
- [ ] Visit `/login` while signed out → branded bar (not a circle) during the auth check, then the form.
- [ ] Visit `/login` while signed in → bar shows briefly, then redirect to dashboard.