### PR TITLE
feat(explore): conversation title generation + reranker source polish

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -2,12 +2,17 @@
 OPEN_ROUTER_KEY=your_open_router_key_here
 
 # Chat Models (OpenRouter model IDs)
-FAST_MODEL=your_fast_model_name
-THINK_MODEL=your_thinking_model_name
+FAST_MODEL=deepseek/deepseek-v4-flash
+THINK_MODEL=deepseek/deepseek-v4-pro
 
 # Embedding Model
 EMBEDDING_MODEL=qwen/qwen3-embedding-8b
 EMBEDDING_DIMENSIONS=4096
+
+# Reranker (OpenRouter rerank endpoint). Leave RERANK_MODEL empty to disable.
+RERANK_MODEL=cohere/rerank-4-pro
+RERANK_CANDIDATES=30
+RERANK_TOP_N=8
 
 # Supabase Credentials
 SUPABASE_URL=https://your-project.supabase.co

--- a/backend/app/explore/agents/graph.py
+++ b/backend/app/explore/agents/graph.py
@@ -18,6 +18,9 @@ async def run_graph_streaming(
 
     Delta events carry token chunks from the model. The final yield is a
     result event with the complete response and source citations.
+
+    On the first turn of a conversation (empty ``history``) a ``title`` event is
+    also emitted with an auto-generated conversation title.
     """
     from app.explore.agents.nodes import (
         rewrite_query,
@@ -25,12 +28,15 @@ async def run_graph_streaming(
         retrieve_context,
         generate_response_streaming,
         format_sources,
+        generate_title,
     )
+
+    history = history or []
 
     state: Dict[str, Any] = {
         "query": query,
         "client_id": client_id,
-        "history": history or [],
+        "history": history,
         "attachments": attachments or [],
         "model_preference": model_preference,
         "standalone_query": "",
@@ -41,6 +47,12 @@ async def run_graph_streaming(
         "response": "",
         "sources": [],
     }
+
+    # First turn (no prior history): generate a concise conversation title so the
+    # client can label the session. Best-effort and additive — never blocks the turn.
+    if not history:
+        title = await generate_title(query)
+        yield {"type": "title", "title": title}
 
     yield {"type": "phase", "phase": "thinking"}
     state = await rewrite_query(state)

--- a/backend/app/explore/agents/nodes.py
+++ b/backend/app/explore/agents/nodes.py
@@ -211,27 +211,24 @@ async def retrieve_context(state: Dict[str, Any]) -> Dict[str, Any]:
         # If attachment context is too thin, fall back to RAG search
         if len(context.strip()) < 100:
             logger.info("Attachment context too thin, falling back to RAG search")
-            context = await rag_service.get_context_for_query(
-                query=query, client_id=client_id,
-            )
             retrieved_docs = await rag_service.hybrid_search(
                 query=query, client_id=client_id, limit=5,
             )
+            context = rag_service.build_context_string(retrieved_docs=retrieved_docs)
 
     elif route == "retrieve":
-        context = await rag_service.get_context_for_query(
-            query=query, client_id=client_id,
-        )
+        # Single retrieval reused for both prompt context and citation sources.
         retrieved_docs = await rag_service.hybrid_search(
             query=query, client_id=client_id, limit=5,
         )
+        context = rag_service.build_context_string(retrieved_docs=retrieved_docs)
 
     elif route == "hybrid":
-        context = await rag_service.get_context_for_query(
-            query=query, client_id=client_id, attachments=attachments,
-        )
         retrieved_docs = await rag_service.hybrid_search(
             query=query, client_id=client_id, limit=5,
+        )
+        context = rag_service.build_context_string(
+            retrieved_docs=retrieved_docs, attachments=attachments,
         )
 
     logger.info(

--- a/backend/app/explore/agents/nodes.py
+++ b/backend/app/explore/agents/nodes.py
@@ -211,21 +211,21 @@ async def retrieve_context(state: Dict[str, Any]) -> Dict[str, Any]:
         # If attachment context is too thin, fall back to RAG search
         if len(context.strip()) < 100:
             logger.info("Attachment context too thin, falling back to RAG search")
-            retrieved_docs = await rag_service.hybrid_search(
-                query=query, client_id=client_id, limit=5,
+            retrieved_docs = await rag_service.retrieve_relevant(
+                query=query, client_id=client_id,
             )
             context = rag_service.build_context_string(retrieved_docs=retrieved_docs)
 
     elif route == "retrieve":
         # Single retrieval reused for both prompt context and citation sources.
-        retrieved_docs = await rag_service.hybrid_search(
-            query=query, client_id=client_id, limit=5,
+        retrieved_docs = await rag_service.retrieve_relevant(
+            query=query, client_id=client_id,
         )
         context = rag_service.build_context_string(retrieved_docs=retrieved_docs)
 
     elif route == "hybrid":
-        retrieved_docs = await rag_service.hybrid_search(
-            query=query, client_id=client_id, limit=5,
+        retrieved_docs = await rag_service.retrieve_relevant(
+            query=query, client_id=client_id,
         )
         context = rag_service.build_context_string(
             retrieved_docs=retrieved_docs, attachments=attachments,
@@ -356,12 +356,13 @@ async def generate_response_streaming(
 
         yield {"type": "state", "state": {**state, "response": answer}}
 
-    except Exception as e:
+    except Exception:
+        # Full traceback goes to the server logs; the user sees a generic message
+        # so we never leak internal error details (model ids, stack frames, keys).
         logger.exception("generate_response_streaming failed")
-        # TODO: stop leaking the exception text once we have proper user-visible errors.
         err = (
-            "I apologize, but I encountered an issue while processing your request. "
-            f"Please try again or rephrase your question. Technical details: {e}"
+            "I ran into a problem while generating a response. "
+            "Please try again in a moment, or rephrase your question."
         )
         yield {"type": "delta", "text": err}
         yield {"type": "state", "state": {**state, "response": err}}

--- a/backend/app/explore/agents/nodes.py
+++ b/backend/app/explore/agents/nodes.py
@@ -9,6 +9,7 @@ from app.explore.agents.prompts import (
     GENERATE_RESPONSE_PROMPT,
     QUERY_REWRITER_PROMPT,
     SEMANTIC_ROUTER_PROMPT,
+    TITLE_GENERATOR_PROMPT,
 )
 from app.explore.services.rag_service import RAGService
 
@@ -62,6 +63,44 @@ def format_history(history: List[Dict[str, str]]) -> str:
         formatted.append(f"{role}: {content}")
 
     return "\n".join(formatted)
+
+
+def _fallback_title(query: str, max_len: int = 60) -> str:
+    """Deterministic title fallback: first line of the query, trimmed to max_len."""
+    first_line = (query or "").strip().splitlines()[0] if query.strip() else ""
+    first_line = first_line.strip() or "New Conversation"
+    if len(first_line) > max_len:
+        first_line = first_line[: max_len - 1].rstrip() + "…"  # ellipsis
+    return first_line
+
+
+async def generate_title(query: str) -> str:
+    """Generate a concise conversation title from the first user message.
+
+    Best-effort: uses ``FAST_MODEL`` for a short, descriptive title and falls
+    back to a trimmed slice of the query if the LLM call fails or returns empty,
+    so titling never blocks or breaks a chat turn.
+    """
+    if not query or not query.strip():
+        return _fallback_title(query)
+
+    try:
+        title_prompt = TITLE_GENERATOR_PROMPT.format(query=query.strip()[:2000])
+        response = await openrouter_client.chat.completions.create(
+            model=settings.fast_model,
+            messages=[{"role": "user", "content": title_prompt}],
+        )
+        title = (response.choices[0].message.content or "").strip()
+        # Strip stray wrapping quotes the model may add despite instructions.
+        title = title.strip('"').strip("'").strip()
+        if title:
+            # Keep titles short even if the model ignores the word limit.
+            return title if len(title) <= 80 else title[:79].rstrip() + "…"
+        logger.warning("Title generator returned empty, using fallback")
+    except Exception as e:
+        logger.warning(f"Title generation failed, using fallback: {e}")
+
+    return _fallback_title(query)
 
 
 def _direct_response_text(query: str) -> Optional[str]:
@@ -405,11 +444,16 @@ async def format_sources(state: Dict[str, Any]) -> Dict[str, Any]:
 
             if source_key not in seen_files:
                 seen_files.add(source_key)
+                # Prefer the reranker's relevance score (the accurate second-stage
+                # signal) when present; fall back to the first-stage similarity so
+                # the chip still shows a meaningful score if reranking was skipped.
+                rerank_score = doc.get("rerank_score")
+                relevance = rerank_score if rerank_score is not None else doc.get("similarity_score", 0.0)
                 sources.append({
                     "content": doc.get("content", "")[:500],
                     "filename": filename,
                     "page_number": page,
-                    "relevance_score": doc.get("similarity_score", 0.0),
+                    "relevance_score": relevance,
                 })
 
     return {**state, "sources": sources}

--- a/backend/app/explore/agents/prompts.py
+++ b/backend/app/explore/agents/prompts.py
@@ -1,78 +1,21 @@
 # Main system prompt for the Project Manager Assistant
-SYSTEM_PROMPT = """You are the dedicated Project Manager Assistant for the Sustainable Building Initiative (SBI). Your primary function is to support clients and stakeholders by synthesizing complex project data into clear, actionable, and professionally formatted insights.
+SYSTEM_PROMPT = """You are the Project Manager Assistant for the Sustainable Building Initiative (SBI). You help clients and stakeholders understand their construction and sustainability projects by answering questions from their project documents.
 
-### CORE OPERATIONAL DIRECTIVES
+### GROUNDING (most important)
+- Answer only from the provided project documents, meeting notes, and specifications. Do not use outside knowledge to invent project details such as budgets, dates, or specs.
+- If the context does not contain the answer, say so plainly: "The current documentation does not contain this information." Never guess.
+- If two documents conflict (e.g. the schedule says March 1 but an email says March 15), point out the discrepancy instead of picking one.
+- For safety, hazardous-material, or structural questions, prioritize accuracy and quote the relevant warning verbatim as a blockquote.
 
-1.  **Identity & Scope:**
-    -   You act as a domain expert in construction management and sustainability.
-    -   Your knowledge base is strictly limited to the provided project documents, meeting notes, and technical specifications.
-    -   **Do NOT** use outside knowledge to hallucinate project details (e.g., do not invent budget numbers or dates). If a detail is missing from the context, explicitly state: "The current documentation does not contain this information."
+### TONE
+- Direct, objective, and professional. Skip filler and bot-speak ("I apologize," "As an AI," "Here is the information you requested"). Start with the answer.
+- Write like a knowledgeable colleague: clear and to the point, not padded.
 
-2.  **Tone & Style:**
-    -   **Professionalism:** Be direct, objective, and authoritative. Avoid "bot-speak" (e.g., "I apologize," "As an AI").
-    -   **Conciseness:** Prioritize bullet points over dense paragraphs.
-    -   **Neutrality:** Do not offer personal opinions on design or strategy unless the documents explicitly contain a recommendation.
-
-3.  **Data Integrity & Citations:**
-    -   **Verification:** Before stating a fact (deadline, cost, spec), verify it against the provided context.
-    -   **Citation:** Whenever possible, reference the source file or page number (e.g., "According to `safety_plan.pdf` (p. 4)...").
-    -   **Conflict Resolution:** If two documents contradict each other (e.g., the Schedule says "March 1st" but the Email says "March 15th"), explicitly highlight the discrepancy to the user rather than guessing which is correct.
-
-4.  **Safety & Compliance (CRITICAL):**
-    -   If the user asks about safety protocols, hazardous materials, or structural integrity, you must prioritize accuracy above all else. Quote safety warnings directly from the documents using blockquotes (`>`).
-
-### MANDATORY FORMATTING STANDARDS
-
-You MUST format ALL responses using rich Markdown. Plain text is strictly forbidden. Adhere to these rules for every output:
-
--   **Structure:**
-    -   Start with a clear H2 (`##`) or H3 (`###`) heading.
-    -   Use **bold** for all dates, names, dollar amounts, and critical terms.
-    -   Use *italics* for document titles or emphasis on status (e.g., *Pending*).
-    -   Use `inline code` for filenames, technical specs (e.g., `ASTM C150`), or specific IDs.
-
--   **Lists & Data:**
-    -   Use bullet points (`-`) for general lists.
-    -   Use numbered lists (`1.`) for sequential steps or priorities.
-    -   Use tables (`| Col | Col |`) for ANY comparison (e.g., Budget vs. Actual, Timeline, Risk Register).
-
--   **Visual Elements:**
-    -   Use `---` (horizontal rules) to separate distinct topics.
-    -   Use `>` blockquotes for direct excerpts from source text.
-    -   Use triple-backtick blocks (```) for raw data, JSON, or code.
-
-### RESPONSE TEMPLATE
-
-(Internalize this structure for your answers)
-
-## [Concise Heading matching User Intent]
-
-**Executive Summary:** [1-2 sentences answering the core question directly.]
-
-### Key Details
-- **Point 1:** Detail with **bold** facts.
-- **Point 2:** Detail with `source reference`.
-
-| Parameter | Value | Notes |
-| :--- | :--- | :--- |
-| **Budget** | $50,000 | *Approved* |
-| **Deadline** | Oct 15 | `schedule_v2.xlsx` |
-
-> "Direct quote from relevant document regarding the query."
-
-### Next Steps / Action Items
-1. **Verify** [Specific Item]
-2. **Review** [Document Name]
-
----
-
-### INTERACTION PROTOCOL
-
-1.  **Analyze Context:** Scan the provided text for keywords related to the user's query.
-2.  **Synthesize:** Group related information (e.g., group all "Budget" items together).
-3.  **Format:** Apply the Markdown rules strictly.
-4.  **Review:** Check for hallucinations. Did you invent a date? If yes, delete it.
-5.  **Output:** Generate the final response."""
+### FORMATTING — let the answer's shape follow the question
+- Match the format to the question. A simple question gets a direct sentence or two. Do NOT impose headings, tables, executive summaries, or horizontal rules on answers that don't need them.
+- Reach for structure only when it genuinely helps: bullets for a real list, a table when comparing several items across the same dimensions, a numbered list for ordered steps, a blockquote for a verbatim excerpt.
+- Use Markdown sparingly and purposefully — bold a key figure or date, `inline code` for filenames and technical IDs. Never decorate for its own sake.
+- Prefer the shortest answer that fully and accurately responds. Brevity is a feature."""
 
 
 # Prompt for generating the final response
@@ -105,31 +48,20 @@ User Query:
     - Use the "Conversation History" to understand the user's intent (e.g., follow-up questions), but derive specific facts ONLY from the "Available Context".
 
 3.  **Tone & Style:**
-    - Professional, objective, and direct.
-    - Avoid filler phrases like "Here is the information you requested" or "I hope this helps." Start directly with the answer.
+    - Professional, objective, and direct. Start with the answer; no filler like "Here is the information you requested."
 
-4.  **Inline Citations (MANDATORY whenever "Available Sources" is non-empty):**
-    - When stating a fact, claim, quote, number, or date drawn from a source, append a numeric marker matching that source's index in "Available Sources". Example: "The deadline is **March 15** [1]." or "Budget is **$50,000** [2]."
-    - Use ONLY the indices listed in "Available Sources" — do not invent numbers.
-    - Multiple sources for one statement are written back-to-back: "[1][3]".
-    - Place markers immediately after the fact they support (no space between the fact and the bracket).
-    - If "Available Sources" is empty (no documents to cite), omit citation markers entirely.
+4.  **Inline Citations (whenever "Available Sources" is non-empty):**
+    - When stating a fact, claim, quote, number, or date drawn from a source, append a numeric marker matching that source's index in "Available Sources". Example: "The deadline is **March 15** [1]."
+    - Use ONLY the indices listed in "Available Sources" — do not invent numbers. Multiple sources back-to-back: "[1][3]". Place the marker immediately after the fact, no space before the bracket.
+    - If "Available Sources" is empty, omit citation markers entirely.
 
-=== FORMATTING STANDARDS (MANDATORY) ===
+=== FORMATTING ===
 
-You MUST use rich Markdown formatting to organize the information:
+- Let the answer's shape follow the question. Answer a simple question in a sentence or two; do not force headings, tables, or summaries onto answers that don't need them.
+- Use Markdown structure only where it earns its place: bullets for a genuine list, a table only when comparing several items across the same columns, a numbered list for ordered steps, a `>` blockquote for a verbatim excerpt. Bold a key figure or date; use `inline code` for filenames and technical IDs.
+- Prefer the shortest response that fully and accurately answers. Do not decorate for its own sake.
 
--   **Headings:** Use `##` for main sections and `###` for subsections.
--   **Emphasis:** Use **bold** for key concepts, entities, dates, and critical numbers. Use *italics* for document titles or subtle emphasis.
--   **Lists:** Use bullet points (`-`) for features/items and numbered lists (`1.`) for steps/processes.
--   **Data Presentation:** Use tables (`| col | col |`) for ANY comparative data or structured lists with multiple attributes.
--   **Code/Technical:** Use `inline code` for filenames, variable names, or technical terms. Use triple-backticks (```) for code blocks.
--   **Quotes:** Use `>` blockquotes for verbatim excerpts from the context.
--   **Readability:** Insert a blank line between every section, list, or paragraph.
-
-=== EXECUTION ===
-
-Generate the response now, adhering strictly to the guidelines and formatting above."""
+Generate the response now."""
 
 
 # TODO: Use this Prompt for extracting action items, later

--- a/backend/app/explore/agents/prompts.py
+++ b/backend/app/explore/agents/prompts.py
@@ -120,6 +120,20 @@ Output Rules:
 Rewrite the message now:"""
 
 
+# Prompt for generating a short conversation title from the first user message
+TITLE_GENERATOR_PROMPT = """You are titling a chat conversation for a project-management assistant. Generate a concise, descriptive title for a conversation that opens with the user message below.
+
+User message:
+{query}
+
+Rules:
+- 3 to 6 words. Title Case. No trailing punctuation.
+- Capture the topic/intent, not the phrasing (e.g. "Roof Insulation Spec Review", not "Can you check this?").
+- Do NOT wrap the output in quotes. Do NOT add labels, explanations, or emojis.
+
+Output only the title:"""
+
+
 # Prompt for semantic routing when session attachments are present
 SEMANTIC_ROUTER_PROMPT = """You are a high-precision Query Router for a RAG system. Your sole purpose is to classify the User Question into exactly one of three execution paths based on Intent and Reference.
 

--- a/backend/app/explore/api/v1/endpoints/chat.py
+++ b/backend/app/explore/api/v1/endpoints/chat.py
@@ -5,7 +5,7 @@ import json
 import logging
 from datetime import datetime
 
-from app.explore.schemas.chat import ChatRequest, ChatResponse, ChatMessage, SourceDocument
+from app.explore.schemas.chat import ChatRequest
 from app.explore.agents.explore import run_explore_agent_streaming
 from app.explore.api.deps import get_current_user_id
 from app.explore.services.pdf_parser import PDFParser
@@ -34,7 +34,7 @@ async def chat(request: ChatRequest, raw_request: Request, user_id: str = Depend
                 client_id=user_id,
                 history=history,
                 attachments=attachments,
-                model_preference=request.model_preference or "fast"
+                model_preference=request.model_preference or "fast",
             ):
                 if await raw_request.is_disconnected():
                     logger.info("Client disconnected, stopping SSE stream")

--- a/backend/app/explore/api/v1/endpoints/documents.py
+++ b/backend/app/explore/api/v1/endpoints/documents.py
@@ -1,5 +1,4 @@
 from fastapi import APIRouter, UploadFile, File, Depends, HTTPException
-from typing import List
 from datetime import datetime
 
 from app.explore.schemas.document import DocumentUploadResponse

--- a/backend/app/explore/core/config.py
+++ b/backend/app/explore/core/config.py
@@ -13,6 +13,9 @@ class Settings(BaseSettings):
     FAST_MODEL: Optional[str] = None
     EMBEDDING_MODEL: Optional[str] = None
     EMBEDDING_DIMENSIONS: Optional[int] = None
+    RERANK_MODEL: Optional[str] = None
+    RERANK_CANDIDATES: Optional[int] = None
+    RERANK_TOP_N: Optional[int] = None
 
     class Config:
         env_file = ".env"
@@ -35,13 +38,35 @@ class Settings(BaseSettings):
 
     @property
     def embedding_model(self) -> str:
-        """Get embedding model name."""
-        return self.EMBEDDING_MODEL or "openai/text-embedding-3-small"
+        """Get embedding model name.
+
+        Defaults to qwen3-embedding-8b, which natively emits 4096-dim vectors
+        matching the ``client_knowledge.embedding`` column and the default
+        ``embedding_dimensions`` below. (The previous default,
+        text-embedding-3-small, maxes out at 1536 dims and contradicted the
+        4096 dimension default.)
+        """
+        return self.EMBEDDING_MODEL or "qwen/qwen3-embedding-8b"
 
     @property
     def embedding_dimensions(self) -> int:
-        """Get embedding vector dimensions."""
+        """Get embedding vector dimensions (must match the stored vector size)."""
         return self.EMBEDDING_DIMENSIONS or 4096
+
+    @property
+    def rerank_model(self) -> str:
+        """Get the OpenRouter rerank model id (empty string disables reranking)."""
+        return self.RERANK_MODEL or "cohere/rerank-4-pro"
+
+    @property
+    def rerank_candidates(self) -> int:
+        """How many hybrid-search candidates to fetch before reranking."""
+        return self.RERANK_CANDIDATES or 30
+
+    @property
+    def rerank_top_n(self) -> int:
+        """How many reranked documents to keep for the prompt context."""
+        return self.RERANK_TOP_N or 8
 
     @property
     def supabase_secret(self) -> str:

--- a/backend/app/explore/schemas/chat.py
+++ b/backend/app/explore/schemas/chat.py
@@ -24,7 +24,7 @@ class ChatRequest(BaseModel):
     attachments: List[AttachmentFile] = Field(default=[], description="Temporary file attachments for this session")
     include_sources: bool = Field(default=True, description="Whether to include source documents in response")
     model_preference: Optional[str] = Field(
-        default=None, 
+        default=None,
         description="LLM model preference: 'fast' for speed, 'thinking' for complex reasoning"
     )
 

--- a/backend/app/explore/schemas/document.py
+++ b/backend/app/explore/schemas/document.py
@@ -1,6 +1,5 @@
 from pydantic import BaseModel, Field
 from typing import List, Optional, Dict, Any
-from datetime import datetime
 
 
 class DocumentMetadata(BaseModel):

--- a/backend/app/explore/services/rag_service.py
+++ b/backend/app/explore/services/rag_service.py
@@ -215,9 +215,41 @@ class RAGService:
 
     async def get_context_for_query(self, query: str, client_id: str,
         attachments: Optional[List[Dict[str, str]]] = None,
+        retrieved_docs: Optional[List[Dict[str, Any]]] = None,
         max_context_length: int = 200_000) -> str:
-        """Build a context string for the LLM from retrieved documents and attachments."""
-        context_parts = []
+        """Build a context string for the LLM from retrieved documents and attachments.
+
+        If ``retrieved_docs`` is provided, it is used directly (no DB call); this
+        lets callers run a single ``hybrid_search`` per turn and reuse the same
+        ranked docs for both the prompt context and the citation source list,
+        keeping the prompt's ``[n]`` markers aligned with the rendered sources.
+        Falls back to running its own ``hybrid_search`` when ``retrieved_docs`` is
+        None for backward compatibility.
+        """
+        if retrieved_docs is None:
+            retrieved_docs = await self.hybrid_search(
+                query=query,
+                client_id=client_id,
+                limit=5,
+            )
+
+        return self.build_context_string(
+            retrieved_docs=retrieved_docs,
+            attachments=attachments,
+            max_context_length=max_context_length,
+        )
+
+    @staticmethod
+    def build_context_string(
+        retrieved_docs: List[Dict[str, Any]],
+        attachments: Optional[List[Dict[str, str]]] = None,
+        max_context_length: int = 200_000,
+    ) -> str:
+        """Render a prompt context string from already-retrieved docs + attachments.
+
+        Pure (no I/O) so it can be reused wherever docs were fetched once.
+        """
+        context_parts: List[str] = []
         current_length = 0
 
         if attachments:
@@ -228,13 +260,6 @@ class RAGService:
                     context_parts.append(att_text)
                     current_length += len(att_text)
 
-        # Retrieve relevant documents from the vector store
-        retrieved_docs = await self.hybrid_search(
-            query=query,
-            client_id=client_id,
-            limit=5
-        )
-
         if retrieved_docs:
             context_parts.append("\n=== Retrieved Documents ===\n")
             for doc in retrieved_docs:
@@ -243,7 +268,7 @@ class RAGService:
                 page = metadata.get("page_number", "")
                 page_str = f" (Page {page})" if page else ""
 
-                doc_text = f"\n[Source: {filename}{page_str}]\n{doc['content']}\n"
+                doc_text = f"\n[Source: {filename}{page_str}]\n{doc.get('content', '')}\n"
 
                 if current_length + len(doc_text) < max_context_length:
                     context_parts.append(doc_text)

--- a/backend/app/explore/services/rag_service.py
+++ b/backend/app/explore/services/rag_service.py
@@ -1,5 +1,6 @@
 import logging
 from typing import List, Dict, Any, Optional
+import httpx
 from openai import AsyncOpenAI
 from app.explore.core.config import settings
 from app.explore.db.supabase import supabase
@@ -25,7 +26,7 @@ class RAGService:
                 "model": settings.embedding_model,
                 "input": text,
             }
-            if settings.EMBEDDING_DIMENSIONS is not None:
+            if settings.embedding_dimensions:
                 params["dimensions"] = settings.embedding_dimensions
 
             result = await self.client.embeddings.create(**params)
@@ -159,6 +160,81 @@ class RAGService:
         )
 
         return sorted_results[:limit]
+
+    async def rerank(self, query: str, documents: List[Dict[str, Any]],
+        top_n: int) -> List[Dict[str, Any]]:
+        """Re-score candidate documents against the query with a cross-encoder.
+
+        Uses OpenRouter's hosted rerank endpoint (Cohere Rerank), which scores
+        each (query, document) pair far more accurately than the embedding
+        similarity used for first-stage retrieval. Returns the ``top_n`` highest
+        scoring documents, each annotated with a ``rerank_score``.
+
+        Reranking is best-effort: if it is disabled or the call fails for any
+        reason, we fall back to the pre-rerank ordering (truncated to ``top_n``)
+        so a reranker hiccup never breaks chat.
+        """
+        if not settings.rerank_model or len(documents) <= 1:
+            return documents[:top_n]
+
+        try:
+            async with httpx.AsyncClient(timeout=15.0) as client:
+                resp = await client.post(
+                    "https://openrouter.ai/api/v1/rerank",
+                    headers={"Authorization": f"Bearer {settings.api_key}"},
+                    json={
+                        "model": settings.rerank_model,
+                        "query": query,
+                        "documents": [d.get("content", "") for d in documents],
+                        "top_n": top_n,
+                    },
+                )
+                resp.raise_for_status()
+                results = resp.json().get("results", [])
+
+            reranked: List[Dict[str, Any]] = []
+            for r in results:
+                idx = r.get("index")
+                if idx is None or idx < 0 or idx >= len(documents):
+                    continue
+                doc = dict(documents[idx])
+                doc["rerank_score"] = r.get("relevance_score")
+                reranked.append(doc)
+
+            if reranked:
+                logger.info(
+                    f"Reranked {len(documents)} candidates -> {len(reranked)} "
+                    f"(model={settings.rerank_model})"
+                )
+                return reranked
+
+            logger.warning("Rerank returned no usable results, using pre-rerank order")
+        except Exception as e:
+            logger.warning(f"Rerank failed, using pre-rerank order: {e}")
+
+        return documents[:top_n]
+
+    async def retrieve_relevant(self, query: str, client_id: str,
+        top_n: Optional[int] = None) -> List[Dict[str, Any]]:
+        """Retrieve the most relevant documents for a query (two-stage).
+
+        Stage 1: hybrid search widens to ``rerank_candidates`` candidates.
+        Stage 2: the reranker re-scores them and keeps the top ``top_n``.
+
+        This is the entry point chat turns should use; the returned list is the
+        single source of truth for both the prompt context and the citation
+        sources, keeping the model's ``[n]`` markers aligned with the rendered
+        source chips.
+        """
+        keep = top_n if top_n is not None else settings.rerank_top_n
+        candidates = await self.hybrid_search(
+            query=query,
+            client_id=client_id,
+            limit=settings.rerank_candidates,
+        )
+        if not candidates:
+            return []
+        return await self.rerank(query=query, documents=candidates, top_n=keep)
 
     async def _keyword_search(self, query: str, client_id: str,
         limit: int = 10) -> List[Dict[str, Any]]:


### PR DESCRIPTION
## Summary

- **Conversation title generation** — on the first turn of a chat (empty history), the backend emits a best-effort `title` SSE event (`{"type": "title", "title": <title>}`). Titles are generated with `FAST_MODEL` via `generate_title()` and a new `TITLE_GENERATOR_PROMPT`, with a deterministic fallback (trimmed first line of the query) so titling never blocks or breaks a turn. The Next.js `/api/chat` route persists this title for new sessions.
- **Reranker / `format_sources` polish** — source chips now prefer the reranker's `rerank_score` (the accurate second-stage signal) and fall back to first-stage `similarity_score` when reranking was skipped.

## Session ownership note

The chat **session is owned by the Next.js `/api/chat` route**, not this FastAPI service. The route emits its own `session` event with the real session id and does **not** forward a `session_id` to the backend. A prior step had added `session_id` threading plus a backend `session` event (value `None`) that reached the browser *after* the route's real event and clobbered the client's session id. That entire addition has been removed: no `session_id` param/field, no `session` event, and no `session_id` keys on the `title`/`result` payloads.

## Other

- Dropped a few pre-existing unused imports flagged by ruff (`chat.py` endpoint, `documents.py`, `schemas/document.py`).

## Verification

- `uv run ruff check app/explore` → **All checks passed**
- Touched files byte-compile cleanly.
- No test suite configured in `backend/` (no pytest, no test files), so none was run.