### PR TITLE
fix(config): restore images.qualities [70, 75]

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -21,6 +21,9 @@ const nextConfig: NextConfig = {
         pathname: "/**",
       },
     ],
+    // Allowed <Image quality> values. Next 16 defaults to [75]; some images
+    // (e.g. the login hero) request 70, so both must be declared.
+    qualities: [70, 75],
   },
   reactStrictMode: true,
 


### PR DESCRIPTION
## Summary

Fixes a regression from PR #47. That PR removed `images.qualities` from `next.config.ts` on the mistaken belief it was an invalid Next.js key (the audit agents flagged it as the suspected Vercel build-fail cause — wrongly; the real cause was the unresolved `@radix-ui/colors` imports, also fixed in #47).

`images.qualities` **is** a valid Next 16 key, and it's needed: at least one `<Image>` (the login hero, `eer_night…jpg`) requests `quality={70}`. With the key gone, Next defaults to `[75]` and throws:

> Image … is using quality "70" which is not configured in images.qualities [75]. Please update your config to [70, 75].

## Change
- Re-add `qualities: [70, 75]` to `next.config.ts` `images`.

## Test plan
- [ ] Vercel preview build passes.
- [ ] The image that requested quality 70 no longer warns/errors.