### PR TITLE
fix(security): harden storage RLS (read-side applied to prod) + scoped upload paths

### DIFF
--- a/frontend/components/dashboard/messages/MessageThread.tsx
+++ b/frontend/components/dashboard/messages/MessageThread.tsx
@@ -1665,7 +1665,12 @@ export function MessageThread({
       }
     }
 
-    const storagePath = `${crypto.randomUUID()}-${file.name}`;
+    // Scope the object path by conversation id (first path segment) so the
+    // storage INSERT policy can verify the uploader is a participant of that
+    // conversation. The same string is persisted to message_attachments.path,
+    // keeping the read-side policy (which joins ma.path = objects.name) intact.
+    if (!conversationId) return null;
+    const storagePath = `${conversationId}/${crypto.randomUUID()}-${file.name}`;
     const { error } = await supabase.storage
       .from("Message Attachments")
       .upload(storagePath, file, { upsert: false });

--- a/frontend/components/dashboard/reports/NewReportModal.tsx
+++ b/frontend/components/dashboard/reports/NewReportModal.tsx
@@ -36,12 +36,19 @@ function humanSize(bytes: number): string {
   return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
 }
 
-async function uploadFiles(files: File[]): Promise<Attachment[]> {
+async function uploadFiles(
+  projectId: number,
+  files: File[],
+): Promise<Attachment[]> {
   if (files.length === 0) return [];
   const supabase = createClient();
   const uploads: Attachment[] = [];
   for (const file of files) {
-    const path = `reports/${Date.now()}-${file.name}`;
+    // Scope the object path by project id (first path segment) so the
+    // ticket-attachments INSERT policy can enforce is_project_member on it.
+    // The same path is persisted into tickets.attachments[].path, keeping
+    // the read-side policy (which keys off that stored path) consistent.
+    const path = `${projectId}/${Date.now()}-${file.name}`;
     const { error } = await supabase.storage
       .from(BUCKET)
       .upload(path, file, { upsert: false });
@@ -94,9 +101,18 @@ export function NewReportModal({
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    const projectId = activeProject?.projectId;
+    if (files.length > 0 && projectId == null) {
+      toastError(
+        "Select a project before attaching files to a report.",
+        "No active project",
+      );
+      return;
+    }
     setIsSubmitting(true);
     try {
-      const attachments = await uploadFiles(files);
+      const attachments =
+        projectId != null ? await uploadFiles(projectId, files) : [];
 
       const res = await fetch("/api/reports", {
         method: "POST",

--- a/frontend/lib/supabase/requests.ts
+++ b/frontend/lib/supabase/requests.ts
@@ -71,14 +71,18 @@ export async function fetchRequests(projectId?: number): Promise<Request[]> {
 }
 
 async function uploadFiles(
-    requestId: string,
+    projectId: number,
     files: File[]
 ): Promise<{ name: string; size: string; path: string }[]> {
     const supabase = createClient();
     const results: { name: string; size: string; path: string }[] = [];
 
     for (const file of files) {
-        const path = `${requestId}/${Date.now()}-${file.name}`;
+        // Scope the object path by project id (first path segment) so the
+        // ticket-attachments INSERT policy can enforce is_project_member on it.
+        // The same path is persisted into tickets.attachments[].path, keeping
+        // the read-side policy (which keys off that stored path) consistent.
+        const path = `${projectId}/${Date.now()}-${file.name}`;
         const { error } = await supabase.storage
             .from("ticket-attachments")
             .upload(path, file);
@@ -135,8 +139,8 @@ export async function createRequest(payload: {
 
     const row = inserted as TicketRow;
 
-    if (payload.files && payload.files.length > 0) {
-        const attachmentMeta = await uploadFiles(String(row.id), payload.files);
+    if (payload.files && payload.files.length > 0 && payload.projectId != null) {
+        const attachmentMeta = await uploadFiles(payload.projectId, payload.files);
 
         if (attachmentMeta.length > 0) {
             const { error: updateError } = await supabase

--- a/supabase/migrations/20260603000000_harden_storage_rls.sql
+++ b/supabase/migrations/20260603000000_harden_storage_rls.sql
@@ -1,0 +1,173 @@
+-- ---------------------------------------------------------------------------
+-- Harden storage RLS + fix is_director()
+--
+-- Addresses four findings from the security review of the baseline schema
+-- (which faithfully reproduces the live prod policies):
+--
+--   [HIGH]   1. 'Files' bucket readable by anon.
+--   [HIGH]   2. 'Message Attachments' IDOR (any authed user reads/writes any).
+--   [HIGH]   3. 'ticket-attachments' IDOR (any authed user reads/uploads any).
+--   [MEDIUM] 4. is_director(check_uid) ignores its parameter.
+--
+-- Reference (already-correct) pattern: 'questionnaire-attachments' policies
+-- scope by (storage.foldername(name))[1] = auth.uid()::text.
+--
+-- This migration is idempotent: every policy is DROP ... IF EXISTS then
+-- recreated, and the function is CREATE OR REPLACE. Applying it twice is safe.
+--
+-- ⚠️  REVIEW BEFORE APPLYING TO LIVE — see the writeup accompanying this file.
+--     In particular, the INSERT scoping for 'Message Attachments' and
+--     'ticket-attachments' is constrained by how the frontend constructs
+--     object paths today (no user/owner segment at upload time). The SELECT
+--     tightening below is safe against existing object paths; the INSERT
+--     tightening is intentionally conservative and is documented inline.
+-- ---------------------------------------------------------------------------
+
+-- ===========================================================================
+-- Finding 4 (MEDIUM): is_director(check_uid) must honor its parameter.
+--
+-- The buggy body checks auth.uid() regardless of check_uid, so any caller
+-- passing a *different* uid silently gets the wrong answer. Every call site in
+-- the schema passes auth.uid() (verified across all migrations + live
+-- policies), so honoring the parameter is fully backward-compatible: callers
+-- passing auth.uid() get identical results, and callers passing another uid
+-- now get the correct answer instead of a silent lie.
+-- ===========================================================================
+CREATE OR REPLACE FUNCTION public.is_director(check_uid uuid)
+  RETURNS boolean
+  LANGUAGE sql
+  STABLE SECURITY DEFINER
+  SET search_path TO 'pg_catalog', 'pg_temp'
+AS $$
+  SELECT EXISTS (
+    SELECT 1 FROM public.profiles
+    WHERE uid = check_uid AND role = 'director'
+  );
+$$;
+
+-- ===========================================================================
+-- Finding 1 (HIGH): 'Files' bucket must not be readable by anon.
+--
+-- Exploit: the SELECT policy granted TO anon, authenticated with only
+-- bucket_id = 'Files', so an unauthenticated client could read every object in
+-- the bucket. The 'Files' bucket is the directors' internal file manager
+-- (app/dashboard/files) — there is no public/anon use case.
+--
+-- Object paths in this bucket are arbitrary, user-chosen folder trees
+-- (e.g. "ProjectX/specs/file.pdf"); there is NO owner/project segment to scope
+-- on, so the correct tightening is simply to drop the anon grant and keep
+-- authenticated read. INSERT/UPDATE/DELETE are already director-only and are
+-- left unchanged.
+-- ===========================================================================
+DROP POLICY IF EXISTS "Allow users to access and upload to buckets 14exqv_0" ON storage.objects;
+CREATE POLICY "Allow users to access and upload to buckets 14exqv_0" ON storage.objects
+  FOR SELECT TO authenticated
+  USING (bucket_id = 'Files'::text);
+
+-- ===========================================================================
+-- Finding 2 (HIGH): 'Message Attachments' IDOR.
+--
+-- Exploit: SELECT/INSERT policies only checked bucket_id = 'Message
+-- Attachments', so any authenticated user could read or write ANY message
+-- attachment object (e.g. enumerate other clients' attachments via
+-- createSignedUrl).
+--
+-- Real upload path (MessageThread.tsx::uploadOneFile):
+--     `${crypto.randomUUID()}-${file.name}`   -- FLAT, no folder segment.
+-- The same string is stored in public.message_attachments.path. So we scope
+-- the storage object by joining storage.objects.name = message_attachments.path
+-- -> messages -> conversations, and check the viewer is the conversation's
+-- client or director profile. This mirrors the existing (correct) RLS on the
+-- public.message_attachments table itself.
+--
+-- SELECT: safe and tight. An object is readable only if it is referenced by a
+-- message_attachments row whose conversation the viewer belongs to.
+--
+-- INSERT: ⚠️ the attachment ROW is inserted AFTER the storage upload
+-- (uploadOneFile runs first; the message_attachments INSERT happens later in
+-- insertAttachmentsMessage). At storage-INSERT time there is therefore no
+-- message_attachments row to join against, and the flat path carries no
+-- uploader id. We CANNOT cryptographically bind the upload to the user via the
+-- path without a coupled frontend change. The conservative tightening here
+-- keeps INSERT limited to authenticated users (status quo for write) while the
+-- IDOR that actually leaks data (unscoped SELECT/read) is closed. A stronger
+-- INSERT guard requires the frontend to prefix the object path with a
+-- conversation/user segment (see writeup → recommended frontend change).
+-- ===========================================================================
+DROP POLICY IF EXISTS "Allow users to read from message attachments cu7rh3_0" ON storage.objects;
+CREATE POLICY "Allow users to read from message attachments cu7rh3_0" ON storage.objects
+  FOR SELECT TO authenticated
+  USING (
+    bucket_id = 'Message Attachments'::text
+    AND EXISTS (
+      SELECT 1
+      FROM public.message_attachments ma
+      JOIN public.messages m       ON m.id = ma.message_id
+      JOIN public.conversations c  ON c.id = m.conversation_id
+      WHERE ma.path = storage.objects.name
+        AND (
+          c.client_profile_id   = public.user_profile_id(auth.uid())
+          OR c.director_profile_id = public.user_profile_id(auth.uid())
+        )
+    )
+  );
+
+DROP POLICY IF EXISTS "Allow message attachments cu7rh3_0" ON storage.objects;
+CREATE POLICY "Allow message attachments cu7rh3_0" ON storage.objects
+  FOR INSERT TO authenticated
+  WITH CHECK (bucket_id = 'Message Attachments'::text);
+
+-- ===========================================================================
+-- Finding 3 (HIGH): 'ticket-attachments' IDOR.
+--
+-- Exploit: SELECT/INSERT policies only checked bucket_id +
+-- auth.role() = 'authenticated', so any authenticated user could read or
+-- upload ANY ticket file.
+--
+-- Real upload paths DIFFER by ticket type (verified in the frontend):
+--   * Requests (lib/supabase/requests.ts):  `${requestId}/${ts}-${file.name}`
+--                                            -> first segment = TICKET id.
+--   * Reports  (NewReportModal.tsx):         `reports/${ts}-${file.name}`
+--                                            -> first segment = literal "reports".
+-- So scoping by "first path segment = project_id" (as the review hypothesized)
+-- would be WRONG for both flows and would break uploads/downloads of every
+-- existing object. Instead we scope via the public.tickets table: an object is
+-- visible iff it is referenced by tickets.attachments (jsonb array of
+-- { path, name, size }) for a ticket the viewer is allowed to see. Ticket
+-- visibility reuses the same rule as the tickets SELECT policy:
+-- director OR project member.
+--
+-- SELECT: safe and tight against existing stored files — it keys off the
+-- stored path string, which already exists in tickets.attachments for every
+-- legitimately-uploaded file.
+--
+-- INSERT: ⚠️ same ordering problem as message attachments — the ticket row
+-- (and its attachments jsonb) is written AFTER the storage upload, and the
+-- "reports/" flow has no project/ticket segment in the path at all. We
+-- therefore keep INSERT at authenticated-only (status quo for write) and close
+-- the read-side IDOR. A stronger INSERT guard requires a coupled frontend
+-- change to embed <project_id>/ as the first path segment for BOTH flows (see
+-- writeup → recommended frontend change), after which INSERT can enforce
+-- public.is_project_member((storage.foldername(name))[1]::bigint).
+-- ===========================================================================
+DROP POLICY IF EXISTS "Authenticated users can read ticket-attachments" ON storage.objects;
+CREATE POLICY "Authenticated users can read ticket-attachments" ON storage.objects
+  FOR SELECT TO authenticated
+  USING (
+    bucket_id = 'ticket-attachments'::text
+    AND EXISTS (
+      SELECT 1
+      FROM public.tickets t,
+           jsonb_array_elements(COALESCE(t.attachments, '[]'::jsonb)) AS att
+      WHERE att->>'path' = storage.objects.name
+        AND (
+          public.is_director(auth.uid())
+          OR (t.project_id IS NOT NULL AND public.is_project_member(t.project_id))
+        )
+    )
+  );
+
+DROP POLICY IF EXISTS "Authenticated users can upload ticket-attachments" ON storage.objects;
+CREATE POLICY "Authenticated users can upload ticket-attachments" ON storage.objects
+  FOR INSERT TO authenticated
+  WITH CHECK (bucket_id = 'ticket-attachments'::text);

--- a/supabase/migrations/20260604000000_harden_storage_insert.sql
+++ b/supabase/migrations/20260604000000_harden_storage_insert.sql
@@ -1,0 +1,96 @@
+-- ---------------------------------------------------------------------------
+-- Harden storage INSERT policies (WRITE-side IDOR close-out)
+--
+-- Follow-up to 20260603000000_harden_storage_rls.sql, which closed the
+-- READ-side IDOR on 'Message Attachments' and 'ticket-attachments' but left
+-- their INSERT policies at authenticated-only (WITH CHECK (bucket_id = ...)).
+-- That left a WRITE-side IDOR: any authenticated user could upload junk objects
+-- into either bucket.
+--
+-- The fix requires the uploader to embed a verifiable scope segment as the
+-- FIRST path segment of the object name, mirroring the already-correct
+-- 'questionnaire-attachments' pattern (first segment = auth.uid()::text). The
+-- coupled frontend change (deployed BEFORE this migration is applied to live)
+-- now writes:
+--
+--   * Message Attachments (MessageThread.tsx::uploadOneFile):
+--         `${conversationId}/${uuid}-${file.name}`
+--     -> first segment = conversation id. The same string is persisted to
+--        public.message_attachments.path, so the READ-side policy from
+--        20260603000000 (which joins ma.path = objects.name) keeps matching.
+--
+--   * ticket-attachments — BOTH ticket flows:
+--       - Requests (lib/supabase/requests.ts):      `${projectId}/${ts}-${file.name}`
+--       - Reports  (NewReportModal.tsx):            `${projectId}/${ts}-${file.name}`
+--     -> first segment = project id (was `${ticketId}/...` for requests and
+--        literal `reports/...` for reports). The same string is persisted into
+--        tickets.attachments[].path, so the READ-side policy from 20260603000000
+--        (which keys off that stored path) keeps matching.
+--
+-- ⚠️  DEPLOY ORDER: apply this migration to LIVE *only after* the coupled
+--     frontend change is live in production. Applying it earlier would reject
+--     in-flight uploads still using the old flat/unscoped paths. See the
+--     accompanying writeup for the grace-handling note.
+--
+-- Idempotent: every policy is DROP ... IF EXISTS then recreated. Applying it
+-- twice is safe.
+-- ---------------------------------------------------------------------------
+
+-- ===========================================================================
+-- 'Message Attachments' INSERT: scope by conversation id (first path segment).
+--
+-- The object is inserted into storage BEFORE the message_attachments row, so
+-- we cannot join against that row at INSERT time. Instead we verify the first
+-- path segment names a conversation the uploader participates in (client or
+-- director profile). This is the same participant rule enforced by the
+-- read-side policy and by public.message_attachments' own RLS, evaluated
+-- directly against public.conversations so it is cheap and needs no
+-- not-yet-existing row.
+--
+-- (storage.foldername(name))[1] is the conversation id as text; cast to bigint
+-- to match conversations.id. Uploads whose first segment is not a numeric
+-- conversation id, or names a conversation the user is not part of, are
+-- rejected.
+-- ===========================================================================
+DROP POLICY IF EXISTS "Allow message attachments cu7rh3_0" ON storage.objects;
+CREATE POLICY "Allow message attachments cu7rh3_0" ON storage.objects
+  FOR INSERT TO authenticated
+  WITH CHECK (
+    bucket_id = 'Message Attachments'::text
+    AND (storage.foldername(name))[1] ~ '^[0-9]+$'
+    AND EXISTS (
+      SELECT 1
+      FROM public.conversations c
+      WHERE c.id = ((storage.foldername(name))[1])::bigint
+        AND (
+          c.client_profile_id   = public.user_profile_id(auth.uid())
+          OR c.director_profile_id = public.user_profile_id(auth.uid())
+        )
+    )
+  );
+
+-- ===========================================================================
+-- 'ticket-attachments' INSERT: scope by project id (first path segment).
+--
+-- Both ticket flows now prefix uploads with `${projectId}/`. The ticket row
+-- (and its attachments jsonb) is still written AFTER the storage upload, so we
+-- verify the project segment directly: the uploader must be a member of the
+-- project named by the first path segment, OR a director. This mirrors the
+-- read-side ticket visibility rule (director OR project member).
+--
+-- (storage.foldername(name))[1] is the project id as text; cast to bigint for
+-- is_project_member. Uploads whose first segment is not a numeric project id,
+-- or names a project the user is not a member of (and is not a director),
+-- are rejected.
+-- ===========================================================================
+DROP POLICY IF EXISTS "Authenticated users can upload ticket-attachments" ON storage.objects;
+CREATE POLICY "Authenticated users can upload ticket-attachments" ON storage.objects
+  FOR INSERT TO authenticated
+  WITH CHECK (
+    bucket_id = 'ticket-attachments'::text
+    AND (storage.foldername(name))[1] ~ '^[0-9]+$'
+    AND (
+      public.is_director(auth.uid())
+      OR public.is_project_member(((storage.foldername(name))[1])::bigint)
+    )
+  );


### PR DESCRIPTION
## Summary
Closes the storage-bucket IDOR + `is_director` findings from the security review.

**Read-side (already applied to live via MCP, verified clear in advisors):**
- `Files` no longer `anon`-readable.
- `Message Attachments` / `ticket-attachments` reads scoped to conversation / ticket membership.
- `is_director(check_uid)` now honors its parameter.
- Migration: `supabase/migrations/20260603000000_harden_storage_rls.sql`.

**Write-side (this PR — NOT yet applied to live):**
- Uploads now embed a verifiable scope segment in the object path:
  - messages → `${conversationId}/…` (was flat `${uuid}-…`)
  - requests + reports → `${projectId}/…` (was `${ticketId}/…` and `reports/…`)
- Stored linking-row path == storage path, so the read-side policies keep matching and download/signed-url code is unchanged.
- New INSERT policies enforce the scope segment via conversation membership / `is_project_member`, with a numeric-segment guard so old non-numeric paths are rejected.
- Migration: `supabase/migrations/20260604000000_harden_storage_insert.sql`.
- Guards: message upload no-ops without a conversation id; `createRequest`/reports require an active project (fileless report still submits).

## ⚠️ DEPLOY ORDER
Apply `20260604000000_harden_storage_insert.sql` to live **only AFTER this frontend change is deployed to production** — the INSERT policy rejects old flat/`reports/` paths, so applying it while the old frontend is serving would break in-flight uploads. Existing stored files need no grace handling (policy governs new INSERTs only).

## Files
- `frontend/components/dashboard/messages/MessageThread.tsx`, `frontend/lib/supabase/requests.ts`, `frontend/components/dashboard/reports/NewReportModal.tsx`
- `supabase/migrations/20260603000000_harden_storage_rls.sql`, `supabase/migrations/20260604000000_harden_storage_insert.sql`