### PR TITLE
fix(explore): loosen RAG prompt — conversational + grounded, drop auto no-docs footer

### DIFF
--- a/backend/app/explore/agents/nodes.py
+++ b/backend/app/explore/agents/nodes.py
@@ -44,12 +44,6 @@ GREETING_RESPONSE = (
     "How may I assist you with your project today?"
 )
 
-NO_CONTEXT_FOOTER = (
-    "\n\n---\n\n> **Note:** No specific documents were found in your project "
-    "files related to this query. You can upload relevant documents or ask me "
-    "to search for something else."
-)
-
 
 def format_history(history: List[Dict[str, str]]) -> str:
     """Format conversation history for prompts."""
@@ -388,11 +382,9 @@ async def generate_response_streaming(
             answer = "I was unable to generate a response. Please try rephrasing your question."
             yield {"type": "delta", "text": answer}
 
-        # If no context was found, append a note (and stream it so the UI sees it).
-        if (not context or context == "No relevant documents found.") and "No relevant documents" not in answer:
-            yield {"type": "delta", "text": NO_CONTEXT_FOOTER}
-            answer = f"{answer}{NO_CONTEXT_FOOTER}"
-
+        # No hardcoded "no documents found" footer: the model now phrases a brief,
+        # natural note about missing project documents itself, and only for genuine
+        # project-data questions (see GENERATE_RESPONSE_PROMPT).
         yield {"type": "state", "state": {**state, "response": answer}}
 
     except Exception:

--- a/backend/app/explore/agents/prompts.py
+++ b/backend/app/explore/agents/prompts.py
@@ -2,8 +2,9 @@
 SYSTEM_PROMPT = """You are the Project Manager Assistant for the Sustainable Building Initiative (SBI). You help clients and stakeholders understand their construction and sustainability projects by answering questions from their project documents.
 
 ### GROUNDING (most important)
-- Answer only from the provided project documents, meeting notes, and specifications. Do not use outside knowledge to invent project details such as budgets, dates, or specs.
-- If the context does not contain the answer, say so plainly: "The current documentation does not contain this information." Never guess.
+- Answer general, conversational, and meta questions directly and helpfully — who you are, what you can do, greetings, and how to use this assistant. You do not need documents for these, and you should never refuse them.
+- For factual PROJECT details — budgets, dates, specs, deliverables, status, named items, or the contents of a document — use only the provided project documents. Never invent or guess these from outside knowledge.
+- If the documents don't contain a project detail you're asked for, stay useful: offer whatever general guidance you reasonably can, and add one brief, natural note that the specifics aren't in their project documents yet (they can upload a file or ask you to search). Don't refuse outright, and never pad a conversational or general answer with that note.
 - If two documents conflict (e.g. the schedule says March 1 but an email says March 15), point out the discrepancy instead of picking one.
 - For safety, hazardous-material, or structural questions, prioritize accuracy and quote the relevant warning verbatim as a blockquote.
 
@@ -37,10 +38,10 @@ User Query:
 
 === RESPONSE GUIDELINES ===
 
-1.  **Strict Grounding (Anti-Hallucination):**
-    - Answer ONLY using the information in "Available Context".
-    - Do NOT use outside knowledge, external facts, or training data to answer the core question.
-    - If the "Available Context" does not contain the answer, explicitly state: *"I cannot answer this based on the provided documents."* Do not make up an answer.
+1.  **Grounding & scope:**
+    - You ARE the SBI Project Manager Assistant. Answer general, conversational, and meta questions directly and helpfully — who you are, what you can do, greetings, and how to use this assistant. You do not need "Available Context" for these; never refuse them.
+    - For factual claims about THE PROJECT (budgets, dates, specs, deliverables, status, named items, or document contents), use ONLY the information in "Available Context". Never invent, guess, or fill in project specifics from outside/training knowledge.
+    - If "Available Context" doesn't answer a project-data question, do NOT refuse flatly. Be useful: give whatever relevant general guidance you reasonably can, then add ONE brief, natural line that the specifics aren't in their project documents yet — e.g., "I don't see that in your project documents yet; you can upload the relevant file or ask me to search for something else." Do NOT add that line to conversational, identity, or general answers.
 
 2.  **Context Synthesis:**
     - If multiple context chunks conflict, mention the discrepancy (e.g., "Document A states X, while Document B states Y").


### PR DESCRIPTION
The assistant refused everything not in documents (even "who are you?") and hardcoded a "No specific documents were found…" footer on every empty-context answer. Now: it answers identity/capability/greetings/general questions directly; keeps PROJECT facts (budgets/dates/specs) strictly from documents (no invention); and when a project-data question isn't covered, stays useful + adds a brief natural note instead of a flat refusal. Removed the hardcoded `NO_CONTEXT_FOOTER` (nodes.py) — the model phrases it now, only when relevant.