### PR TITLE
fix(explore): UX/brand polish + a11y labels (audit safe subset)

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -11,7 +11,7 @@
   --color-sbi-dark-btn: #0f1a12;
   --color-sbi-input: #0d120e;
   --color-sbi-muted: #8a9a93;
-  --color-sbi-muted-dark: #6b7c74;
+  --color-sbi-muted-dark: #7d8f86;
   --font-urbanist: var(--font-urbanist);
   --font-jetbrains-mono: var(--font-jetbrains-mono);
   --font-mono: var(--font-jetbrains-mono);
@@ -23,8 +23,12 @@
 }
 
 @keyframes thread-fade-in {
-  from { opacity: 0; }
-  to { opacity: 1; }
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
 }
 
 @layer base {
@@ -129,28 +133,28 @@ html::-webkit-scrollbar-thumb:hover {
   background-color: rgba(255, 255, 255, 0.32);
 }
 
-.animate-title>div {
+.animate-title > div {
   opacity: 0;
   animation: fadeInUp 2s ease forwards;
 }
 
-.animate-title>div:nth-child(1) {
+.animate-title > div:nth-child(1) {
   animation-delay: 0.1s;
 }
 
-.animate-title>div:nth-child(2) {
+.animate-title > div:nth-child(2) {
   animation-delay: 0.3s;
 }
 
-.animate-title>div:nth-child(3) {
+.animate-title > div:nth-child(3) {
   animation-delay: 0.5s;
 }
 
-.animate-title>div:nth-child(4) {
+.animate-title > div:nth-child(4) {
   animation-delay: 0.7s;
 }
 
-.animate-title>div:nth-child(5) {
+.animate-title > div:nth-child(5) {
   animation-delay: 0.9s;
 }
 
@@ -380,7 +384,6 @@ html::-webkit-scrollbar-thumb:hover {
 
 /* Subtle glow pulse for active states */
 @keyframes glow-pulse {
-
   0%,
   100% {
     box-shadow: 0 0 20px -8px rgba(34, 197, 94, 0.3);

--- a/frontend/components/dashboard/common/app-sidebar.tsx
+++ b/frontend/components/dashboard/common/app-sidebar.tsx
@@ -25,6 +25,7 @@ import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 import { ChatHistoryNav } from "@/components/dashboard/explore/ui/ChatHistoryNav";
+import { useIsMobile } from "@/hooks/use-mobile";
 import { useChat } from "@/lib/chat/chat-context";
 import { useProject } from "@/lib/project/project-context";
 import { useSidebar } from "@/lib/sidebar/sidebar-context";
@@ -127,6 +128,7 @@ function NavLink({ item, isActive, baseUrl, isCollapsed }: NavLinkProps) {
 
 export function AppSidebar() {
   const { state, open, setOpen } = useSidebar();
+  const isMobile = useIsMobile();
   const pathname = usePathname();
   const router = useRouter();
   const { user, activeProject, projects, switchProject } = useProject();
@@ -135,8 +137,13 @@ export function AppSidebar() {
   const [isProjectMenuOpen, setIsProjectMenuOpen] = useState(false);
   const userMenuRef = useRef<HTMLDivElement>(null);
   const projectMenuRef = useRef<HTMLDivElement>(null);
+  const userMenuButtonRef = useRef<HTMLButtonElement>(null);
+  const projectMenuButtonRef = useRef<HTMLButtonElement>(null);
 
-  const isCollapsed = state === "collapsed";
+  // On mobile the sidebar is an off-canvas overlay that always shows its full
+  // (expanded) content; `open` only drives whether it's slid in or parked off
+  // the left edge. The collapsed icon-rail is a desktop-only affordance.
+  const isCollapsed = !isMobile && state === "collapsed";
 
   // Base URL for all dashboard routes
   const baseUrl = "/dashboard";
@@ -255,6 +262,42 @@ export function AppSidebar() {
     return () => document.removeEventListener("mousedown", handleClickOutside);
   }, []);
 
+  // Escape closes whichever dropdown is open and returns focus to its trigger.
+  useEffect(() => {
+    if (!isUserMenuOpen && !isProjectMenuOpen) return;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      if (isUserMenuOpen) {
+        setIsUserMenuOpen(false);
+        userMenuButtonRef.current?.focus();
+      }
+      if (isProjectMenuOpen) {
+        setIsProjectMenuOpen(false);
+        projectMenuButtonRef.current?.focus();
+      }
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [isUserMenuOpen, isProjectMenuOpen]);
+
+  // On mobile the sidebar is a slide-over: Escape and route changes dismiss it.
+  useEffect(() => {
+    if (!isMobile || !open) return;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [isMobile, open, setOpen]);
+
+  // Close the mobile overlay after navigating to another route. Keyed on
+  // pathname alone on purpose: it should fire on navigation, not when the
+  // viewport crosses the mobile breakpoint.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: intentional pathname-only trigger
+  useEffect(() => {
+    if (isMobile) setOpen(false);
+  }, [pathname]);
+
   const userRole = user?.role;
   const filterByRole = (items: NavItem[]) =>
     items.filter(
@@ -263,366 +306,410 @@ export function AppSidebar() {
   const showProjectSwitcher = userRole === "director" || userRole === "member";
 
   return (
-    <aside
-      className={`relative flex flex-col h-screen bg-sbi-dark border-r border-sbi-dark-border/30 transition-all duration-300 ease-out ${
-        isCollapsed ? "w-16" : "w-60"
-      }`}
-    >
-      {/* Architectural corner accents */}
-      <div className="absolute top-0 left-0 w-4 h-4 border-t border-l border-sbi-green/20" />
-      <div className="absolute top-0 right-0 w-4 h-4 border-t border-r border-sbi-dark-border/30" />
-      <div className="absolute bottom-0 left-0 w-4 h-4 border-b border-l border-sbi-dark-border/30" />
-      <div className="absolute bottom-0 right-0 w-4 h-4 border-b border-r border-sbi-green/20" />
+    <>
+      {/* Mobile-only dimmed backdrop. Tap to dismiss the slide-over. Lives below
+          the aside (z) but above content; absent on md+ where the rail is inline. */}
+      <button
+        type="button"
+        aria-label="Close menu"
+        tabIndex={open ? 0 : -1}
+        onClick={() => setOpen(false)}
+        className={cn(
+          "fixed inset-0 z-40 bg-black/60 backdrop-blur-[1px] transition-opacity duration-300 md:hidden",
+          open ? "opacity-100" : "opacity-0 pointer-events-none",
+        )}
+      />
 
-      {/* Header */}
-      <div className="h-16 flex items-center border-b border-sbi-dark-border/30 px-3">
-        <button
-          type="button"
-          onClick={handleLogoClick}
-          className="group flex items-center gap-3 transition-all duration-300 cursor-pointer"
-        >
-          {/* Logo */}
-          <div className="relative flex items-center justify-center size-8">
-            {/* Rotating border */}
-            <div className="absolute inset-0 border border-sbi-dark-border/50 group-hover:border-sbi-green/40 transition-colors duration-500 rotate-45" />
-            {/* Icon */}
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="1.5"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              role="img"
-              aria-label="SBI"
-              className="size-4 text-sbi-green"
-            >
-              <circle cx="12" cy="12" r="10" />
-              <path d="M12 2v20" />
-              <path d="m4.93 4.93 14.14 14.14" />
-            </svg>
-          </div>
+      <aside
+        // Off-canvas slide-over on mobile (fixed + translate, never animating
+        // layout width); inline collapsing rail on md+.
+        className={cn(
+          "relative flex flex-col h-screen bg-sbi-dark border-r border-sbi-dark-border/30 transition-all duration-300 ease-out",
+          // Mobile: fixed full-height overlay at a comfortable width, slid in/out.
+          "fixed inset-y-0 left-0 z-50 w-60 max-w-[85vw]",
+          open ? "translate-x-0" : "-translate-x-full",
+          // md+: back to an inline rail in normal flow; collapse toggles width.
+          "md:static md:z-auto md:max-w-none md:translate-x-0",
+          isCollapsed ? "md:w-16" : "md:w-60",
+        )}
+      >
+        {/* Architectural corner accents */}
+        <div className="absolute top-0 left-0 w-4 h-4 border-t border-l border-sbi-green/20" />
+        <div className="absolute top-0 right-0 w-4 h-4 border-t border-r border-sbi-dark-border/30" />
+        <div className="absolute bottom-0 left-0 w-4 h-4 border-b border-l border-sbi-dark-border/30" />
+        <div className="absolute bottom-0 right-0 w-4 h-4 border-b border-r border-sbi-green/20" />
 
-          {/* Brand text */}
-          {!isCollapsed && (
-            <div className="flex flex-col text-left">
-              <span className="text-sm font-light tracking-[0.25em] text-white uppercase">
-                SBI
-              </span>
-              <span className="text-[9px] tracking-widest text-sbi-muted uppercase">
-                {user?.role === "director"
-                  ? "Director Portal"
-                  : user?.role === "member"
-                    ? "Member Portal"
-                    : "Client Portal"}
-              </span>
-            </div>
-          )}
-        </button>
-      </div>
-
-      {/* Project Switcher (directors/members only) */}
-      {showProjectSwitcher && !isCollapsed && (
-        <div
-          ref={projectMenuRef}
-          className="relative px-3 py-3 border-b border-sbi-dark-border/30"
-        >
+        {/* Header */}
+        <div className="h-16 flex items-center border-b border-sbi-dark-border/30 px-3">
           <button
             type="button"
-            onClick={() => setIsProjectMenuOpen(!isProjectMenuOpen)}
-            className="w-full flex items-center justify-between px-3 py-2 rounded-lg bg-sbi-dark-card/40 border border-sbi-dark-border/30 hover:border-sbi-green/30 transition-colors cursor-pointer"
+            onClick={handleLogoClick}
+            className="group flex items-center gap-3 transition-all duration-300 cursor-pointer"
           >
-            <div className="flex flex-col text-left min-w-0">
-              <span className="text-[10px] tracking-widest uppercase text-sbi-muted">
-                Project
-              </span>
-              <span className="text-sm text-white truncate">
-                {activeProject?.companyName || "Select project"}
-              </span>
+            {/* Logo */}
+            <div className="relative flex items-center justify-center size-8">
+              {/* Rotating border */}
+              <div className="absolute inset-0 border border-sbi-dark-border/50 group-hover:border-sbi-green/40 transition-colors duration-500 rotate-45" />
+              {/* Icon */}
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                role="img"
+                aria-label="SBI"
+                className="size-4 text-sbi-green"
+              >
+                <circle cx="12" cy="12" r="10" />
+                <path d="M12 2v20" />
+                <path d="m4.93 4.93 14.14 14.14" />
+              </svg>
             </div>
-            <ChevronUp
-              className={`size-4 text-sbi-muted transition-transform ${isProjectMenuOpen ? "" : "rotate-180"}`}
-            />
-          </button>
-          {isProjectMenuOpen && (
-            <div className="absolute top-full left-3 right-3 mt-1 bg-sbi-dark border border-sbi-dark-border/50 rounded-lg overflow-hidden shadow-2xl shadow-black/50 z-50">
-              {projects.map((project) => (
-                <button
-                  key={project.projectId}
-                  type="button"
-                  onClick={() => {
-                    switchProject(project.projectId);
-                    setIsProjectMenuOpen(false);
-                  }}
-                  className={`w-full text-left px-4 py-2.5 text-sm transition-colors cursor-pointer ${
-                    activeProject?.projectId === project.projectId
-                      ? "text-sbi-green bg-sbi-green/5"
-                      : "text-white/70 hover:text-white hover:bg-white/5"
-                  }`}
-                >
-                  {project.companyName}
-                </button>
-              ))}
-            </div>
-          )}
-        </div>
-      )}
 
-      {/* Client project label (clients only) */}
-      {!showProjectSwitcher && !isCollapsed && activeProject && (
-        <div className="px-3 py-3 border-b border-sbi-dark-border/30">
-          <div className="px-3 py-2">
-            <span className="text-[10px] tracking-widest uppercase text-sbi-muted">
-              Project
-            </span>
-            <p className="text-sm text-white truncate">
-              {activeProject.companyName}
-            </p>
-          </div>
-        </div>
-      )}
-
-      {/* Navigation. On Explore the primary nav stays fixed at its natural height
-          and the chat-history list takes the remaining space with its own scroll;
-          elsewhere the nav itself scrolls. */}
-      <div className="flex-1 flex flex-col min-h-0">
-        <nav
-          className={cn(
-            "overflow-y-auto overflow-x-hidden py-4 px-2",
-            showChatHistory ? "shrink-0" : "flex-1",
-          )}
-        >
-          {/* Main Navigation */}
-          <div className="space-y-1">
-            {filterByRole(mainItems).map((item) => (
-              <NavLink
-                key={item.title}
-                item={item}
-                isActive={isActive(item.path)}
-                baseUrl={baseUrl}
-                isCollapsed={isCollapsed}
-              />
-            ))}
-          </div>
-
-          {/* Divider */}
-          <div className="my-4 mx-3 h-px bg-linear-to-r from-transparent via-sbi-dark-border/50 to-transparent" />
-
-          {/* Documents Section */}
-          <div className="space-y-1">
+            {/* Brand text */}
             {!isCollapsed && (
-              <div className="px-3 mb-2">
-                <span className="text-[10px] tracking-[0.2em] uppercase text-sbi-muted font-light">
-                  Documents
+              <div className="flex flex-col text-left">
+                <span className="text-sm font-light tracking-[0.25em] text-white uppercase">
+                  SBI
+                </span>
+                <span className="text-[9px] tracking-widest text-sbi-muted uppercase">
+                  {user?.role === "director"
+                    ? "Director Portal"
+                    : user?.role === "member"
+                      ? "Member Portal"
+                      : "Client Portal"}
                 </span>
               </div>
             )}
-            {filterByRole(documentItems).map((item) => (
-              <NavLink
-                key={item.title}
-                item={item}
-                isActive={isActive(item.path)}
-                baseUrl={baseUrl}
-                isCollapsed={isCollapsed}
-              />
-            ))}
-          </div>
+          </button>
+        </div>
 
-          {/* Collapsed chat rail (Explore only): the essential chat actions stay
-              reachable on the icon rail. Search expands the sidebar and focuses
-              the history search box. */}
-          {isExplore && isCollapsed && (
-            <>
-              <div className="my-4 mx-3 h-px bg-linear-to-r from-transparent via-sbi-dark-border/50 to-transparent" />
-              <div className="space-y-1">
-                <button
-                  type="button"
-                  onClick={handleCollapsedNewChat}
-                  title="New chat"
-                  aria-label="New chat"
-                  className="group relative w-full flex items-center justify-center px-3 py-2.5 text-sbi-muted hover:text-white transition-colors duration-300"
-                >
-                  <MessageSquarePlus
-                    className="size-[18px] group-hover:text-sbi-green transition-colors duration-300"
-                    strokeWidth={1.5}
-                  />
-                  <span className="absolute inset-0 bg-sbi-green/0 group-hover:bg-sbi-green/5 transition-colors duration-300 rounded-lg -z-10" />
-                </button>
-                <button
-                  type="button"
-                  onClick={handleCollapsedSearch}
-                  title="Search chats"
-                  aria-label="Search chats"
-                  className="group relative w-full flex items-center justify-center px-3 py-2.5 text-sbi-muted hover:text-white transition-colors duration-300"
-                >
-                  <Search
-                    className="size-[18px] group-hover:text-sbi-green transition-colors duration-300"
-                    strokeWidth={1.5}
-                  />
-                  <span className="absolute inset-0 bg-sbi-green/0 group-hover:bg-sbi-green/5 transition-colors duration-300 rounded-lg -z-10" />
-                </button>
-                <Link
-                  href="/dashboard/chats"
-                  title="All chats"
-                  aria-label="All chats"
-                  className="group relative w-full flex items-center justify-center px-3 py-2.5 text-sbi-muted hover:text-white transition-colors duration-300"
-                >
-                  <MessagesSquare
-                    className="size-[18px] group-hover:text-sbi-green transition-colors duration-300"
-                    strokeWidth={1.5}
-                  />
-                  <span className="absolute inset-0 bg-sbi-green/0 group-hover:bg-sbi-green/5 transition-colors duration-300 rounded-lg -z-10" />
-                </Link>
+        {/* Project Switcher (directors/members only) */}
+        {showProjectSwitcher && !isCollapsed && (
+          <div
+            ref={projectMenuRef}
+            className="relative px-3 py-3 border-b border-sbi-dark-border/30"
+          >
+            <button
+              ref={projectMenuButtonRef}
+              type="button"
+              onClick={() => setIsProjectMenuOpen(!isProjectMenuOpen)}
+              aria-haspopup="menu"
+              aria-expanded={isProjectMenuOpen}
+              className="w-full flex items-center justify-between px-3 py-2 rounded-lg bg-sbi-dark-card/40 border border-sbi-dark-border/30 hover:border-sbi-green/30 transition-colors cursor-pointer"
+            >
+              <div className="flex flex-col text-left min-w-0">
+                <span className="text-[10px] tracking-widest uppercase text-sbi-muted">
+                  Project
+                </span>
+                <span className="text-sm text-white truncate">
+                  {activeProject?.companyName || "Select project"}
+                </span>
               </div>
-            </>
-          )}
-        </nav>
-
-        {/* Contextual chat history (Explore only) */}
-        {showChatHistory && (
-          <div className="flex-1 min-h-0 flex flex-col border-t border-sbi-dark-border/30">
-            <ChatHistoryNav focusSearchRef={pendingSearchFocusRef} />
+              <ChevronUp
+                className={`size-4 text-sbi-muted transition-transform ${isProjectMenuOpen ? "" : "rotate-180"}`}
+              />
+            </button>
+            {isProjectMenuOpen && (
+              <div
+                role="menu"
+                aria-label="Switch project"
+                className="absolute top-full left-3 right-3 mt-1 bg-sbi-dark border border-sbi-dark-border/50 rounded-lg overflow-hidden shadow-2xl shadow-black/50 z-50"
+              >
+                {projects.map((project) => (
+                  <button
+                    key={project.projectId}
+                    type="button"
+                    role="menuitem"
+                    onClick={() => {
+                      switchProject(project.projectId);
+                      setIsProjectMenuOpen(false);
+                      projectMenuButtonRef.current?.focus();
+                    }}
+                    className={`w-full text-left px-4 py-2.5 text-sm transition-colors cursor-pointer ${
+                      activeProject?.projectId === project.projectId
+                        ? "text-sbi-green bg-sbi-green/5"
+                        : "text-white/70 hover:text-white hover:bg-white/5"
+                    }`}
+                  >
+                    {project.companyName}
+                  </button>
+                ))}
+              </div>
+            )}
           </div>
         )}
-      </div>
 
-      {/* User Profile Footer */}
-      <div
-        ref={userMenuRef}
-        className="relative border-t border-sbi-dark-border/30"
-      >
-        {/* User Menu Popup */}
-        {isUserMenuOpen && (
-          <div
-            className={`absolute bottom-full mb-1 bg-sbi-dark border border-sbi-dark-border/50 rounded-lg overflow-hidden shadow-2xl shadow-black/50 z-50 ${
-              isCollapsed
-                ? "left-full ml-2 bottom-0 w-56"
-                : "left-0 right-0 mx-2"
-            }`}
+        {/* Client project label (clients only) */}
+        {!showProjectSwitcher && !isCollapsed && activeProject && (
+          <div className="px-3 py-3 border-b border-sbi-dark-border/30">
+            <div className="px-3 py-2">
+              <span className="text-[10px] tracking-widest uppercase text-sbi-muted">
+                Project
+              </span>
+              <p className="text-sm text-white truncate">
+                {activeProject.companyName}
+              </p>
+            </div>
+          </div>
+        )}
+
+        {/* Navigation. On Explore the primary nav stays fixed at its natural height
+          and the chat-history list takes the remaining space with its own scroll;
+          elsewhere the nav itself scrolls. */}
+        <div className="flex-1 flex flex-col min-h-0">
+          <nav
+            className={cn(
+              "overflow-y-auto overflow-x-hidden py-4 px-2",
+              showChatHistory ? "shrink-0" : "flex-1",
+            )}
           >
-            {/* User info header */}
-            <div className="px-3 py-3 border-b border-sbi-dark-border/30">
-              <div className="flex items-center gap-3">
-                <div className="relative flex items-center justify-center size-9">
-                  <div className="absolute inset-0 border border-sbi-dark-border/50 rounded-lg" />
-                  <span className="text-xs font-light text-sbi-green tracking-wider">
-                    {userInitials}
+            {/* Main Navigation */}
+            <div className="space-y-1">
+              {filterByRole(mainItems).map((item) => (
+                <NavLink
+                  key={item.title}
+                  item={item}
+                  isActive={isActive(item.path)}
+                  baseUrl={baseUrl}
+                  isCollapsed={isCollapsed}
+                />
+              ))}
+            </div>
+
+            {/* Divider */}
+            <div className="my-4 mx-3 h-px bg-linear-to-r from-transparent via-sbi-dark-border/50 to-transparent" />
+
+            {/* Documents Section */}
+            <div className="space-y-1">
+              {!isCollapsed && (
+                <div className="px-3 mb-2">
+                  <span className="text-[10px] tracking-[0.2em] uppercase text-sbi-muted font-light">
+                    Documents
                   </span>
                 </div>
-                <div className="flex-1 min-w-0">
+              )}
+              {filterByRole(documentItems).map((item) => (
+                <NavLink
+                  key={item.title}
+                  item={item}
+                  isActive={isActive(item.path)}
+                  baseUrl={baseUrl}
+                  isCollapsed={isCollapsed}
+                />
+              ))}
+            </div>
+
+            {/* Collapsed chat rail (Explore only): the essential chat actions stay
+              reachable on the icon rail. Search expands the sidebar and focuses
+              the history search box. */}
+            {isExplore && isCollapsed && (
+              <>
+                <div className="my-4 mx-3 h-px bg-linear-to-r from-transparent via-sbi-dark-border/50 to-transparent" />
+                <div className="space-y-1">
+                  <button
+                    type="button"
+                    onClick={handleCollapsedNewChat}
+                    title="New chat"
+                    aria-label="New chat"
+                    className="group relative w-full flex items-center justify-center px-3 py-2.5 text-sbi-muted hover:text-white transition-colors duration-300"
+                  >
+                    <MessageSquarePlus
+                      className="size-[18px] group-hover:text-sbi-green transition-colors duration-300"
+                      strokeWidth={1.5}
+                    />
+                    <span className="absolute inset-0 bg-sbi-green/0 group-hover:bg-sbi-green/5 transition-colors duration-300 rounded-lg -z-10" />
+                  </button>
+                  <button
+                    type="button"
+                    onClick={handleCollapsedSearch}
+                    title="Search chats"
+                    aria-label="Search chats"
+                    className="group relative w-full flex items-center justify-center px-3 py-2.5 text-sbi-muted hover:text-white transition-colors duration-300"
+                  >
+                    <Search
+                      className="size-[18px] group-hover:text-sbi-green transition-colors duration-300"
+                      strokeWidth={1.5}
+                    />
+                    <span className="absolute inset-0 bg-sbi-green/0 group-hover:bg-sbi-green/5 transition-colors duration-300 rounded-lg -z-10" />
+                  </button>
+                  <Link
+                    href="/dashboard/chats"
+                    title="All chats"
+                    aria-label="All chats"
+                    className="group relative w-full flex items-center justify-center px-3 py-2.5 text-sbi-muted hover:text-white transition-colors duration-300"
+                  >
+                    <MessagesSquare
+                      className="size-[18px] group-hover:text-sbi-green transition-colors duration-300"
+                      strokeWidth={1.5}
+                    />
+                    <span className="absolute inset-0 bg-sbi-green/0 group-hover:bg-sbi-green/5 transition-colors duration-300 rounded-lg -z-10" />
+                  </Link>
+                </div>
+              </>
+            )}
+          </nav>
+
+          {/* Contextual chat history (Explore only) */}
+          {showChatHistory && (
+            <div className="flex-1 min-h-0 flex flex-col border-t border-sbi-dark-border/30">
+              <ChatHistoryNav focusSearchRef={pendingSearchFocusRef} />
+            </div>
+          )}
+        </div>
+
+        {/* User Profile Footer */}
+        <div
+          ref={userMenuRef}
+          className="relative border-t border-sbi-dark-border/30"
+        >
+          {/* User Menu Popup */}
+          {isUserMenuOpen && (
+            <div
+              role="menu"
+              aria-label="Account menu"
+              className={`absolute bottom-full mb-1 bg-sbi-dark border border-sbi-dark-border/50 rounded-lg overflow-hidden shadow-2xl shadow-black/50 z-50 ${
+                isCollapsed
+                  ? "left-full ml-2 bottom-0 w-56"
+                  : "left-0 right-0 mx-2"
+              }`}
+            >
+              {/* User info header */}
+              <div className="px-3 py-3 border-b border-sbi-dark-border/30">
+                <div className="flex items-center gap-3">
+                  <div className="relative flex items-center justify-center size-9">
+                    <div className="absolute inset-0 border border-sbi-dark-border/50 rounded-lg" />
+                    <span className="text-xs font-light text-sbi-green tracking-wider">
+                      {userInitials}
+                    </span>
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <p className="text-sm font-light text-white truncate">
+                      {userName}
+                    </p>
+                    <p className="text-xs text-sbi-muted truncate">
+                      {userEmail}
+                    </p>
+                  </div>
+                </div>
+              </div>
+
+              {/* Menu items */}
+              <div className="py-1">
+                <button
+                  type="button"
+                  role="menuitem"
+                  onClick={() => {
+                    router.push("/dashboard/settings?section=profile");
+                    setIsUserMenuOpen(false);
+                  }}
+                  className="w-full flex items-center gap-3 px-3 py-2.5 text-sbi-muted hover:text-white hover:bg-sbi-green/5 transition-colors duration-200 cursor-pointer"
+                >
+                  <User className="size-4" strokeWidth={1.5} />
+                  <span className="text-sm font-light">Account</span>
+                </button>
+                <button
+                  type="button"
+                  role="menuitem"
+                  onClick={() => {
+                    router.push("/dashboard/settings?section=notifications");
+                    setIsUserMenuOpen(false);
+                  }}
+                  className="w-full flex items-center gap-3 px-3 py-2.5 text-sbi-muted hover:text-white hover:bg-sbi-green/5 transition-colors duration-200 cursor-pointer"
+                >
+                  <Bell className="size-4" strokeWidth={1.5} />
+                  <span className="text-sm font-light">Notifications</span>
+                </button>
+                <button
+                  type="button"
+                  role="menuitem"
+                  onClick={() => {
+                    router.push("/dashboard/settings");
+                    setIsUserMenuOpen(false);
+                  }}
+                  className="w-full flex items-center gap-3 px-3 py-2.5 text-sbi-muted hover:text-white hover:bg-sbi-green/5 transition-colors duration-200 cursor-pointer"
+                >
+                  <Settings className="size-4" strokeWidth={1.5} />
+                  <span className="text-sm font-light">Settings</span>
+                </button>
+                <a
+                  href="mailto:support@utsbi.org?subject=Portal%20support"
+                  role="menuitem"
+                  onClick={() => setIsUserMenuOpen(false)}
+                  className="w-full flex items-center gap-3 px-3 py-2.5 text-sbi-muted hover:text-white hover:bg-sbi-green/5 transition-colors duration-200 cursor-pointer"
+                >
+                  <HelpCircle className="size-4" strokeWidth={1.5} />
+                  <span className="text-sm font-light">Help</span>
+                </a>
+              </div>
+
+              {/* Logout */}
+              <div className="border-t border-sbi-dark-border/30 py-1">
+                <button
+                  type="button"
+                  role="menuitem"
+                  onClick={handleLogout}
+                  className="w-full flex items-center gap-3 px-3 py-2.5 text-sbi-muted hover:text-white hover:bg-sbi-green/5 transition-colors duration-200 cursor-pointer"
+                >
+                  <LogOut className="size-4" strokeWidth={1.5} />
+                  <span className="text-sm font-light">Log out</span>
+                </button>
+              </div>
+            </div>
+          )}
+
+          {/* User button */}
+          <button
+            ref={userMenuButtonRef}
+            type="button"
+            onClick={() => setIsUserMenuOpen(!isUserMenuOpen)}
+            aria-haspopup="menu"
+            aria-expanded={isUserMenuOpen}
+            className={`w-full flex items-center gap-3 p-3 transition-all duration-300 hover:bg-sbi-green/5 ${
+              isCollapsed ? "justify-center" : ""
+            } ${isUserMenuOpen ? "bg-sbi-green/5" : ""}`}
+          >
+            {/* Avatar */}
+            <div className="relative flex items-center justify-center size-9 shrink-0">
+              <div
+                className={`absolute inset-0 border transition-colors duration-300 rounded-lg ${
+                  isUserMenuOpen
+                    ? "border-sbi-green/40"
+                    : "border-sbi-dark-border/50 hover:border-sbi-green/30"
+                }`}
+              />
+              <span className="text-xs font-light text-sbi-green tracking-wider">
+                {userInitials}
+              </span>
+            </div>
+
+            {/* User info */}
+            {!isCollapsed && (
+              <>
+                <div className="flex-1 text-left min-w-0">
                   <p className="text-sm font-light text-white truncate">
                     {userName}
                   </p>
-                  <p className="text-xs text-sbi-muted truncate">{userEmail}</p>
+                  <p className="text-[11px] text-sbi-muted truncate">
+                    {userEmail}
+                  </p>
                 </div>
-              </div>
-            </div>
 
-            {/* Menu items */}
-            <div className="py-1">
-              <button
-                type="button"
-                onClick={() => {
-                  router.push("/dashboard/settings?section=profile");
-                  setIsUserMenuOpen(false);
-                }}
-                className="w-full flex items-center gap-3 px-3 py-2.5 text-sbi-muted hover:text-white hover:bg-sbi-green/5 transition-colors duration-200 cursor-pointer"
-              >
-                <User className="size-4" strokeWidth={1.5} />
-                <span className="text-sm font-light">Account</span>
-              </button>
-              <button
-                type="button"
-                onClick={() => {
-                  router.push("/dashboard/settings?section=notifications");
-                  setIsUserMenuOpen(false);
-                }}
-                className="w-full flex items-center gap-3 px-3 py-2.5 text-sbi-muted hover:text-white hover:bg-sbi-green/5 transition-colors duration-200 cursor-pointer"
-              >
-                <Bell className="size-4" strokeWidth={1.5} />
-                <span className="text-sm font-light">Notifications</span>
-              </button>
-              <button
-                type="button"
-                onClick={() => {
-                  router.push("/dashboard/settings");
-                  setIsUserMenuOpen(false);
-                }}
-                className="w-full flex items-center gap-3 px-3 py-2.5 text-sbi-muted hover:text-white hover:bg-sbi-green/5 transition-colors duration-200 cursor-pointer"
-              >
-                <Settings className="size-4" strokeWidth={1.5} />
-                <span className="text-sm font-light">Settings</span>
-              </button>
-              <a
-                href="mailto:support@utsbi.org?subject=Portal%20support"
-                onClick={() => setIsUserMenuOpen(false)}
-                className="w-full flex items-center gap-3 px-3 py-2.5 text-sbi-muted hover:text-white hover:bg-sbi-green/5 transition-colors duration-200 cursor-pointer"
-              >
-                <HelpCircle className="size-4" strokeWidth={1.5} />
-                <span className="text-sm font-light">Help</span>
-              </a>
-            </div>
-
-            {/* Logout */}
-            <div className="border-t border-sbi-dark-border/30 py-1">
-              <button
-                type="button"
-                onClick={handleLogout}
-                className="w-full flex items-center gap-3 px-3 py-2.5 text-sbi-muted hover:text-white hover:bg-sbi-green/5 transition-colors duration-200 cursor-pointer"
-              >
-                <LogOut className="size-4" strokeWidth={1.5} />
-                <span className="text-sm font-light">Log out</span>
-              </button>
-            </div>
-          </div>
-        )}
-
-        {/* User button */}
-        <button
-          type="button"
-          onClick={() => setIsUserMenuOpen(!isUserMenuOpen)}
-          className={`w-full flex items-center gap-3 p-3 transition-all duration-300 hover:bg-sbi-green/5 ${
-            isCollapsed ? "justify-center" : ""
-          } ${isUserMenuOpen ? "bg-sbi-green/5" : ""}`}
-        >
-          {/* Avatar */}
-          <div className="relative flex items-center justify-center size-9 shrink-0">
-            <div
-              className={`absolute inset-0 border transition-colors duration-300 rounded-lg ${
-                isUserMenuOpen
-                  ? "border-sbi-green/40"
-                  : "border-sbi-dark-border/50 hover:border-sbi-green/30"
-              }`}
-            />
-            <span className="text-xs font-light text-sbi-green tracking-wider">
-              {userInitials}
-            </span>
-          </div>
-
-          {/* User info */}
-          {!isCollapsed && (
-            <>
-              <div className="flex-1 text-left min-w-0">
-                <p className="text-sm font-light text-white truncate">
-                  {userName}
-                </p>
-                <p className="text-[11px] text-sbi-muted truncate">
-                  {userEmail}
-                </p>
-              </div>
-
-              {/* Chevron */}
-              <ChevronUp
-                className={`size-4 text-sbi-muted transition-transform duration-300 ${
-                  isUserMenuOpen ? "rotate-180" : ""
-                }`}
-                strokeWidth={1.5}
-              />
-            </>
-          )}
-        </button>
-      </div>
-    </aside>
+                {/* Chevron */}
+                <ChevronUp
+                  className={`size-4 text-sbi-muted transition-transform duration-300 ${
+                    isUserMenuOpen ? "rotate-180" : ""
+                  }`}
+                  strokeWidth={1.5}
+                />
+              </>
+            )}
+          </button>
+        </div>
+      </aside>
+    </>
   );
 }

--- a/frontend/components/dashboard/common/app-sidebar.tsx
+++ b/frontend/components/dashboard/common/app-sidebar.tsx
@@ -179,6 +179,14 @@ export function AppSidebar() {
   const lastOpenRef = useRef(open);
 
   useEffect(() => {
+    // Desktop only: auto-expand on Explore and restore the prior state on leave.
+    // On mobile the sidebar is a trigger-driven slide-over (dismissed on navigation
+    // below), so it must never auto-open over the content — Explore is the landing
+    // page, and auto-opening there would cover the screen on every visit.
+    if (isMobile) {
+      wasExploreRef.current = isExplore;
+      return;
+    }
     const wasExplore = wasExploreRef.current;
     if (isExplore && !wasExplore) {
       preExploreOpenRef.current = open;
@@ -187,7 +195,7 @@ export function AppSidebar() {
       setOpen(preExploreOpenRef.current);
     }
     wasExploreRef.current = isExplore;
-  }, [isExplore, open, setOpen]);
+  }, [isExplore, open, setOpen, isMobile]);
 
   // Treat a collapse performed while on Explore as an explicit opt-out.
   useEffect(() => {

--- a/frontend/components/dashboard/explore/ChatsView.tsx
+++ b/frontend/components/dashboard/explore/ChatsView.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import {
+  MessageSquare,
   MessageSquarePlus,
   MoreHorizontal,
   Pencil,
@@ -11,6 +12,14 @@ import {
 } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useEffect, useMemo, useRef, useState } from "react";
+import {
+  btnPrimary,
+  DashboardShell,
+  EmptyState,
+  inputClass,
+  PageHeader,
+  Panel,
+} from "@/components/dashboard/common/ui";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import {
   DropdownMenu,
@@ -213,46 +222,54 @@ export function ChatsView() {
   };
 
   return (
-    <div className="absolute inset-0 overflow-y-auto dashboard-scrollbar">
-      <div className="w-full max-w-3xl mx-auto px-6 py-10">
-        <div className="flex items-center justify-between mb-6">
-          <h1 className="text-2xl font-light tracking-tight text-white">
-            Chats
-          </h1>
-          <button
-            type="button"
-            onClick={handleNewChat}
-            className="inline-flex items-center gap-2 px-3 h-9 rounded-lg border border-sbi-dark-border bg-sbi-dark-card/40 text-sm text-sbi-muted hover:text-sbi-green hover:border-sbi-green/30 transition-colors"
-          >
-            <MessageSquarePlus className="h-4 w-4" strokeWidth={1.5} />
+    <DashboardShell className="max-w-3xl">
+      <PageHeader
+        title="Chats"
+        action={
+          <button type="button" onClick={handleNewChat} className={btnPrimary}>
+            <MessageSquarePlus className="h-3.5 w-3.5" strokeWidth={1.5} />
             New chat
           </button>
-        </div>
+        }
+      />
 
-        <div className="relative mb-2">
-          <Search
-            className="absolute left-3.5 top-1/2 -translate-y-1/2 h-4 w-4 text-sbi-muted"
-            strokeWidth={1.5}
-          />
-          <input
-            type="text"
-            value={query}
-            onChange={(e) => setQuery(e.target.value)}
-            placeholder="Search chats…"
-            aria-label="Search chats"
-            className="w-full h-11 pl-10 pr-4 rounded-md bg-sbi-dark-card/60 border border-sbi-dark-border/50 text-sm text-white placeholder:text-sbi-muted-dark focus:outline-none focus:border-sbi-green/50 transition-colors"
-          />
-        </div>
+      <div className="relative mb-4 shrink-0">
+        <Search
+          className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-sbi-muted-dark"
+          strokeWidth={1.5}
+        />
+        <input
+          type="text"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search chats…"
+          aria-label="Search chats"
+          className={cn(inputClass, "pl-9")}
+        />
+      </div>
 
+      <Panel className="flex-1 min-h-0 overflow-y-auto dashboard-scrollbar">
         {loading && (
           <div className="py-12 text-center text-sm text-sbi-muted-dark">
             Loading…
           </div>
         )}
         {!loading && sessionList.length === 0 && (
-          <div className="py-12 text-center text-sm text-sbi-muted-dark">
-            No conversations yet.
-          </div>
+          <EmptyState
+            icon={<MessageSquare size={24} />}
+            title="No conversations yet"
+            description="Start a new chat to explore your project with the AI portal."
+            action={
+              <button
+                type="button"
+                onClick={handleNewChat}
+                className={btnPrimary}
+              >
+                <MessageSquarePlus className="h-3.5 w-3.5" strokeWidth={1.5} />
+                New chat
+              </button>
+            }
+          />
         )}
         {!loading && sessionList.length > 0 && filteredCount === 0 && (
           <div className="py-12 text-center text-sm text-sbi-muted-dark">
@@ -283,7 +300,7 @@ export function ChatsView() {
             </div>
           </div>
         )}
-      </div>
+      </Panel>
 
       <ConfirmDialog
         opened={deleteTarget !== null}
@@ -302,6 +319,6 @@ export function ChatsView() {
         danger
         onConfirm={confirmDelete}
       />
-    </div>
+    </DashboardShell>
   );
 }

--- a/frontend/components/dashboard/explore/ChatsView.tsx
+++ b/frontend/components/dashboard/explore/ChatsView.tsx
@@ -239,7 +239,8 @@ export function ChatsView() {
             value={query}
             onChange={(e) => setQuery(e.target.value)}
             placeholder="Search chats…"
-            className="w-full h-11 pl-10 pr-4 rounded-xl bg-sbi-dark-card/60 border border-sbi-dark-border text-sm text-white placeholder:text-sbi-muted-dark focus:outline-none focus:border-sbi-green/40 transition-colors"
+            aria-label="Search chats"
+            className="w-full h-11 pl-10 pr-4 rounded-md bg-sbi-dark-card/60 border border-sbi-dark-border/50 text-sm text-white placeholder:text-sbi-muted-dark focus:outline-none focus:border-sbi-green/50 transition-colors"
           />
         </div>
 

--- a/frontend/components/dashboard/explore/DashboardPortal.tsx
+++ b/frontend/components/dashboard/explore/DashboardPortal.tsx
@@ -5,7 +5,6 @@ import { motion } from "motion/react";
 import { useParams } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 import { useChat } from "@/lib/chat/chat-context";
-import { cn } from "@/lib/utils";
 import { AmbientGrid } from "./ui/AmbientGrid";
 import { ChatMessages } from "./ui/ChatMessages";
 import { FloatingNodes } from "./ui/FloatingNodes";
@@ -43,10 +42,25 @@ export function ExplorePortal() {
     newSession,
     clearChat,
     cancelRequest,
+    isLoading,
+    loadFailed,
   } = useChat();
 
   const isNewRoute = !chatId || chatId === "new";
-  const showWelcome = messages.length === 0;
+  // A revisited/loaded thread that ended up empty (failed load, or no messages
+  // while nothing is in flight) gets a small explicit state instead of the
+  // new-chat welcome hero or a blank scroll region.
+  const showEmptyState =
+    messages.length === 0 && !isNewRoute && !isLoading && loadFailed;
+  const showWelcome = messages.length === 0 && !showEmptyState;
+  // Announce the active conversation / generating state to screen readers.
+  const liveAnnouncement = loadFailed
+    ? "Could not load this conversation."
+    : isLoading
+      ? `Generating a response in ${sessionTitle || "this conversation"}.`
+      : showWelcome
+        ? "New conversation."
+        : `Viewing conversation: ${sessionTitle || "Untitled"}.`;
 
   // Mirror the open session id into a ref so the hydrate effect always compares
   // against the *current* value, not a stale closure (the effect deliberately
@@ -194,8 +208,8 @@ export function ExplorePortal() {
           until the backend auto-titles it after the first response). */}
       {!showWelcome && (
         <div className="absolute top-0 inset-x-0 z-20 flex justify-center px-4 pt-3 pointer-events-none">
-          <div className="max-w-md rounded-full bg-sbi-dark/70 backdrop-blur-sm border border-sbi-dark-border/50 px-4 py-1.5">
-            <span className="block text-xs font-medium text-white/80 truncate">
+          <div className="min-w-[8rem] max-w-md rounded-full bg-sbi-dark/70 backdrop-blur-sm border border-sbi-dark-border/50 px-4 py-1.5">
+            <span className="block text-xs font-medium text-white/80 text-center truncate">
               {sessionTitle || "Untitled"}
             </span>
           </div>
@@ -208,15 +222,33 @@ export function ExplorePortal() {
         framer-motion `layout` smoothly animates it from centered (welcome) to
         the bottom (thread). Mirrors claude.ai.
       */}
-      <div
-        className={cn(
-          "relative z-10 flex flex-col h-full",
-          showWelcome && "justify-center",
-        )}
-      >
+      <div className="relative z-10 flex flex-col h-full">
+        {/* SR-only live region: announces the active conversation and generating
+            state so screen-reader users aren't left guessing which thread they're
+            in or whether a response is in flight. */}
+        <p aria-live="polite" className="sr-only">
+          {liveAnnouncement}
+        </p>
+
         {showWelcome ? (
-          <div className="shrink-0 w-full max-w-3xl mx-auto px-4 mb-2">
-            <PortalHero />
+          // Welcome state: clamp + scroll so the hero, composer, and suggestion
+          // chips never get cut off on short viewports.
+          <div className="flex-1 min-h-0 overflow-y-auto dashboard-scrollbar flex items-center justify-center">
+            <div className="shrink-0 w-full max-w-3xl mx-auto px-4 py-6">
+              <PortalHero />
+            </div>
+          </div>
+        ) : showEmptyState ? (
+          <div className="flex-1 min-h-0 overflow-y-auto dashboard-scrollbar flex items-center justify-center">
+            <div className="w-full max-w-md mx-auto px-4 text-center">
+              <p className="text-sm font-medium text-white/80">
+                This conversation couldn't be loaded
+              </p>
+              <p className="mt-2 text-xs text-sbi-muted-dark font-light leading-relaxed">
+                It may have been deleted or is no longer available. Start a new
+                message below to keep going.
+              </p>
+            </div>
           </div>
         ) : (
           <div className="flex-1 min-h-0 overflow-y-auto dashboard-scrollbar">

--- a/frontend/components/dashboard/explore/ui/ChatHistoryNav.tsx
+++ b/frontend/components/dashboard/explore/ui/ChatHistoryNav.tsx
@@ -283,7 +283,7 @@ export function ChatHistoryNav({ focusSearchRef }: ChatHistoryNavProps = {}) {
         </div>
         <div className="relative">
           <Search
-            className="absolute left-3 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-sbi-muted"
+            className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-sbi-muted"
             strokeWidth={1.5}
           />
           <input
@@ -292,7 +292,8 @@ export function ChatHistoryNav({ focusSearchRef }: ChatHistoryNavProps = {}) {
             value={query}
             onChange={(e) => setQuery(e.target.value)}
             placeholder="Search…"
-            className="w-full h-8 pl-8 pr-3 rounded-md bg-sbi-dark-card/60 border border-sbi-dark-border text-[13px] text-white placeholder:text-sbi-muted-dark focus:outline-none focus:border-sbi-green/40 transition-colors"
+            aria-label="Search conversations"
+            className="w-full h-8 pl-9 pr-3 rounded-md bg-sbi-dark-card/60 border border-sbi-dark-border/50 text-[13px] text-white placeholder:text-sbi-muted-dark focus:outline-none focus:border-sbi-green/50 transition-colors"
           />
         </div>
         <button

--- a/frontend/components/dashboard/explore/ui/ChatMessage.tsx
+++ b/frontend/components/dashboard/explore/ui/ChatMessage.tsx
@@ -59,6 +59,7 @@ function CodeBlock({ language, code }: { language: string; code: string }) {
         <button
           type="button"
           onClick={handleCopy}
+          aria-label="Copy code"
           className="p-1 text-sbi-muted hover:text-white transition-colors"
           title="Copy code"
         >
@@ -360,6 +361,7 @@ export function ChatMessage({
               <button
                 type="button"
                 onClick={handleCopy}
+                aria-label="Copy message"
                 className="p-1.5 text-sbi-muted hover:text-white hover:bg-sbi-dark-card rounded-lg transition-colors"
                 title="Copy"
               >
@@ -372,6 +374,7 @@ export function ChatMessage({
               <button
                 type="button"
                 onClick={handleEdit}
+                aria-label="Edit message"
                 className="p-1.5 text-sbi-muted hover:text-white hover:bg-sbi-dark-card rounded-lg transition-colors"
                 title="Edit"
               >
@@ -386,6 +389,9 @@ export function ChatMessage({
                 <button
                   type="button"
                   onClick={() => setIsExpanded(!isExpanded)}
+                  aria-label={
+                    isExpanded ? "Collapse message" : "Expand message"
+                  }
                   className="absolute top-2 right-2 p-1 text-sbi-muted hover:text-white hover:bg-sbi-dark rounded-lg transition-colors z-10"
                   title={isExpanded ? "Collapse" : "Expand"}
                 >
@@ -516,6 +522,7 @@ export function ChatMessage({
                 type="button"
                 onClick={regenerateResponse}
                 disabled={isLoading}
+                aria-label="Regenerate response"
                 className="p-1.5 text-sbi-muted hover:text-white hover:bg-sbi-dark-card rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                 title="Redo"
               >
@@ -526,6 +533,7 @@ export function ChatMessage({
               <button
                 type="button"
                 onClick={handleCopy}
+                aria-label="Copy response"
                 className="p-1.5 text-sbi-muted hover:text-white hover:bg-sbi-dark-card rounded-lg transition-colors"
                 title="Copy Reponse"
               >
@@ -538,6 +546,7 @@ export function ChatMessage({
             )}
             <button
               type="button"
+              aria-label="More options"
               className="p-1.5 text-sbi-muted hover:text-white hover:bg-sbi-dark-card rounded-lg transition-colors"
               title="More"
             >

--- a/frontend/components/dashboard/explore/ui/ChatMessage.tsx
+++ b/frontend/components/dashboard/explore/ui/ChatMessage.tsx
@@ -217,7 +217,6 @@ export function ChatMessage({
   const [isEditing, setIsEditing] = useState(false);
   const [isExpanded, setIsExpanded] = useState(false);
   const [isOverflowing, setIsOverflowing] = useState(false);
-  const [isHovered, setIsHovered] = useState(false);
   const [editedContent, setEditedContent] = useState(message.content);
   const { editAndResend, isLoading, regenerateResponse } = useChat();
 
@@ -319,12 +318,7 @@ export function ChatMessage({
   // User message
   if (isUser) {
     return (
-      <div
-        ref={containerRef}
-        className="flex justify-end mb-6"
-        onMouseEnter={() => setIsHovered(true)}
-        onMouseLeave={() => setIsHovered(false)}
-      >
+      <div ref={containerRef} className="group flex justify-end mb-6">
         {/* Content column, right aligned, set width */}
         <div className="flex flex-col items-end gap-2 max-w-[80%] overflow-hidden">
           {/* Attached files, horizontal row, right-aligned */}
@@ -356,7 +350,11 @@ export function ChatMessage({
           <div className="flex items-start gap-2 min-w-0 w-full justify-end">
             {/* Action buttons - left of msg bubble, aligned top */}
             <div
-              className={`flex items-center gap-1 shrink-0 pt-2 transition-opacity duration-200 ${isHovered && !isEditing ? "opacity-100" : "opacity-0"}`}
+              className={`flex items-center gap-1 shrink-0 pt-2 transition-opacity duration-200 ${
+                isEditing
+                  ? "opacity-0"
+                  : "opacity-0 group-hover:opacity-100 group-focus-within:opacity-100"
+              }`}
             >
               <button
                 type="button"
@@ -454,6 +452,19 @@ export function ChatMessage({
             </div>
           </div>
         </div>
+      </div>
+    );
+  }
+
+  // Cancelled before any content streamed in: skip the avatar + bubble shell
+  // and surface a minimal inline note rather than an orphaned empty block.
+  if (message.isCancelled && !displayContent) {
+    return (
+      <div ref={containerRef} className="flex items-center gap-2 mb-6 pl-12">
+        <span className="w-1.5 h-1.5 rounded-full bg-sbi-muted/60 shrink-0" />
+        <p className="text-sbi-muted italic text-sm font-light">
+          Response was cancelled
+        </p>
       </div>
     );
   }

--- a/frontend/components/dashboard/explore/ui/ChatMessages.tsx
+++ b/frontend/components/dashboard/explore/ui/ChatMessages.tsx
@@ -1,17 +1,39 @@
-'use client';
+"use client";
 
-import { useRef, useEffect } from 'react';
-import { useChat } from '@/lib/chat/chat-context';
-import { ChatMessage } from './ChatMessage';
-import { ChatLoading } from './ChatLoading';
+import { useEffect, useRef } from "react";
+import { useChat } from "@/lib/chat/chat-context";
+import { ChatLoading } from "./ChatLoading";
+import { ChatMessage } from "./ChatMessage";
 
 export function ChatMessages() {
   const { messages, isLoading } = useChat();
   const bottomRef = useRef<HTMLDivElement>(null);
 
+  // Track the streaming (last) message so the effect re-fires as its content
+  // grows, not just when a new message is appended — otherwise a long answer
+  // scrolls out of view mid-stream.
+  const lastMessage = messages[messages.length - 1];
+  const lastContentLength = lastMessage?.content.length ?? 0;
+  const isStreaming = lastMessage?.isStreaming ?? false;
+
+  // Best-effort: don't fight a user who has scrolled up to read earlier
+  // content. Only auto-scroll when they're already near the bottom.
+  // lastContentLength / isStreaming are intentional triggers (re-scroll as the
+  // streaming answer grows), not values read in the body.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: scroll triggers
   useEffect(() => {
-    bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
-  }, [messages, isLoading]);
+    const anchor = bottomRef.current;
+    if (!anchor) return;
+
+    const scroller = anchor.closest<HTMLElement>(".dashboard-scrollbar");
+    if (scroller) {
+      const distanceFromBottom =
+        scroller.scrollHeight - scroller.scrollTop - scroller.clientHeight;
+      if (distanceFromBottom > 160) return;
+    }
+
+    anchor.scrollIntoView({ behavior: "smooth" });
+  }, [messages.length, isLoading, lastContentLength, isStreaming]);
 
   if (messages.length === 0 && !isLoading) {
     return null;
@@ -20,7 +42,7 @@ export function ChatMessages() {
   // Find the last assistant message ID for redo button visibility
   let lastAssistantId: string | undefined;
   for (let i = messages.length - 1; i >= 0; i--) {
-    if (messages[i].role === 'assistant') {
+    if (messages[i].role === "assistant") {
       lastAssistantId = messages[i].id;
       break;
     }

--- a/frontend/components/dashboard/explore/ui/HoverPeekPanel.tsx
+++ b/frontend/components/dashboard/explore/ui/HoverPeekPanel.tsx
@@ -22,7 +22,9 @@ const NOTION_EASE = [0.165, 0.84, 0.44, 1] as const;
 //  - locked: docked flush full-height, square corners, no shadow
 const panelVariants: Variants = {
   hidden: {
-    x: DEFAULT_WIDTH + 24,
+    // Translate fully past its own right edge so it clears even when the width
+    // is capped to 90vw on narrow screens. 110% > any capped width.
+    x: "110%",
     opacity: 0,
     top: "7.5%",
     bottom: "7.5%",
@@ -91,6 +93,10 @@ export function HoverPeekPanel({
 }: HoverPeekPanelProps) {
   const [pinned, setPinned] = useState(false);
   const [peek, setPeek] = useState(false);
+  // Hover-peek is a fine-pointer affordance only. On touch (coarse pointer) the
+  // hover events never fire reliably, so we gate them off and let users tap the
+  // edge handle to toggle the panel instead.
+  const [canHover, setCanHover] = useState(true);
   const open = pinned || peek;
   const closeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -100,6 +106,16 @@ export function HoverPeekPanel({
       if (localStorage.getItem(storageKey) === "1") setPinned(true);
     } catch {}
   }, [storageKey]);
+
+  // Detect whether the primary pointer can hover (mouse/trackpad vs touch).
+  useEffect(() => {
+    if (typeof window === "undefined" || !window.matchMedia) return;
+    const mql = window.matchMedia("(hover: hover) and (pointer: fine)");
+    const update = () => setCanHover(mql.matches);
+    update();
+    mql.addEventListener("change", update);
+    return () => mql.removeEventListener("change", update);
+  }, []);
 
   const openPeek = useCallback(() => {
     if (closeTimer.current) clearTimeout(closeTimer.current);
@@ -140,20 +156,29 @@ export function HoverPeekPanel({
           edge strip widens the hover target. Both hide once the panel is open. */}
       {!pinned && (
         <>
-          {/* biome-ignore lint/a11y/noStaticElementInteractions: purely a mouse
-              hover-target widener; the adjacent button is the keyboard affordance. */}
-          <div
-            className="absolute top-0 right-0 z-30 h-full w-4"
-            onMouseEnter={openPeek}
-          />
+          {/* The right-edge handle. On fine pointers a tall invisible strip
+              (::before) widens the hover target so the peek triggers a little
+              before the cursor reaches the visible tab; on touch it's a plain
+              tap target. It's the keyboard affordance too (focusable button,
+              Enter/Space pin it open). */}
           <button
             type="button"
-            onMouseEnter={openPeek}
+            onMouseEnter={canHover ? openPeek : undefined}
             onClick={togglePin}
             aria-label={tabLabel}
-            title={`${title} — hover to peek, click to keep open`}
+            aria-expanded={open}
+            title={
+              canHover
+                ? `${title} — hover to peek, click to keep open`
+                : `${title} — tap to open`
+            }
             className={cn(
               "absolute right-0 top-1/2 -translate-y-1/2 z-30 inline-flex items-center justify-center rounded-l-xl border border-r-0 border-sbi-dark-border bg-sbi-dark-card py-4 pl-2.5 pr-2 text-sbi-muted shadow-lg shadow-black/30 transition-all duration-200 hover:text-sbi-green hover:pr-3",
+              // Fine-pointer hover-target widener: an invisible full-height strip
+              // along the right edge so the peek can trigger before the cursor
+              // lands on the visible tab. No-op for touch.
+              canHover &&
+                "before:absolute before:top-1/2 before:right-0 before:h-screen before:max-h-[100vh] before:w-4 before:-translate-y-1/2 before:content-['']",
               open && "opacity-0 pointer-events-none translate-x-4",
             )}
           >
@@ -166,15 +191,17 @@ export function HoverPeekPanel({
           so the float->dock transition tweens (x, inset, radius, shadow) instead
           of snapping between class sets. */}
       <motion.aside
-        onMouseEnter={cancelClose}
-        onMouseLeave={scheduleClose}
+        onMouseEnter={canHover ? cancelClose : undefined}
+        onMouseLeave={canHover ? scheduleClose : undefined}
         initial={false}
         animate={visualState}
         variants={panelVariants}
         transition={{ duration: 0.3, ease: NOTION_EASE }}
         style={{
           position: "absolute",
-          width,
+          // Cap to the viewport on narrow screens so the fixed 288px panel never
+          // overflows; respects the requested width on roomy layouts.
+          width: `min(${width}px, 90vw)`,
           zIndex: 40,
           pointerEvents: open ? "auto" : "none",
         }}

--- a/frontend/components/dashboard/explore/ui/PortalInput.tsx
+++ b/frontend/components/dashboard/explore/ui/PortalInput.tsx
@@ -1,15 +1,27 @@
-'use client';
+"use client";
 
-import React, { useState, useRef, type KeyboardEvent, type ChangeEvent } from 'react';
-import { Button } from '@/components/ui/button';
-import { Plus, Send, X, FileText, File, Mic, Settings2, Zap, Lightbulb, ChevronDown, Square, Loader2, Check } from 'lucide-react';
-import { useChat, type ModelPreference } from '@/lib/chat/chat-context';
+import {
+  Check,
+  ChevronDown,
+  Lightbulb,
+  Loader2,
+  Plus,
+  Send,
+  Settings2,
+  Square,
+  X,
+  Zap,
+} from "lucide-react";
+import { type ChangeEvent, type KeyboardEvent, useRef, useState } from "react";
+import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu';
+} from "@/components/ui/dropdown-menu";
+import { type ModelPreference, useChat } from "@/lib/chat/chat-context";
+import { getFileInfo } from "./file-info";
 
 type ModelType = ModelPreference;
 
@@ -22,50 +34,18 @@ interface ModelOption {
 
 const modelOptions: ModelOption[] = [
   {
-    id: 'fast',
-    name: 'Fast',
-    description: 'Answers quickly',
+    id: "fast",
+    name: "Fast",
+    description: "Answers quickly",
     icon: Zap,
   },
   {
-    id: 'thinking',
-    name: 'Thinking',
-    description: 'Solves complex problems',
+    id: "thinking",
+    name: "Thinking",
+    description: "Solves complex problems",
     icon: Lightbulb,
   },
 ];
-
-function getFileInfo(filename: string): { icon: React.ReactNode; label: string; color: string } {
-  const ext = filename.split('.').pop()?.toLowerCase() || '';
-
-  switch (ext) {
-    case 'pdf':
-      return {
-        icon: <div className="w-6 h-6 bg-red-500 rounded-lg text-[9px] font-bold text-white flex items-center justify-center">PDF</div>,
-        label: 'PDF',
-        color: 'text-red-400',
-      };
-    case 'doc':
-    case 'docx':
-      return {
-        icon: <div className="w-6 h-6 bg-blue-600 rounded-lg text-[9px] font-bold text-white flex items-center justify-center">W</div>,
-        label: 'DOCX',
-        color: 'text-blue-400',
-      };
-    case 'txt':
-      return {
-        icon: <div className="w-6 h-6 bg-blue-400 rounded-lg flex items-center justify-center"><FileText className="w-3.5 h-3.5 text-white" /></div>,
-        label: 'TXT',
-        color: 'text-blue-300',
-      };
-    default:
-      return {
-        icon: <File className="w-6 h-6 text-sbi-muted" />,
-        label: ext.toUpperCase() || 'FILE',
-        color: 'text-sbi-muted',
-      };
-  }
-}
 
 interface PortalInputProps {
   onSubmit?: (query: string) => void;
@@ -73,8 +53,12 @@ interface PortalInputProps {
   animated?: boolean;
 }
 
-export function PortalInput({ onSubmit, disabled = false, animated = true }: PortalInputProps) {
-  const [input, setInput] = useState('');
+export function PortalInput({
+  onSubmit,
+  disabled = false,
+  animated = true,
+}: PortalInputProps) {
+  const [input, setInput] = useState("");
   const fileInputRef = useRef<HTMLInputElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const {
@@ -88,18 +72,20 @@ export function PortalInput({ onSubmit, disabled = false, animated = true }: Por
     modelPreference,
     setModelPreference,
     cancelRequest,
+    error,
+    clearError,
   } = useChat();
 
-  const isStreaming = messages.some(m => m.isStreaming);
+  const isStreaming = messages.some((m) => m.isStreaming);
 
   const handleSubmit = async () => {
     if (!input.trim() || isBusy || disabled) return;
-    
+
     const query = input.trim();
-    setInput('');
+    setInput("");
 
     if (textareaRef.current) {
-      textareaRef.current.style.height = 'auto';
+      textareaRef.current.style.height = "auto";
       // Keep focus so the user can keep typing while the answer streams.
       textareaRef.current.focus();
     }
@@ -112,7 +98,7 @@ export function PortalInput({ onSubmit, disabled = false, animated = true }: Por
   };
 
   const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
-    if (e.key === 'Enter' && !e.shiftKey) {
+    if (e.key === "Enter" && !e.shiftKey) {
       e.preventDefault();
       handleSubmit();
     }
@@ -120,9 +106,9 @@ export function PortalInput({ onSubmit, disabled = false, animated = true }: Por
 
   const handleInputChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
     setInput(e.target.value);
-    
+
     const textarea = e.target;
-    textarea.style.height = 'auto';
+    textarea.style.height = "auto";
     textarea.style.height = `${Math.min(textarea.scrollHeight, 200)}px`;
   };
 
@@ -136,9 +122,11 @@ export function PortalInput({ onSubmit, disabled = false, animated = true }: Por
 
     for (const file of Array.from(files)) {
       const name = file.name.toLowerCase();
-      const isAccepted = file.type === 'application/pdf'
-        || file.type.startsWith('text/')
-        || name.endsWith('.doc') || name.endsWith('.docx');
+      const isAccepted =
+        file.type === "application/pdf" ||
+        file.type.startsWith("text/") ||
+        name.endsWith(".doc") ||
+        name.endsWith(".docx");
       if (isAccepted) {
         await addAttachment(file);
       }
@@ -146,16 +134,41 @@ export function PortalInput({ onSubmit, disabled = false, animated = true }: Por
 
     // Reset file input
     if (fileInputRef.current) {
-      fileInputRef.current.value = '';
+      fileInputRef.current.value = "";
     }
   };
 
   const isBusy = isLoading || isStreaming;
   const hasInput = input.trim().length > 0;
-  const currentModel = modelOptions.find(m => m.id === modelPreference) || modelOptions[0];
+  const currentModel =
+    modelOptions.find((m) => m.id === modelPreference) || modelOptions[0];
 
   return (
-    <div className={`input-container space-y-3 ${animated ? 'opacity-0 translate-y-8' : ''}`}>
+    <div
+      className={`input-container space-y-3 ${animated ? "opacity-0 translate-y-8" : ""}`}
+    >
+      {/* Inline error banner — surfaces send failures and attachment-read
+          errors (both flow through the shared chat `error` state). Muted red,
+          restrained, dismissable. */}
+      {error && (
+        <div
+          role="alert"
+          className="flex items-start justify-between gap-3 rounded-xl border border-red-500/30 bg-red-500/5 px-4 py-2.5"
+        >
+          <p className="text-red-400 text-xs font-light leading-relaxed">
+            {error}
+          </p>
+          <button
+            type="button"
+            onClick={clearError}
+            aria-label="Dismiss error"
+            className="shrink-0 text-red-400/70 hover:text-red-300 transition-colors"
+          >
+            <X className="w-3.5 h-3.5" strokeWidth={1.5} />
+          </button>
+        </div>
+      )}
+
       {/* Main user input container */}
       <div className="relative group">
         {/* Hidden file input */}
@@ -189,7 +202,7 @@ export function PortalInput({ onSubmit, disabled = false, animated = true }: Por
                     </div>
                     <div className="flex flex-col min-w-0">
                       <span className="text-sm text-white/60 font-light truncate max-w-[120px]">
-                        {filename.replace(/\.[^/.]+$/, '')}
+                        {filename.replace(/\.[^/.]+$/, "")}
                       </span>
                       <span className={`text-xs ${fileInfo.color} opacity-60`}>
                         {fileInfo.label}
@@ -210,7 +223,7 @@ export function PortalInput({ onSubmit, disabled = false, animated = true }: Por
                     {fileInfo.icon}
                     <div className="flex flex-col min-w-0">
                       <span className="text-sm text-white font-light truncate max-w-[120px]">
-                        {attachment.filename.replace(/\.[^/.]+$/, '')}
+                        {attachment.filename.replace(/\.[^/.]+$/, "")}
                       </span>
                       <span className={`text-xs ${fileInfo.color}`}>
                         {fileInfo.label}
@@ -237,6 +250,7 @@ export function PortalInput({ onSubmit, disabled = false, animated = true }: Por
             onChange={handleInputChange}
             onKeyDown={handleKeyDown}
             placeholder="Ask anything ..."
+            aria-label="Message"
             disabled={disabled}
             rows={1}
             className="w-full bg-transparent px-5 pt-5 pb-3 text-base text-white font-light tracking-wide placeholder:text-sbi-muted-dark resize-none focus:outline-none disabled:opacity-50 min-h-[52px] max-h-[200px]"
@@ -252,6 +266,7 @@ export function PortalInput({ onSubmit, disabled = false, animated = true }: Por
                 variant="ghost"
                 onClick={handleFileSelect}
                 disabled={disabled}
+                aria-label="Attach file"
                 className="h-9 w-9 text-sbi-muted hover:text-sbi-green hover:bg-sbi-dark rounded-full transition-colors duration-300 disabled:opacity-50"
               >
                 <Plus className="w-5 h-5" strokeWidth={1.5} />
@@ -262,6 +277,7 @@ export function PortalInput({ onSubmit, disabled = false, animated = true }: Por
                 size="sm"
                 variant="ghost"
                 disabled={disabled}
+                aria-label="Tools"
                 className="h-9 px-3 text-sbi-muted hover:text-sbi-green hover:bg-sbi-dark rounded-full transition-colors duration-300 disabled:opacity-50 gap-1.5"
               >
                 <Settings2 className="w-4 h-4" strokeWidth={1.5} />
@@ -278,10 +294,16 @@ export function PortalInput({ onSubmit, disabled = false, animated = true }: Por
                     size="sm"
                     variant="ghost"
                     disabled={disabled}
+                    aria-label={`Response style: ${currentModel.name}`}
                     className="h-9 px-3 text-sbi-muted hover:text-white hover:bg-sbi-dark rounded-full transition-colors duration-300 disabled:opacity-50 gap-1.5"
                   >
-                    <currentModel.icon className="w-4 h-4 text-sbi-green" strokeWidth={1.5} />
-                    <span className="text-sm font-light">{currentModel.name}</span>
+                    <currentModel.icon
+                      className="w-4 h-4 text-sbi-green"
+                      strokeWidth={1.5}
+                    />
+                    <span className="text-sm font-light">
+                      {currentModel.name}
+                    </span>
                     <ChevronDown className="w-3.5 h-3.5" strokeWidth={1.5} />
                   </Button>
                 </DropdownMenuTrigger>
@@ -302,11 +324,13 @@ export function PortalInput({ onSubmit, disabled = false, animated = true }: Por
                         className="flex items-center gap-3 px-2.5 py-2 rounded-lg cursor-pointer text-sbi-muted focus:bg-sbi-dark-card focus:text-white"
                       >
                         <model.icon
-                          className={`w-4 h-4 shrink-0 ${active ? 'text-sbi-green' : 'text-sbi-muted-dark'}`}
+                          className={`w-4 h-4 shrink-0 ${active ? "text-sbi-green" : "text-sbi-muted-dark"}`}
                           strokeWidth={1.5}
                         />
                         <div className="flex-1 min-w-0">
-                          <div className={`text-sm ${active ? 'text-white' : ''}`}>
+                          <div
+                            className={`text-sm ${active ? "text-white" : ""}`}
+                          >
                             {model.name}
                           </div>
                           <p className="text-xs text-sbi-muted-dark font-light">
@@ -314,7 +338,10 @@ export function PortalInput({ onSubmit, disabled = false, animated = true }: Por
                           </p>
                         </div>
                         {active && (
-                          <Check className="w-4 h-4 shrink-0 text-sbi-green" strokeWidth={2} />
+                          <Check
+                            className="w-4 h-4 shrink-0 text-sbi-green"
+                            strokeWidth={2}
+                          />
                         )}
                       </DropdownMenuItem>
                     );
@@ -322,34 +349,36 @@ export function PortalInput({ onSubmit, disabled = false, animated = true }: Por
                 </DropdownMenuContent>
               </DropdownMenu>
 
-              {/* Send / Stop / Mic button with transition */}
+              {/* Send / Stop button. Empty input shows a disabled send affordance
+                  (reduced opacity), not a mic — no voice feature is implied. */}
               {isBusy ? (
                 <Button
                   size="icon"
                   variant="ghost"
                   onClick={cancelRequest}
+                  aria-label="Stop generating"
                   className="h-9 w-9 rounded-full bg-sbi-dark-card border border-sbi-dark-border text-white hover:bg-sbi-dark hover:border-sbi-muted transition-all duration-300"
                   title="Stop generating"
                 >
-                  <Square className="w-3.5 h-3.5 fill-current" strokeWidth={0} />
+                  <Square
+                    className="w-3.5 h-3.5 fill-current"
+                    strokeWidth={0}
+                  />
                 </Button>
               ) : (
                 <Button
                   size="icon"
                   variant="ghost"
                   onClick={hasInput ? handleSubmit : undefined}
-                  disabled={disabled || (hasInput && !input.trim())}
-                  className={`h-9 w-9 rounded-full transition-all duration-300 ${
+                  disabled={disabled || !hasInput}
+                  aria-label="Send message"
+                  className={`h-9 w-9 rounded-full transition-all duration-300 disabled:opacity-50 ${
                     hasInput
-                      ? 'bg-sbi-green text-sbi-dark hover:bg-sbi-green/90'
-                      : 'text-sbi-muted hover:text-sbi-green hover:bg-sbi-dark'
-                  } disabled:opacity-50`}
+                      ? "bg-sbi-green/10 text-sbi-green border border-sbi-green/30 hover:bg-sbi-green hover:text-sbi-dark"
+                      : "text-sbi-muted"
+                  }`}
                 >
-                  {hasInput ? (
-                    <Send className="w-4 h-4" strokeWidth={2} />
-                  ) : (
-                    <Mic className="w-5 h-5" strokeWidth={1.5} />
-                  )}
+                  <Send className="w-4 h-4" strokeWidth={2} />
                 </Button>
               )}
             </div>
@@ -362,4 +391,3 @@ export function PortalInput({ onSubmit, disabled = false, animated = true }: Por
     </div>
   );
 }
-

--- a/frontend/components/dashboard/explore/ui/PortalInput.tsx
+++ b/frontend/components/dashboard/explore/ui/PortalInput.tsx
@@ -272,13 +272,16 @@ export function PortalInput({
                 <Plus className="w-5 h-5" strokeWidth={1.5} />
               </Button>
 
-              {/* Tools button */}
+              {/* Tools button — feature not yet available. Kept visible but
+                  inert so the affordance reads as "coming", not broken. */}
               <Button
                 size="sm"
                 variant="ghost"
-                disabled={disabled}
-                aria-label="Tools"
-                className="h-9 px-3 text-sbi-muted hover:text-sbi-green hover:bg-sbi-dark rounded-full transition-colors duration-300 disabled:opacity-50 gap-1.5"
+                disabled
+                aria-disabled="true"
+                aria-label="Tools (coming soon)"
+                title="Coming soon"
+                className="h-9 px-3 text-sbi-muted rounded-full opacity-50 cursor-not-allowed gap-1.5"
               >
                 <Settings2 className="w-4 h-4" strokeWidth={1.5} />
                 <span className="text-sm font-light">Tools</span>

--- a/frontend/components/dashboard/explore/ui/SuggestionChips.tsx
+++ b/frontend/components/dashboard/explore/ui/SuggestionChips.tsx
@@ -1,28 +1,32 @@
-'use client';
+"use client";
 
-import { useEffect, useRef } from 'react';
-import { TrendingUp, DollarSign, Clock } from 'lucide-react';
-import gsap from 'gsap';
+import gsap from "gsap";
+import { Clock, DollarSign, TrendingUp } from "lucide-react";
+import { useEffect, useRef } from "react";
+import { useChat } from "@/lib/chat/chat-context";
 
 const suggestions = [
-  { icon: TrendingUp, text: 'Progress updates', accent: 'emerald' },
-  { icon: DollarSign, text: 'Budget summary', accent: 'emerald' },
-  { icon: Clock, text: 'Current Project blockers', accent: 'emerald' },
+  { icon: TrendingUp, text: "Progress updates" },
+  { icon: DollarSign, text: "Budget summary" },
+  { icon: Clock, text: "Current Project blockers" },
 ];
 
 interface SuggestionChipsProps {
   disableAutoAnimation?: boolean;
 }
 
-export function SuggestionChips({ disableAutoAnimation = false }: SuggestionChipsProps) {
+export function SuggestionChips({
+  disableAutoAnimation = false,
+}: SuggestionChipsProps) {
   const chipsRef = useRef<HTMLDivElement>(null);
+  const { sendMessage, isLoading } = useChat();
 
   useEffect(() => {
     if (disableAutoAnimation) return;
     if (!chipsRef.current) return;
 
-    const chips = chipsRef.current.querySelectorAll('.suggestion-chip');
-    
+    const chips = chipsRef.current.querySelectorAll(".suggestion-chip");
+
     gsap.set(chips, { opacity: 0, y: 15, scale: 0.95 });
 
     const ctx = gsap.context(() => {
@@ -33,7 +37,7 @@ export function SuggestionChips({ disableAutoAnimation = false }: SuggestionChip
         duration: 0.8,
         delay: 1,
         stagger: 0.1,
-        ease: 'power3.out',
+        ease: "power3.out",
       });
     }, chipsRef);
 
@@ -41,31 +45,39 @@ export function SuggestionChips({ disableAutoAnimation = false }: SuggestionChip
   }, [disableAutoAnimation]);
 
   return (
-    <div ref={chipsRef} className="flex flex-wrap items-center justify-center gap-3">
+    <div
+      ref={chipsRef}
+      className="flex flex-wrap items-center justify-center gap-3"
+    >
       {suggestions.map((suggestion, index) => (
         <button
           key={index}
           type="button"
-          className="suggestion-chip invisible opacity-0 translate-y-4 scale-95 group relative overflow-hidden rounded-full"
+          onClick={() => {
+            if (isLoading) return;
+            void sendMessage(suggestion.text);
+          }}
+          disabled={isLoading}
+          className="suggestion-chip invisible opacity-0 translate-y-4 scale-95 group relative overflow-hidden rounded-full disabled:opacity-50 disabled:cursor-not-allowed"
         >
           {/* Background layers */}
           <div className="absolute inset-0 bg-sbi-dark-card/60 backdrop-blur-sm transition-all duration-500 group-hover:bg-sbi-dark-card rounded-full" />
           <div className="absolute inset-0 bg-linear-to-r from-sbi-green/0 via-sbi-green/5 to-sbi-green/0 -translate-x-full group-hover:translate-x-full transition-transform duration-700 rounded-full" />
-          
+
           {/* Border */}
           <div className="absolute inset-0 border border-sbi-dark-border group-hover:border-sbi-green/30 transition-colors duration-500 rounded-full" />
-          
+
           {/* Content */}
           <div className="relative flex items-center gap-3 px-6 py-3">
-            <suggestion.icon 
-              className="w-4 h-4 text-sbi-muted group-hover:text-sbi-green transition-colors duration-300" 
-              strokeWidth={1.5} 
+            <suggestion.icon
+              className="w-4 h-4 text-sbi-muted group-hover:text-sbi-green transition-colors duration-300"
+              strokeWidth={1.5}
             />
-            <span className="text-sm font-extralight tracking-wide text-sbi-muted group-hover:text-white transition-colors duration-300">
+            <span className="text-sm font-light tracking-wide text-sbi-muted group-hover:text-white transition-colors duration-300">
               {suggestion.text}
             </span>
           </div>
-          
+
           {/* Bottom glow indicator on hover */}
           <div className="absolute inset-0 rounded-full opacity-0 group-hover:opacity-100 transition-opacity duration-500 shadow-[inset_0_-1px_0_0_rgba(34,197,94,0.3)]" />
         </button>

--- a/frontend/components/dashboard/explore/ui/file-info.tsx
+++ b/frontend/components/dashboard/explore/ui/file-info.tsx
@@ -5,7 +5,21 @@ import type { ReactNode } from "react";
  * Maps a filename to a small file-type badge, label, and accent color. Shared by
  * the chat message attachments, inline citations, and the Sources panel so the
  * visual language for a document is identical everywhere it appears.
+ *
+ * All badges share ONE tinted-neutral family (sbi-dark-card chip, sbi-dark-border
+ * outline, muted glyph) — files are differentiated by their label/glyph, never by
+ * saturated fills. Brand: restrained, no loud color.
  */
+
+/** Shared monochrome chip wrapper for every file-type badge. */
+function Chip({ children }: { children: ReactNode }) {
+  return (
+    <div className="w-6 h-6 rounded-lg bg-sbi-dark-card border border-sbi-dark-border flex items-center justify-center text-sbi-muted">
+      {children}
+    </div>
+  );
+}
+
 export function getFileInfo(filename: string): {
   icon: ReactNode;
   label: string;
@@ -17,37 +31,41 @@ export function getFileInfo(filename: string): {
     case "pdf":
       return {
         icon: (
-          <div className="w-6 h-6 bg-red-500 rounded-lg text-[9px] font-bold text-white flex items-center justify-center">
-            PDF
-          </div>
+          <Chip>
+            <span className="text-[8px] font-bold tracking-tight">PDF</span>
+          </Chip>
         ),
         label: "PDF",
-        color: "text-red-400",
+        color: "text-sbi-muted",
       };
     case "doc":
     case "docx":
       return {
         icon: (
-          <div className="w-6 h-6 bg-blue-600 rounded-lg text-[9px] font-bold text-white flex items-center justify-center">
-            W
-          </div>
+          <Chip>
+            <span className="text-[9px] font-bold">W</span>
+          </Chip>
         ),
         label: "DOCX",
-        color: "text-blue-400",
+        color: "text-sbi-muted",
       };
     case "txt":
       return {
         icon: (
-          <div className="w-6 h-6 bg-blue-400 rounded-lg flex items-center justify-center">
-            <FileText className="w-3.5 h-3.5 text-white" />
-          </div>
+          <Chip>
+            <FileText className="w-3.5 h-3.5" strokeWidth={1.5} />
+          </Chip>
         ),
         label: "TXT",
-        color: "text-blue-300",
+        color: "text-sbi-muted",
       };
     default:
       return {
-        icon: <File className="w-6 h-6 text-sbi-muted" />,
+        icon: (
+          <Chip>
+            <File className="w-3.5 h-3.5" strokeWidth={1.5} />
+          </Chip>
+        ),
         label: ext.toUpperCase() || "FILE",
         color: "text-sbi-muted",
       };

--- a/frontend/lib/chat/chat-context.tsx
+++ b/frontend/lib/chat/chat-context.tsx
@@ -63,6 +63,10 @@ interface ChatContextType {
   isLoading: boolean;
   error: string | null;
   clearError: () => void;
+  // True when the most recent loadSession() failed to hydrate a conversation
+  // (unknown id, RLS, or fetch error). Lets the surface show an empty/error
+  // state instead of a blank thread. Reset on any successful load / new session.
+  loadFailed: boolean;
   attachments: AttachmentFile[];
   loadingAttachments: string[];
   modelPreference: ModelPreference;
@@ -96,6 +100,7 @@ export function ChatProvider({ children }: { children: ReactNode }) {
   const [sessionTitle, setSessionTitle] = useState<string | null>(null);
   const [loadingPhase, setLoadingPhase] = useState<LoadingPhase>("idle");
   const [error, setError] = useState<string | null>(null);
+  const [loadFailed, setLoadFailed] = useState(false);
   const [attachments, setAttachments] = useState<AttachmentFile[]>([]);
   const [modelPreference, setModelPreference] =
     useState<ModelPreference>("fast");
@@ -482,6 +487,7 @@ export function ChatProvider({ children }: { children: ReactNode }) {
     setLoadingAttachments([]);
     setLoadingPhase("idle");
     setError(null);
+    setLoadFailed(false);
     setSessionId(null);
     setSessionPublicId(null);
     setSessionTitle(null);
@@ -499,6 +505,7 @@ export function ChatProvider({ children }: { children: ReactNode }) {
         abortControllerRef.current = null;
       }
       setError(null);
+      setLoadFailed(false);
       setLoadingPhase("idle");
 
       const supabase = createClient();
@@ -510,6 +517,7 @@ export function ChatProvider({ children }: { children: ReactNode }) {
         .maybeSingle();
 
       if (sessErr || !session) {
+        setLoadFailed(true);
         return false;
       }
 
@@ -525,6 +533,7 @@ export function ChatProvider({ children }: { children: ReactNode }) {
 
       if (fetchErr) {
         setError(`Failed to load session: ${fetchErr.message}`);
+        setLoadFailed(true);
         return false;
       }
 
@@ -544,6 +553,7 @@ export function ChatProvider({ children }: { children: ReactNode }) {
       setMessages(hydrated);
       setAttachments([]);
       setLoadingAttachments([]);
+      setLoadFailed(false);
       setSessionId(session.id);
       setSessionPublicId(session.public_id as string);
       return true;
@@ -651,6 +661,7 @@ export function ChatProvider({ children }: { children: ReactNode }) {
         isLoading,
         error,
         clearError,
+        loadFailed,
         attachments,
         loadingAttachments,
         modelPreference,

--- a/frontend/lib/chat/chat-context.tsx
+++ b/frontend/lib/chat/chat-context.tsx
@@ -62,6 +62,7 @@ interface ChatContextType {
   loadingPhase: LoadingPhase;
   isLoading: boolean;
   error: string | null;
+  clearError: () => void;
   attachments: AttachmentFile[];
   loadingAttachments: string[];
   modelPreference: ModelPreference;
@@ -363,6 +364,8 @@ export function ChatProvider({ children }: { children: ReactNode }) {
     setAttachments((prev) => prev.filter((a) => a.filename !== filename));
   }, []);
 
+  const clearError = useCallback(() => setError(null), []);
+
   const cancelRequest = useCallback(() => {
     cancelledRef.current = true;
     if (abortControllerRef.current) {
@@ -647,6 +650,7 @@ export function ChatProvider({ children }: { children: ReactNode }) {
         loadingPhase,
         isLoading,
         error,
+        clearError,
         attachments,
         loadingAttachments,
         modelPreference,


### PR DESCRIPTION
Implements the safe, high-confidence subset of the Explore UI/UX audit. Stacked on #61 (`feat/explore-ui`). On-brand: restrained register, outlined-green buttons (fill on hover, never solid green at rest), tinted neutrals, no emoji-icons, no saturated fills.

## Fixed (8 items)

1. **Send button banned green fill** — `PortalInput.tsx`: the active send button used `bg-sbi-green text-sbi-dark` at rest. Now uses the dashboard language `bg-sbi-green/10 text-sbi-green border border-sbi-green/30 hover:bg-sbi-green hover:text-sbi-dark` (fills on hover only), matching the `btnPrimary` token.
2. **Multi-color file badges → one tinted-neutral family** — `file-info.tsx`: removed the saturated red (PDF) / blue (DOC/TXT) chips. All badges now share one `bg-sbi-dark-card` + `border-sbi-dark-border` chip with a muted glyph; files differ by label/glyph, not color. Labels are `text-sbi-muted`.
3. **Dedupe `getFileInfo`** — `PortalInput.tsx` had its own local copy. Deleted it and imported the shared `./file-info`, so the monochrome treatment (#2) now applies everywhere (composer, messages, sources).
4. **Dead suggestion chips** — `SuggestionChips.tsx`: welcome-screen chips did nothing. Each chip now calls `useChat().sendMessage(text)` (guarded by `isLoading`, disabled while busy). Removed the unused `accent`/`color` field; `font-extralight` → `font-light`. Wired directly via the shared `useChat` context (component sits inside `ChatProvider`) — no extra prop plumbing needed.
5. **Invisible errors** — added a minimal, dismissable inline error banner in the composer (`PortalInput.tsx`) rendering the shared chat `error` (muted red, `text-red-400 text-xs`). Covers both send failures and attachment-read failures (both already flow through `error`). Added a small `clearError()` to `chat-context.tsx` so the banner can be dismissed.
6. **Misleading Mic icon** — `PortalInput.tsx`: the empty-input state showed a Mic icon implying voice input. Replaced with a disabled send affordance (same Send arrow, `disabled`, reduced opacity) — no unsupported feature implied.
7. **a11y labels (additive)** — `aria-label`s added: composer textarea ("Message"); send/stop button ("Send message" / "Stop generating"); model picker; attach/tools toolbar buttons; and icon-only buttons in `ChatMessage.tsx` (copy/edit/regenerate/copy-response/more/expand/copy-code). Pure additive, no behavior change.
8. **Search input consistency** — `ChatHistoryNav.tsx` and `ChatsView.tsx` search fields standardized on the `inputClass` tokens (`rounded-md`, `border-sbi-dark-border/50`, `focus:border-sbi-green/50`) and matching icon size. Sidebar keeps its smaller `h-8` height; tokens now match.

### Notes / smallest-safe choices
- **#4**: chips use the existing `useChat` context directly (no `DashboardPortal` prop wiring required) since they render inside the provider. Sending is no-op while a request is in flight.
- **#5**: reused the existing shared `error` state (no new error plumbing); the banner is dismissable via a new tiny `clearError` and otherwise clears on next send (`sendMessage` already calls `setError(null)`).

## Deferred (needs review) — NOT in this PR
- Keyboard access for the hover-only Sources panel (`HoverPeekPanel`) + hover-only message action toolbars (`ChatMessage`) — needs focus-visible reveal + keyboard trigger.
- Custom dropdowns (project switcher / user menu in `app-sidebar`) lack menu semantics / focus management.
- `sbi-muted-dark` fails WCAG AA contrast at small sizes (`globals.css` token) — needs a verified contrast bump (global impact).
- Responsive/mobile: sidebar has no overlay behavior (fixed 16rem rail eats small viewports); `HoverPeekPanel` is hover-driven + fixed-width (broken on touch); composer + chips can overflow on short viewports.
- `ChatsView` should be rebuilt on `DashboardShell` + `PageHeader` + `Panel` (it hand-rolls page chrome and floats rows on bare black).
- `ProjectStatusBar`: `animate-ping`, amber/blue multi-color, status-by-color-alone, hardcoded values — fold into #60 (already touches this file).
- Streaming response not auto-scrolled mid-stream (`ChatMessages`).
- Inert "Tools" button in the composer (wire or remove — product decision).
- Title pill read-only/ambiguous mid-generation; long titles collapse the chip; cancel-with-no-content leaves an empty "Response was cancelled" bubble; no empty/error state when a revisited chat fails to load.

## Verification
- `npx tsc --noEmit`: **clean** — 0 errors outside the pre-existing `lib/data/projects.ts` webp errors. (`next-env.d.ts` was generated locally via `next typegen` to provide the `@/assets/*` image-module declarations; it is gitignored and not committed.)
- `npx biome check --write` on the changed files: applied all safe formatting fixes. Remaining lint findings are **pre-existing** patterns in code only touched additively (array-index `key` in the suggestions map, `useTemplate`/`noAssignInExpressions`/`noStaticElementInteractions`/`useExhaustiveDependencies` in untouched `ChatMessage` logic) — none introduced by this change.

Draft — do not merge.