### PR TITLE
feat(dashboard): wire ProjectStatusBar to live lifecycle task counts

### DIFF
--- a/frontend/components/dashboard/common/ProjectStatusBar.tsx
+++ b/frontend/components/dashboard/common/ProjectStatusBar.tsx
@@ -1,15 +1,23 @@
-'use client';
+"use client";
 
-import { useEffect, useRef } from 'react';
-import gsap from 'gsap';
+import gsap from "gsap";
+import { useEffect, useMemo, useRef } from "react";
+import { countByStatus } from "@/app/dashboard/lifecycle/components/status-meta";
+import type { Task } from "@/app/dashboard/lifecycle/types";
+import { useLifecycleProjects } from "@/app/dashboard/lifecycle/use-lifecycle";
+import { useProject } from "@/lib/project/project-context";
 
 interface StatusIndicatorProps {
   label: string;
   value: string | number;
-  status?: 'active' | 'pending' | 'complete';
+  status?: "active" | "pending" | "complete";
 }
 
-export function StatusIndicator({ label, value, status = 'active' }: StatusIndicatorProps) {
+export function StatusIndicator({
+  label,
+  value,
+  status = "active",
+}: StatusIndicatorProps) {
   const indicatorRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -19,7 +27,7 @@ export function StatusIndicator({ label, value, status = 'active' }: StatusIndic
       gsap.fromTo(
         indicatorRef.current,
         { opacity: 0, y: 10 },
-        { opacity: 1, y: 0, duration: 0.6, ease: 'power2.out' }
+        { opacity: 1, y: 0, duration: 0.6, ease: "power2.out" },
       );
     });
 
@@ -27,18 +35,23 @@ export function StatusIndicator({ label, value, status = 'active' }: StatusIndic
   }, []);
 
   const statusColors = {
-    active: 'bg-sbi-green',
-    pending: 'bg-amber-500',
-    complete: 'bg-blue-400',
+    active: "bg-sbi-green",
+    pending: "bg-amber-500",
+    complete: "bg-blue-400",
   };
 
   return (
-    <div ref={indicatorRef} className="group flex items-center gap-3 px-4 py-2 cursor-default">
+    <div
+      ref={indicatorRef}
+      className="group flex items-center gap-3 px-4 py-2 cursor-default"
+    >
       {/* Status dot */}
       <div className="relative">
         <div className={`w-1.5 h-1.5 rounded-full ${statusColors[status]}`} />
-        {status === 'active' && (
-          <div className={`absolute inset-0 w-1.5 h-1.5 rounded-full ${statusColors[status]} animate-ping opacity-75`} />
+        {status === "active" && (
+          <div
+            className={`absolute inset-0 w-1.5 h-1.5 rounded-full ${statusColors[status]} animate-ping opacity-75`}
+          />
         )}
       </div>
 
@@ -58,14 +71,60 @@ export function StatusIndicator({ label, value, status = 'active' }: StatusIndic
   );
 }
 
+/**
+ * Status -> header-stat bucket mapping (DECIDED — adjust here if buckets change).
+ * `not_started` is intentionally excluded from every bucket.
+ *   Active Tasks  = in_progress + blocked
+ *   Under Review  = pending_approval
+ *   Completed     = completed
+ */
+function deriveHeaderStats(tasks: Task[]): {
+  active: number;
+  underReview: number;
+  completed: number;
+} {
+  const counts = countByStatus(tasks);
+  return {
+    active: counts.in_progress + counts.blocked,
+    underReview: counts.pending_approval,
+    completed: counts.completed,
+  };
+}
+
 export function ProjectStatusBar() {
+  const { activeProject } = useProject();
+
+  // Reuse the existing lifecycle query layer (RLS + project scoping included).
+  // Re-fetches whenever the active project changes via parentProjectId.
+  const { projects } = useLifecycleProjects({
+    parentProjectId: activeProject?.projectId,
+    demoMode: false,
+  });
+
+  const stats = useMemo(() => {
+    const tasks = projects.flatMap((p) => p.tasks);
+    return deriveHeaderStats(tasks);
+  }, [projects]);
+
   return (
     <div className="hidden md:flex items-center gap-1 border-l border-sbi-dark-border/30 ml-4">
-      <StatusIndicator label="Active Tasks" value={3} status="active" />
+      <StatusIndicator
+        label="Active Tasks"
+        value={stats.active}
+        status="active"
+      />
       <div className="w-px h-6 bg-sbi-dark-border/20" />
-      <StatusIndicator label="Under Review" value={2} status="pending" />
+      <StatusIndicator
+        label="Under Review"
+        value={stats.underReview}
+        status="pending"
+      />
       <div className="w-px h-6 bg-sbi-dark-border/20" />
-      <StatusIndicator label="Completed" value={12} status="complete" />
+      <StatusIndicator
+        label="Completed"
+        value={stats.completed}
+        status="complete"
+      />
     </div>
   );
 }


### PR DESCRIPTION
## What changed

The dashboard header `ProjectStatusBar` previously **hardcoded** its three stats
(Active Tasks=3, Under Review=2, Completed=12). It is now driven by real
`lifecycle_tasks` data for the active project.

`components/dashboard/common/ProjectStatusBar.tsx` is now a `"use client"`
component that:
- reads the active project via `useProject()` (`activeProject.projectId`),
- reuses the existing lifecycle query layer (`useLifecycleProjects` →
  `fetchProjects(parentProjectId)` in `app/dashboard/lifecycle/api.ts`), which
  is already RLS- and project-scoped (`lifecycle_projects.project_id` →
  `lifecycle_tasks.lifecycle_project_id`),
- flattens all tasks across the project's lifecycle projects and counts them
  with the existing `countByStatus()` helper from
  `app/dashboard/lifecycle/components/status-meta.ts`.

No new/parallel query layer was introduced — it relies entirely on the existing
lifecycle helpers and `lib/supabase/client.ts`. `app/dashboard/layout.tsx`
(a Server Component) was left unchanged.

## Status → bucket mapping (decided; defined as `deriveHeaderStats`)

`not_started` is intentionally excluded from every bucket.

| Header stat   | Counted statuses            |
|---------------|-----------------------------|
| Active Tasks  | `in_progress` + `blocked`   |
| Under Review  | `pending_approval`          |
| Completed     | `completed`                 |

The mapping lives in a single clearly-commented `deriveHeaderStats()` function
so it is easy to adjust later.

## Loading / empty handling

`useLifecycleProjects` initializes `projects` to `[]`, so during the initial
fetch and when a project has zero tasks the bar renders `0 / 0 / 0` with **no
layout shift** — the `StatusIndicator` visual design is untouched, only the
numbers are live. Zero tasks shows zeros, never an error. The query re-fetches
automatically when the active project changes (keyed on `parentProjectId`).

## Verification

- `npx tsc --noEmit` — clean (exit 0, 0 errors) after `next typegen`.
- `npx biome check components/dashboard/common/ProjectStatusBar.tsx` — clean
  (exit 0, formatted with `--write`).