### PR TITLE
feat(explore): tool-calling agent loop + search_documents/search_sbi_knowledge tools

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -2,8 +2,11 @@
 OPEN_ROUTER_KEY=your_open_router_key_here
 
 # Chat Models (OpenRouter model IDs)
+# FAST_MODEL drives the tool-calling agent loop, so it MUST be a tool-capable model.
 FAST_MODEL=deepseek/deepseek-v4-flash
-THINK_MODEL=deepseek/deepseek-v4-pro
+# THINK_MODEL is used for the final answer when model_preference="thinking".
+# Ring supports tool calls + structured outputs (deepseek-v4-pro lacks tool support).
+THINK_MODEL=inclusionai/ring-2.6-1t
 
 # Embedding Model
 EMBEDDING_MODEL=qwen/qwen3-embedding-8b

--- a/backend/app/explore/agents/graph.py
+++ b/backend/app/explore/agents/graph.py
@@ -1,4 +1,12 @@
+import json
+import logging
 from typing import Any, AsyncGenerator, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+# Cap on tool-decision iterations so a model that keeps requesting tools can
+# never spin the turn forever.
+MAX_TOOL_ITERATIONS = 4
 
 
 async def run_graph_streaming(
@@ -8,76 +16,187 @@ async def run_graph_streaming(
     attachments: Optional[List[Dict[str, str]]] = None,
     model_preference: str = "fast",
 ) -> AsyncGenerator[Dict[str, Any], None]:
-    """Run the Explore agent pipeline, yielding SSE events.
+    """Run the Explore agent tool-calling loop, yielding SSE events.
 
-    Phase events map to the pipeline nodes:
-      thinking   -- rewrite_query
-      planning   -- semantic_route
-      searching  -- retrieve_context
-      generating -- generate_response_streaming (interleaved with delta events)
+    Flow:
+      1. On the first turn (empty ``history``) emit a ``title`` event.
+      2. Emit ``phase: thinking``, then run a NON-streaming tool-decision loop
+         (max ``MAX_TOOL_ITERATIONS``) using ``FAST_MODEL`` with ``tools`` and
+         ``tool_choice="auto"``. Each requested tool is executed via
+         ``execute_tool``; ``search_documents`` results contribute citation
+         sources.
+      3. Emit ``phase: generating`` and produce the FINAL answer as a STREAMING
+         completion WITHOUT tools, yielding ``delta`` events per token.
+      4. Emit a single ``result`` event with the full answer and sources.
 
-    Delta events carry token chunks from the model. The final yield is a
-    result event with the complete response and source citations.
-
-    On the first turn of a conversation (empty ``history``) a ``title`` event is
-    also emitted with an auto-generated conversation title.
+    The SSE contract (title / phase / delta / result) is preserved exactly; the
+    endpoint owns the ``session`` event, so it is never emitted here.
     """
+    # Imported lazily to keep import-time side effects (OpenAI client creation)
+    # out of module import and mirror the previous graph.py structure.
     from app.explore.agents.nodes import (
-        rewrite_query,
-        semantic_route,
-        retrieve_context,
-        generate_response_streaming,
-        format_sources,
+        openrouter_client,
         generate_title,
+        _format_sources_list,
     )
+    from app.explore.agents.prompts import AGENT_SYSTEM_PROMPT
+    from app.explore.agents.tools import TOOLS, execute_tool
+    from app.explore.core.config import settings
 
     history = history or []
+    attachments = attachments or []
 
-    state: Dict[str, Any] = {
-        "query": query,
-        "client_id": client_id,
-        "history": history,
-        "attachments": attachments or [],
-        "model_preference": model_preference,
-        "standalone_query": "",
-        "route": "",
-        "route_reason": "",
-        "context": "",
-        "retrieved_docs": [],
-        "response": "",
-        "sources": [],
-    }
-
-    # First turn (no prior history): generate a concise conversation title so the
-    # client can label the session. Best-effort and additive — never blocks the turn.
+    # First turn: best-effort conversation title (never blocks the turn).
     if not history:
         title = await generate_title(query)
         yield {"type": "title", "title": title}
 
     yield {"type": "phase", "phase": "thinking"}
-    state = await rewrite_query(state)
 
-    if state.get("route") != "direct":
-        yield {"type": "phase", "phase": "planning"}
-        state = await semantic_route(state)
+    # Build the working message list. History is normalized to role/content
+    # pairs and capped to the last ~10 turns to bound prompt size.
+    messages: List[Dict[str, Any]] = [
+        {"role": "system", "content": AGENT_SYSTEM_PROMPT}
+    ]
+    for msg in history[-10:]:
+        role = msg.get("role", "user")
+        content = msg.get("content", "")
+        if role in ("user", "assistant") and content:
+            messages.append({"role": role, "content": content})
+    messages.append({"role": "user", "content": query})
 
-        yield {"type": "phase", "phase": "searching"}
-        state = await retrieve_context(state)
+    collected_sources: List[Dict[str, Any]] = []
+    searched_emitted = False
 
-        # Materialize sources before generation so the prompt can reference them by [n].
-        state = await format_sources(state)
+    # --- Tool-decision loop (non-streaming) ---------------------------------
+    for iteration in range(MAX_TOOL_ITERATIONS):
+        try:
+            resp = await openrouter_client.chat.completions.create(
+                model=settings.fast_model,
+                messages=messages,
+                tools=TOOLS,
+                tool_choice="auto",
+            )
+        except Exception:
+            # A failure deciding on tools must not crash the turn; fall through
+            # to generation with whatever (if anything) we have so far.
+            logger.exception("Tool-decision call failed; proceeding to generation")
+            break
 
+        message = resp.choices[0].message
+        tool_calls = getattr(message, "tool_calls", None)
+
+        if not tool_calls:
+            # Model is ready to answer; stop deciding and stream the final answer.
+            break
+
+        # Record the assistant's tool-call message so the tool results attach
+        # to the right call ids.
+        messages.append({
+            "role": "assistant",
+            "content": message.content or "",
+            "tool_calls": [
+                {
+                    "id": tc.id,
+                    "type": "function",
+                    "function": {
+                        "name": tc.function.name,
+                        "arguments": tc.function.arguments or "{}",
+                    },
+                }
+                for tc in tool_calls
+            ],
+        })
+
+        if not searched_emitted:
+            yield {"type": "phase", "phase": "searching"}
+            searched_emitted = True
+
+        for tc in tool_calls:
+            name = tc.function.name
+            raw_args = tc.function.arguments or "{}"
+            try:
+                args = json.loads(raw_args) if raw_args.strip() else {}
+                if not isinstance(args, dict):
+                    args = {}
+            except (json.JSONDecodeError, TypeError):
+                logger.warning(f"Failed to parse tool args for {name}: {raw_args!r}")
+                args = {}
+
+            result_text, sources = await execute_tool(name, args, client_id)
+            collected_sources.extend(sources)
+
+            messages.append({
+                "role": "tool",
+                "tool_call_id": tc.id,
+                "content": result_text,
+            })
+    else:
+        # Loop exhausted iterations without the model settling on an answer.
+        logger.info(
+            f"Tool loop hit MAX_TOOL_ITERATIONS ({MAX_TOOL_ITERATIONS}); "
+            "forcing final generation"
+        )
+
+    # Dedupe sources while preserving order so [n] indices stay stable.
+    deduped_sources: List[Dict[str, Any]] = []
+    seen_keys: set[str] = set()
+    for s in collected_sources:
+        key = f"{s.get('filename')}:{s.get('page_number')}"
+        if key in seen_keys:
+            continue
+        seen_keys.add(key)
+        deduped_sources.append(s)
+    collected_sources = deduped_sources
+
+    # If documents were cited, give the model the numbered source list so it can
+    # attach [n] markers to project facts in the final streamed answer.
+    if collected_sources:
+        messages.append({
+            "role": "system",
+            "content": (
+                "Available Sources (cite project facts drawn from these using [n] "
+                "markers, matching the index below; use only these indices):\n"
+                + _format_sources_list(collected_sources)
+            ),
+        })
+
+    # --- Final answer (streaming, no tools) ---------------------------------
     yield {"type": "phase", "phase": "generating"}
-    async for event in generate_response_streaming(state):
-        if event["type"] == "delta":
-            yield event
-        elif event["type"] == "state":
-            state = event["state"]
+
+    model = settings.think_model if model_preference == "thinking" else settings.fast_model
+
+    answer_parts: List[str] = []
+    try:
+        stream = await openrouter_client.chat.completions.create(
+            model=model,
+            messages=messages,
+            stream=True,
+        )
+        async for chunk in stream:
+            if not chunk.choices:
+                continue
+            delta = chunk.choices[0].delta.content
+            if delta:
+                answer_parts.append(delta)
+                yield {"type": "delta", "text": delta}
+    except Exception:
+        logger.exception("Final response generation failed")
+        if not answer_parts:
+            err = (
+                "I ran into a problem while generating a response. "
+                "Please try again in a moment, or rephrase your question."
+            )
+            yield {"type": "delta", "text": err}
+            answer_parts.append(err)
+
+    full_answer = "".join(answer_parts).strip()
+    if not full_answer:
+        full_answer = "I was unable to generate a response. Please try rephrasing your question."
+        yield {"type": "delta", "text": full_answer}
 
     yield {
         "type": "result",
-        "answer": state.get("response", ""),
-        "sources": state.get("sources", []),
-        "route": state.get("route", ""),
-        "route_reason": state.get("route_reason", ""),
+        "answer": full_answer,
+        "sources": collected_sources,
     }

--- a/backend/app/explore/agents/prompts.py
+++ b/backend/app/explore/agents/prompts.py
@@ -18,6 +18,34 @@ SYSTEM_PROMPT = """You are the Project Manager Assistant for the Sustainable Bui
 - Prefer the shortest answer that fully and accurately responds. Brevity is a feature."""
 
 
+# System prompt for the tool-calling agent loop.
+# Extends SYSTEM_PROMPT's grounding philosophy with tool-use guidance: answer
+# conversational/identity questions directly, call tools for facts, and ground
+# project facts ONLY in tool results.
+AGENT_SYSTEM_PROMPT = """You are the Project Manager Assistant for the Sustainable Building Initiative (SBI). You help clients understand their construction and sustainability projects, and you can answer questions about SBI itself.
+
+You have two tools:
+- `search_documents` — searches the client's uploaded project documents (their specs, meeting notes, reports). Call this for ANY question about the client's specific project: facts, figures, dates, budgets, specs, deliverables, or document contents.
+- `search_sbi_knowledge` — looks up general info about SBI: what it is, its mission, services, team/leadership, departments, and how this portal works. Call this for "what is SBI" / "who runs SBI" style questions.
+
+### WHEN TO CALL A TOOL vs. ANSWER DIRECTLY
+- Greetings, small talk, identity questions ("who are you?", "what can you do?"), and clarifying questions: answer directly, no tool call.
+- Questions about the client's PROJECT facts: call `search_documents` first.
+- Questions about SBI the organization or how the portal works: call `search_sbi_knowledge`.
+- You may call a tool more than once with refined queries if the first result is thin, but keep it efficient.
+
+### GROUNDING (most important)
+- Ground project facts ONLY in `search_documents` results. Never invent budgets, dates, specs, or other project details from outside knowledge.
+- If a project question isn't covered by the documents, say so briefly and plainly ("The current documentation does not contain this information."), then stay useful — offer what you can or suggest next steps. Do not guess.
+- Ground SBI/org facts in `search_sbi_knowledge` results.
+- If two sources conflict, point out the discrepancy instead of silently picking one.
+- For safety, hazardous-material, or structural questions, prioritize accuracy and quote the relevant warning verbatim as a blockquote.
+
+### TONE & FORMATTING
+- Direct, objective, professional. Start with the answer; skip filler ("I apologize", "As an AI", "Here is the information you requested").
+- Let the answer's shape follow the question. A simple question gets a sentence or two — do not force headings, tables, or summaries onto answers that don't need them. Use Markdown structure only where it earns its place. Prefer the shortest answer that fully and accurately responds."""
+
+
 # Prompt for generating the final response
 GENERATE_RESPONSE_PROMPT = """You are an expert AI Knowledge Assistant. Your task is to synthesize a precise, well-formatted answer to the User Query based STRICTLY on the provided Context and Conversation History.
 

--- a/backend/app/explore/agents/tools.py
+++ b/backend/app/explore/agents/tools.py
@@ -1,0 +1,163 @@
+"""Tool definitions and dispatch for the Explore agent tool-calling loop.
+
+Exposes two tools to the model:
+  - ``search_documents`` — RAG over the client's uploaded project documents.
+  - ``search_sbi_knowledge`` — curated org knowledge about SBI and the portal.
+
+``TOOLS`` is the OpenAI function-calling schema list passed to the chat
+completion. ``execute_tool`` dispatches a single tool call and returns the tool
+result text plus any citation sources (only ``search_documents`` yields sources).
+"""
+
+import logging
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+from app.explore.agents.nodes import rag_service
+
+logger = logging.getLogger(__name__)
+
+
+# --- Curated SBI knowledge (loaded once at import) ---------------------------
+
+def _load_sbi_knowledge() -> str:
+    """Load the curated SBI knowledge markdown bundled with the package."""
+    path = Path(__file__).resolve().parent.parent / "knowledge" / "sbi.md"
+    try:
+        return path.read_text(encoding="utf-8").strip()
+    except Exception as e:  # pragma: no cover - defensive; file is bundled
+        logger.warning(f"Failed to load SBI knowledge from {path}: {e}")
+        return (
+            "The Sustainable Building Initiative (SBI) is a student-led "
+            "sustainable-building consultancy founded at the University of Texas "
+            "at Austin in 2024."
+        )
+
+
+SBI_KNOWLEDGE: str = _load_sbi_knowledge()
+
+
+# --- Tool schemas ------------------------------------------------------------
+
+TOOLS: List[Dict[str, Any]] = [
+    {
+        "type": "function",
+        "function": {
+            "name": "search_documents",
+            "description": (
+                "Search the client's uploaded project documents for relevant "
+                "passages. Use this for any question about the client's specific "
+                "project: facts, figures, dates, budgets, specs, meeting notes, "
+                "deliverables, or document contents."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "description": (
+                            "A focused, self-contained search query describing the "
+                            "project information to retrieve."
+                        ),
+                    },
+                },
+                "required": ["query"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "search_sbi_knowledge",
+            "description": (
+                "Look up general info about SBI (Sustainable Building Initiative): "
+                "what it is, its mission, services, team/leadership, departments, "
+                "and how the portal works. Use this for 'what is SBI' or 'who is "
+                "SBI' style questions, not for the client's own project documents."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "description": (
+                            "What to look up about SBI (e.g. 'mission', "
+                            "'leadership', 'departments', 'how the portal works')."
+                        ),
+                    },
+                },
+                "required": ["query"],
+            },
+        },
+    },
+]
+
+
+# --- Tool implementations ----------------------------------------------------
+
+async def _search_documents(query: str, client_id: str) -> Tuple[str, List[Dict[str, Any]]]:
+    """Run RAG retrieval; return (context_text, sources) for citations."""
+    if not query or not query.strip():
+        return "No search query was provided.", []
+
+    docs = await rag_service.retrieve_relevant(query=query, client_id=client_id)
+    if not docs:
+        return (
+            "No matching passages were found in the client's project documents "
+            "for this query.",
+            [],
+        )
+
+    context_text = rag_service.build_context_string(retrieved_docs=docs)
+
+    sources: List[Dict[str, Any]] = []
+    seen: set[str] = set()
+    for doc in docs:
+        metadata = doc.get("metadata", {})
+        filename = metadata.get("filename", "Unknown")
+        page = metadata.get("page_number")
+        key = f"{filename}:{page}" if page else filename
+        if key in seen:
+            continue
+        seen.add(key)
+        rerank_score = doc.get("rerank_score")
+        relevance = (
+            rerank_score if rerank_score is not None else doc.get("similarity_score", 0.0)
+        )
+        sources.append({
+            "content": (doc.get("content", "") or "")[:500],
+            "filename": filename,
+            "page_number": page,
+            "relevance_score": relevance,
+        })
+
+    return context_text, sources
+
+
+def _search_sbi_knowledge(query: str) -> Tuple[str, List[Dict[str, Any]]]:
+    """Return the curated SBI knowledge text. No document sources."""
+    # The curated knowledge is small, so returning it whole gives the model the
+    # full picture; the ``query`` is accepted for interface symmetry and logging.
+    return SBI_KNOWLEDGE, []
+
+
+async def execute_tool(
+    name: str, args: Dict[str, Any], client_id: str
+) -> Tuple[str, List[Dict[str, Any]]]:
+    """Dispatch a single tool call.
+
+    Returns ``(result_text, sources)``. Never raises: a tool failure is returned
+    as an error string so the agent loop can continue the turn.
+    """
+    try:
+        if name == "search_documents":
+            query = str(args.get("query", "")) if args else ""
+            return await _search_documents(query, client_id)
+        if name == "search_sbi_knowledge":
+            query = str(args.get("query", "")) if args else ""
+            return _search_sbi_knowledge(query)
+        logger.warning(f"Unknown tool requested: {name}")
+        return f"Unknown tool '{name}'. No action taken.", []
+    except Exception:
+        logger.exception(f"Tool '{name}' failed")
+        return f"The tool '{name}' encountered an error and returned no results.", []

--- a/backend/app/explore/knowledge/sbi.md
+++ b/backend/app/explore/knowledge/sbi.md
@@ -1,0 +1,77 @@
+# Sustainable Building Initiative (SBI)
+
+## What SBI Is
+The Sustainable Building Initiative (SBI) is a professionally driven, student-led
+consultancy founded at the University of Texas at Austin in 2024. It unites
+students from every academic discipline to function as a single, cohesive company,
+tackling real-world infrastructure challenges. Its tagline: "Research Driven.
+Professionally Inspired. Student Powered."
+
+## Mission & Vision
+- **Mission:** Provide hands-on consultancy experience that delivers tangible value
+  to clients while developing members' practical skills. SBI executes
+  professional-grade sustainable building projects that address the specific needs
+  of its clients and community, transforming ambitious ideas into tangible
+  realities.
+- **Vision:** Drive innovation in sustainable infrastructure and empower the next
+  generation of industry leaders. SBI bridges the gap between academic theory and
+  professional practice, addressing the technical, environmental, and economic
+  aspects of sustainable development. Its goal is to become the premier student-led
+  consultancy for sustainable development in the region.
+
+## How SBI Works (Strategy)
+1. **Identify the Opportunity** — Assess infrastructure challenges to find where
+   sustainable design can deliver the greatest impact for clients and community.
+2. **Architect the Solution** — Fuse client vision with cutting-edge sustainable
+   practices to design practical, personalized solutions.
+3. **Execute with Precision** — A hands-on implementation approach, delivering
+   projects on time and to a high professional standard.
+
+## Departments
+- **Engineering** — Structural analysis and load-bearing design, MEP systems
+  integration for energy performance, sustainable infrastructure planning with
+  lifecycle assessment.
+- **Architecture** — Conceptual design and creative direction, 3D modeling and
+  visualization, spatial planning balancing function, aesthetics, and
+  sustainability.
+- **Business** — Project management from inception to handoff, client relations and
+  stakeholder communication, strategic planning aligned with growth and
+  sustainability targets.
+- **Legal** — Contract negotiation and documentation, zoning compliance and
+  regulatory navigation, internal relations and conflict mitigation.
+- **Technology** — Building information modeling, energy simulations and performance
+  benchmarking, digital infrastructure for collaboration and data integrity.
+- **Research & Development** — Material science research, sustainability metrics and
+  environmental impact quantification, innovation labs prototyping emerging
+  construction technologies.
+- **Public Relations** — Community engagement and public-facing communication,
+  outreach programs connecting partners and stakeholders, partnership development.
+
+## Leadership / Team
+SBI is a student organization. Current leadership:
+- Pedro Guzman — President
+- Sam Moran — Vice President
+- Brendan Lyon — Director of Project Operations
+- Kabir Muzumdar — Director of Civil Engineering
+- Preston Vajdos — Director of Civil Engineering
+- Enoch Zhu — Director of External Technologies
+- Daniel Lam — Director of Internal Technologies
+- Dev Shroff — Director of Business
+- Arianne Grace — Director of Public Relations
+- Christian Butler — Director of Architecture
+- Alim Makanov — Director of Legal
+
+## By the Numbers
+- $210M+ project portfolio of professional-grade sustainable solutions.
+- 50+ multidisciplinary student members from engineering, business, and technology.
+- 1500+ hours contributed to innovative designs serving the community.
+
+## Partner Universities
+Texas A&M, Rice University, UT Austin, Harvard University, and Imperial College London.
+
+## The Portal
+This portal is SBI's client-facing platform. Clients can view their projects and
+use the Explore AI assistant to ask questions about their uploaded project
+documents, meeting notes, and specifications. The assistant grounds project-specific
+answers in the client's own documents. To join SBI, applications are accepted via
+the team's application form; to reach SBI, use the Contact page.


### PR DESCRIPTION
## Summary
Phase 1 of a tool-calling agent loop for the Explore chat backend. `run_graph_streaming` is rewritten from a fixed rewrite→route→retrieve→generate pipeline into a model-driven tool-calling loop, while preserving the exact SSE contract the Next.js route + frontend depend on.

## Loop design (`backend/app/explore/agents/graph.py`)
1. **Title** — first turn only (empty history), reuses `generate_title`.
2. **Phase `thinking`** — build `messages = [AGENT_SYSTEM_PROMPT, *history(last 10), user query]`.
3. **Tool-decision loop (non-streaming, max 4 iterations)** — `FAST_MODEL` with `tools=TOOLS, tool_choice="auto"`.
   - On `tool_calls`: append the assistant tool-call message, emit `phase: searching` (once), run each tool via `execute_tool` (defensive `json.loads` of arguments), append a `{role: "tool", tool_call_id, content}` per call, collect sources.
   - No `tool_calls` → break and answer.
4. **Sources** — dedupe (stable order so `[n]` stays aligned), and if any were collected, append a system message listing them via `_format_sources_list` + a one-line `[n]` citation instruction.
5. **Phase `generating`** — final answer is a **streaming** completion **without tools** (`THINK_MODEL` if `model_preference == "thinking"`, else `FAST_MODEL`); each non-empty chunk yields `{type: "delta", text}`; the full answer is accumulated.
6. **`result`** — single event with `{answer, sources}`.

Hardening: every tool error is caught and returned as an error string (never crashes the turn); tool-decision and final-generation calls are wrapped in try/except with graceful fallbacks; total tool iterations capped at 4.

## Preserved SSE contract
Emits, in order: `title` (first turn) → `phase` (thinking|searching|generating) → `delta` (per token of final answer) → `result` (`answer` + `sources`). No `session` event (owned by the Next.js route). `explore.py`'s signature is unchanged; `chat.py` still strips `sources` when `include_sources` is false.

## Tools (`backend/app/explore/agents/tools.py`)
- **`search_documents(query)`** — `rag_service.retrieve_relevant(query, client_id)`; returns `build_context_string(docs)` as the tool result text plus deduped citation sources.
- **`search_sbi_knowledge(query)`** — returns curated org text (whole; it's small). No document sources.
- `execute_tool(name, args, client_id) -> (result_text, sources)` — never raises.

## SBI knowledge (`backend/app/explore/knowledge/sbi.md`)
Distilled at import time from the in-repo frontend marketing copy: `frontend/app/(static)/about/page.tsx`, `frontend/app/(static)/page.tsx`, and `frontend/lib/data/home.ts`. Covers what SBI is, mission/vision, the 3-step strategy, departments, leadership roster, the numbers, partner universities, and how the portal works.

## THINK_MODEL swap
`.env.example`: `THINK_MODEL` → `inclusionai/ring-2.6-1t` (was `deepseek/deepseek-v4-pro`, which lacks tool support). `FAST_MODEL` unchanged (`deepseek/deepseek-v4-flash`); added a comment that FAST drives the loop and **must** be tool-capable.

## Notes
- Old pipeline nodes (`rewrite_query`/`semantic_route`/`retrieve_context`/`generate_response_streaming`) are left in `nodes.py` untouched; `graph.py` no longer imports them (unused imports removed, ruff clean).
- The previous `result` extras `route`/`route_reason` are no longer emitted (there is no routing step). The endpoint and frontend only depend on `answer`/`sources`.

## Verification
- `python -m py_compile graph.py tools.py nodes.py prompts.py` → OK
- `uvx ruff check app/explore` → All checks passed
- Import smoke (`uv run`): `import app.explore.agents.graph, ...tools` → tools `['search_documents','search_sbi_knowledge']`, `SBI_KNOWLEDGE` 4115 chars, `run_graph_streaming` present, `execute_tool` is a coroutine.

## TODO(confirm)
SBI facts pulled from frontend marketing copy — please confirm before relying on them in answers:
- **Leadership roster** (names/titles): President Pedro Guzman, VP Sam Moran, Directors (Brendan Lyon — Project Operations; Kabir Muzumdar & Preston Vajdos — Civil Engineering; Enoch Zhu — External Technologies; Daniel Lam — Internal Technologies; Dev Shroff — Business; Arianne Grace — Public Relations; Christian Butler — Architecture; Alim Makanov — Legal). Source lists a Director of R&D as vacant/commented-out. Confirm this is current.
- **Stats**: \$210M+ portfolio, 50+ members, 1500+ hours — confirm these marketing figures should be stated as fact by the assistant.
- **Founded 2024 at UT Austin** and **partner universities** (Texas A&M, Rice, UT Austin, Harvard, Imperial College London) — confirm accuracy.