### PR TITLE
ci: add GitHub Actions CI workflow (frontend + backend)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,94 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [dev, main]
+  workflow_dispatch:
+
+# Cancel superseded runs on the same PR/branch to save minutes.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  frontend:
+    name: Frontend (lint, build)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      # `biome check` currently reports pre-existing errors across the tree, so
+      # lint is advisory for now. Run `bun run lint:fix`, clean up the rest, then
+      # drop continue-on-error to make it a blocking gate.
+      - name: Lint (Biome, advisory)
+        continue-on-error: true
+        run: bun run lint
+
+      # `next build` type-checks with Next's generated `next-env.d.ts` (which
+      # declares image/asset module types), so it is the typecheck + build gate.
+      # A standalone `tsc --noEmit` would spuriously fail on `@/assets/*` imports.
+      - name: Build (includes typecheck)
+        run: bun run build
+        env:
+          # Real values come from repo secrets when configured; otherwise the
+          # placeholders below let `next build` complete (it only needs these
+          # to be present, not valid). Add the secrets to run a faithful build.
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL || 'https://placeholder.supabase.co' }}
+          NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY || 'placeholder-publishable-key' }}
+          NEXT_PUBLIC_TURNSTILE_SITE_KEY: ${{ secrets.NEXT_PUBLIC_TURNSTILE_SITE_KEY || '1x00000000000000000000AA' }}
+          SUPABASE_SECRET_KEY: ${{ secrets.SUPABASE_SECRET_KEY || 'placeholder-secret-key' }}
+          TURNSTILE_SECRET_KEY: ${{ secrets.TURNSTILE_SECRET_KEY || '1x0000000000000000000000000000000AA' }}
+          N8N_CONTACT_WEBHOOK_URL: ${{ secrets.N8N_CONTACT_WEBHOOK_URL || 'https://placeholder.invalid/webhook' }}
+          BASIC_AUTH_USER: ${{ secrets.BASIC_AUTH_USER || 'ci' }}
+          BASIC_AUTH_PASSWORD: ${{ secrets.BASIC_AUTH_PASSWORD || 'ci' }}
+          GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID || 'placeholder' }}
+          GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET || 'placeholder' }}
+          GOOGLE_REDIRECT_URI: ${{ secrets.GOOGLE_REDIRECT_URI || 'https://placeholder.invalid/callback' }}
+
+  backend:
+    name: Backend (deps, compile, lint)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.12"
+          enable-cache: true
+
+      - name: Install dependencies (verifies uv.lock)
+        run: uv sync --frozen
+
+      - name: Compile check
+        run: uv run python -m compileall app
+
+      # ruff and pyright are not yet project dependencies, so these run via
+      # `uvx` (ephemeral) and are advisory for now. Flip continue-on-error to
+      # false (and/or add them to backend dev deps) once the code is clean.
+      - name: Lint (ruff, advisory)
+        continue-on-error: true
+        run: uvx ruff check . --output-format=github
+
+      - name: Typecheck (pyright, advisory)
+        continue-on-error: true
+        run: uvx pyright
+        env:
+          VIRTUAL_ENV: .venv


### PR DESCRIPTION
## Summary

Adds a pre-merge CI gate at `.github/workflows/ci.yml`, running on PRs to `dev` and `main` (+ manual `workflow_dispatch`). Currently Vercel only catches frontend build failures *after* merge; this catches them before. Independent of #51.

I ran every step locally against this branch before opening — see Test plan.

## What runs

**Frontend job** (`frontend/`)
- `bun install --frozen-lockfile`
- **Build (blocking)** — `bun run build`. `next build` type-checks using Next's generated `next-env.d.ts`, so it covers typecheck + build in one step.
- **Lint (advisory)** — `bun run lint` (`biome check`) runs with `continue-on-error` because the tree currently has pre-existing Biome errors (see Notes).

**Backend job** (`backend/`)
- `uv sync --frozen` (blocking — also verifies `uv.lock` integrity)
- `python -m compileall app` (blocking — syntax check)
- **ruff + pyright (advisory)** via `uvx` — they aren't project deps yet, so they run ephemerally and don't block.

## Design notes

- **No standalone `tsc --noEmit`.** Run alone before `next build`, it spuriously fails with `TS2307` on `@/assets/*` image imports (those module types come from `next-env.d.ts`, generated by `next build`). `next build` already enforces types (no `ignoreBuildErrors` in `next.config.ts`), so it's the real typecheck gate.
- **Build env.** `next build` needs the env vars present (not necessarily valid). The build step uses `${{ secrets.X || 'placeholder' }}` — faithful when you add repo secrets, green out of the box otherwise.
- Concurrency cancels superseded runs per ref; `permissions: contents: read` (least privilege).

## Test plan (run locally on this branch)

- [x] Frontend `bun install --frozen-lockfile` → `next build`: **Compiled successfully**, 34 static pages generated, exit 0 (with placeholder env)
- [x] Backend `uv sync --frozen` → `compileall app`: exit 0
- [x] Confirmed `biome check` currently fails (326 errors / 97 warnings) → justifies advisory lint
- [x] Confirmed ruff flags real unused imports (advisory) and `next.config.ts` has no `ignoreBuildErrors`
- [x] `ci.yml` validates as YAML

## Follow-ups (not in this PR)

- Clean up Biome errors (`bun run lint:fix` + manual), then flip frontend lint to **blocking** (drop `continue-on-error`).
- Adopt ruff + pyright as backend dev deps, fix findings, then make them blocking.
- After one green run on a PR: enable branch protection + mark this workflow a **required status check** on `dev`/`main`.
- Optionally add `secrets.*` for a fully faithful frontend build.