### PR TITLE
feat(dashboard): sidebar IA by scope + top-bar project switcher

### DIFF
--- a/frontend/app/dashboard/layout.tsx
+++ b/frontend/app/dashboard/layout.tsx
@@ -1,6 +1,7 @@
 import { redirect } from "next/navigation";
 import { AppSidebar } from "@/components/dashboard/common/app-sidebar";
 import { ProjectStatusBar } from "@/components/dashboard/common/ProjectStatusBar";
+import { ProjectSwitcher } from "@/components/dashboard/common/ProjectSwitcher";
 import { ProjectSwitchOverlay } from "@/components/dashboard/common/ProjectSwitchOverlay";
 import { SidebarTriggerCustom } from "@/components/dashboard/common/SidebarTriggerCustom";
 import { TimeDisplay } from "@/components/dashboard/explore/ui/TimeDisplay";
@@ -39,13 +40,17 @@ export default async function DashboardLayout({
             <AppSidebar />
             <div className="flex-1 flex flex-col min-h-0">
               {/* Header */}
-              <header className="relative flex h-16 shrink-0 items-center gap-2 bg-sbi-dark px-6 border-b border-sbi-dark-border/30">
-                <div className="absolute left-0 top-0 w-16 h-full border-r border-sbi-dark-border/20" />
-
-                {/* Sidebar */}
-                <div className="relative z-10">
+              <header className="relative flex h-16 shrink-0 items-center gap-2 bg-sbi-dark pr-6 border-b border-sbi-dark-border/30">
+                {/* Sidebar trigger — px-6 on both sides so the right hairline
+                    mirrors the left inset (was an absolute w-16 strip). */}
+                <div className="relative z-10 flex h-full items-center px-6 border-r border-sbi-dark-border/20">
                   <SidebarTriggerCustom />
                 </div>
+
+                {/* Active-project context (switcher for directors/members,
+                    static label for clients) — always visible here regardless
+                    of the sidebar's collapsed state. */}
+                <ProjectSwitcher />
 
                 <ProjectStatusBar />
 

--- a/frontend/components/dashboard/common/ProjectStatusBar.tsx
+++ b/frontend/components/dashboard/common/ProjectStatusBar.tsx
@@ -107,7 +107,7 @@ export function ProjectStatusBar() {
   }, [projects]);
 
   return (
-    <div className="hidden md:flex items-center gap-1 border-l border-sbi-dark-border/30 ml-4">
+    <div className="hidden md:flex items-center gap-1 border-l border-sbi-dark-border/30 ml-4 pl-4 [&>.group:first-of-type]:pl-0">
       <StatusIndicator
         label="Active Tasks"
         value={stats.active}

--- a/frontend/components/dashboard/common/ProjectSwitcher.tsx
+++ b/frontend/components/dashboard/common/ProjectSwitcher.tsx
@@ -1,7 +1,12 @@
 "use client";
 
 import { Check, ChevronDown } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { useProject } from "@/lib/project/project-context";
 import { cn } from "@/lib/utils";
 
@@ -17,37 +22,9 @@ import { cn } from "@/lib/utils";
  */
 export function ProjectSwitcher() {
   const { user, activeProject, projects, switchProject } = useProject();
-  const [open, setOpen] = useState(false);
-  const ref = useRef<HTMLDivElement>(null);
-  const buttonRef = useRef<HTMLButtonElement>(null);
 
   const role = user?.role;
   const canSwitch = role === "director" || role === "member";
-
-  // Close on outside click.
-  useEffect(() => {
-    if (!open) return;
-    const handleClickOutside = (event: MouseEvent) => {
-      if (ref.current && !ref.current.contains(event.target as Node)) {
-        setOpen(false);
-      }
-    };
-    document.addEventListener("mousedown", handleClickOutside);
-    return () => document.removeEventListener("mousedown", handleClickOutside);
-  }, [open]);
-
-  // Escape closes the menu and returns focus to the trigger.
-  useEffect(() => {
-    if (!open) return;
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") {
-        setOpen(false);
-        buttonRef.current?.focus();
-      }
-    };
-    document.addEventListener("keydown", handleKeyDown);
-    return () => document.removeEventListener("keydown", handleKeyDown);
-  }, [open]);
 
   // Nothing to show until the project context has resolved a project.
   if (!activeProject && !canSwitch) return null;
@@ -75,86 +52,72 @@ export function ProjectSwitcher() {
   }
 
   return (
-    <div ref={ref} className="relative ml-4">
-      <button
-        ref={buttonRef}
-        type="button"
-        onClick={() => setOpen(!open)}
-        aria-haspopup="menu"
-        aria-expanded={open}
-        aria-label="Switch project"
-        className="group relative flex flex-col px-4 py-2 text-left"
-      >
-        {eyebrow}
-        <span className="flex items-center gap-1.5 text-xs font-light text-white">
-          <span className="max-w-[160px] truncate">{label}</span>
-          <ChevronDown
-            className={cn(
-              "size-3 shrink-0 text-sbi-muted transition-transform duration-300",
-              "group-hover:text-sbi-green",
-              open && "rotate-180",
-            )}
-            strokeWidth={1.5}
-          />
-        </span>
-
-        {/* Hairline green underline on hover, mirroring StatusIndicator. */}
-        <span
-          className={cn(
-            "absolute bottom-0 left-0 right-0 h-px transition-colors duration-300",
-            open
-              ? "bg-sbi-green/40"
-              : "bg-sbi-green/0 group-hover:bg-sbi-green/30",
-          )}
-        />
-      </button>
-
-      {open && (
-        <div
-          role="menu"
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
           aria-label="Switch project"
-          className="absolute left-2 top-full z-50 mt-1.5 w-60 rounded-xl border border-sbi-dark-border bg-sbi-dark p-1.5 shadow-xl shadow-black/40"
+          className="group relative ml-4 flex flex-col px-4 py-2 text-left"
         >
-          <p className="px-2.5 pb-1.5 pt-1 text-[0.7rem] uppercase tracking-[0.2em] text-sbi-muted-dark">
-            Switch project
-          </p>
-          {projects.map((project) => {
-            const isActive = activeProject?.projectId === project.projectId;
-            return (
-              <button
-                key={project.projectId}
-                type="button"
-                role="menuitem"
-                onClick={() => {
-                  switchProject(project.projectId);
-                  setOpen(false);
-                  buttonRef.current?.focus();
-                }}
+          {eyebrow}
+          <span className="flex items-center gap-1.5 text-xs font-light text-white">
+            <span className="max-w-[160px] truncate">{label}</span>
+            <ChevronDown
+              className={cn(
+                "size-3 shrink-0 text-sbi-muted transition-transform duration-300",
+                "group-hover:text-sbi-green",
+                "group-data-[state=open]:rotate-180 group-data-[state=open]:text-sbi-green",
+              )}
+              strokeWidth={1.5}
+            />
+          </span>
+
+          {/* Hairline green underline on hover, mirroring StatusIndicator. */}
+          <span
+            className={cn(
+              "absolute bottom-0 left-0 right-0 h-px transition-colors duration-300",
+              "bg-sbi-green/0 group-hover:bg-sbi-green/30 group-data-[state=open]:bg-sbi-green/40",
+            )}
+          />
+        </button>
+      </DropdownMenuTrigger>
+
+      <DropdownMenuContent
+        align="start"
+        alignOffset={8}
+        sideOffset={6}
+        className="w-60 rounded-xl border-sbi-dark-border bg-sbi-dark p-1.5 shadow-xl shadow-black/40"
+      >
+        <p className="px-2.5 pb-1.5 pt-1 text-[0.7rem] uppercase tracking-[0.2em] text-sbi-muted-dark">
+          Switch project
+        </p>
+        {projects.map((project) => {
+          const isActive = activeProject?.projectId === project.projectId;
+          return (
+            <DropdownMenuItem
+              key={project.projectId}
+              onClick={() => switchProject(project.projectId)}
+              className={cn(
+                "flex cursor-pointer items-center gap-2.5 rounded-lg px-2.5 py-2 text-sm transition-colors focus:bg-sbi-dark-card",
+                isActive
+                  ? "text-sbi-green focus:text-sbi-green"
+                  : "text-sbi-muted focus:text-white",
+              )}
+            >
+              <span
                 className={cn(
-                  "flex w-full cursor-pointer items-center gap-2.5 rounded-lg px-2.5 py-2 text-left text-sm transition-colors",
-                  isActive
-                    ? "text-sbi-green"
-                    : "text-sbi-muted hover:bg-sbi-dark-card hover:text-white",
+                  "size-1.5 shrink-0 rounded-full transition-colors",
+                  isActive ? "bg-sbi-green" : "bg-sbi-muted-dark/40",
                 )}
-              >
-                <span
-                  className={cn(
-                    "size-1.5 shrink-0 rounded-full transition-colors",
-                    isActive ? "bg-sbi-green" : "bg-sbi-muted-dark/40",
-                  )}
-                />
-                <span className="truncate">{project.companyName}</span>
-                {isActive && (
-                  <Check
-                    className="ml-auto size-3.5 shrink-0"
-                    strokeWidth={2}
-                  />
-                )}
-              </button>
-            );
-          })}
-        </div>
-      )}
-    </div>
+              />
+              <span className="truncate">{project.companyName}</span>
+              {isActive && (
+                <Check className="ml-auto size-3.5 shrink-0" strokeWidth={2} />
+              )}
+            </DropdownMenuItem>
+          );
+        })}
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }

--- a/frontend/components/dashboard/common/ProjectSwitcher.tsx
+++ b/frontend/components/dashboard/common/ProjectSwitcher.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import { Check, ChevronDown } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { useProject } from "@/lib/project/project-context";
+import { cn } from "@/lib/utils";
+
+/**
+ * Active-project context for the dashboard header.
+ *
+ * Shares the visual language of the adjacent ProjectStatusBar StatusIndicators:
+ * a tracked eyebrow label over a light value, no boxed chrome, a hairline green
+ * underline on hover. Directors/members get a switcher (chevron + dropdown);
+ * clients get the same readout without the control. It lives in the top bar so
+ * the active project stays visible regardless of the sidebar's collapsed state,
+ * and the project-scoped nav + the AI assistant both follow what is selected.
+ */
+export function ProjectSwitcher() {
+  const { user, activeProject, projects, switchProject } = useProject();
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+
+  const role = user?.role;
+  const canSwitch = role === "director" || role === "member";
+
+  // Close on outside click.
+  useEffect(() => {
+    if (!open) return;
+    const handleClickOutside = (event: MouseEvent) => {
+      if (ref.current && !ref.current.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [open]);
+
+  // Escape closes the menu and returns focus to the trigger.
+  useEffect(() => {
+    if (!open) return;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setOpen(false);
+        buttonRef.current?.focus();
+      }
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [open]);
+
+  // Nothing to show until the project context has resolved a project.
+  if (!activeProject && !canSwitch) return null;
+
+  const label = activeProject?.companyName ?? "Select project";
+
+  // Stacked eyebrow + value, matching StatusIndicator's typography exactly
+  // (no gap, natural line-height) so the project block reads as part of the bar.
+  const eyebrow = (
+    <span className="text-[10px] font-medium uppercase tracking-[0.2em] text-sbi-muted-dark">
+      Project
+    </span>
+  );
+
+  // Clients: a static readout, no switching, no hover affordance.
+  if (!canSwitch) {
+    return (
+      <div className="ml-4 flex flex-col px-4 py-2">
+        {eyebrow}
+        <span className="max-w-[200px] truncate text-xs font-light text-white">
+          {label}
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <div ref={ref} className="relative ml-4">
+      <button
+        ref={buttonRef}
+        type="button"
+        onClick={() => setOpen(!open)}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-label="Switch project"
+        className="group relative flex flex-col px-4 py-2 text-left"
+      >
+        {eyebrow}
+        <span className="flex items-center gap-1.5 text-xs font-light text-white">
+          <span className="max-w-[160px] truncate">{label}</span>
+          <ChevronDown
+            className={cn(
+              "size-3 shrink-0 text-sbi-muted transition-transform duration-300",
+              "group-hover:text-sbi-green",
+              open && "rotate-180",
+            )}
+            strokeWidth={1.5}
+          />
+        </span>
+
+        {/* Hairline green underline on hover, mirroring StatusIndicator. */}
+        <span
+          className={cn(
+            "absolute bottom-0 left-0 right-0 h-px transition-colors duration-300",
+            open
+              ? "bg-sbi-green/40"
+              : "bg-sbi-green/0 group-hover:bg-sbi-green/30",
+          )}
+        />
+      </button>
+
+      {open && (
+        <div
+          role="menu"
+          aria-label="Switch project"
+          className="absolute left-2 top-full z-50 mt-1.5 w-60 rounded-xl border border-sbi-dark-border bg-sbi-dark p-1.5 shadow-xl shadow-black/40"
+        >
+          <p className="px-2.5 pb-1.5 pt-1 text-[0.7rem] uppercase tracking-[0.2em] text-sbi-muted-dark">
+            Switch project
+          </p>
+          {projects.map((project) => {
+            const isActive = activeProject?.projectId === project.projectId;
+            return (
+              <button
+                key={project.projectId}
+                type="button"
+                role="menuitem"
+                onClick={() => {
+                  switchProject(project.projectId);
+                  setOpen(false);
+                  buttonRef.current?.focus();
+                }}
+                className={cn(
+                  "flex w-full cursor-pointer items-center gap-2.5 rounded-lg px-2.5 py-2 text-left text-sm transition-colors",
+                  isActive
+                    ? "text-sbi-green"
+                    : "text-sbi-muted hover:bg-sbi-dark-card hover:text-white",
+                )}
+              >
+                <span
+                  className={cn(
+                    "size-1.5 shrink-0 rounded-full transition-colors",
+                    isActive ? "bg-sbi-green" : "bg-sbi-muted-dark/40",
+                  )}
+                />
+                <span className="truncate">{project.companyName}</span>
+                {isActive && (
+                  <Check
+                    className="ml-auto size-3.5 shrink-0"
+                    strokeWidth={2}
+                  />
+                )}
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/components/dashboard/common/app-sidebar.tsx
+++ b/frontend/components/dashboard/common/app-sidebar.tsx
@@ -41,18 +41,14 @@ interface NavItem {
   roles?: Array<"client" | "director" | "member">; // if undefined, shown to all
 }
 
-const mainItems: NavItem[] = [
+// Nav is grouped by SCOPE, not by content type:
+//   - General: cross-project surfaces that consolidate everything in one place
+//     and do NOT change when you switch the active project.
+//   - Project: surfaces scoped to the active project — switching the project
+//     (via the header switcher) changes what these show.
+const generalItems: NavItem[] = [
   { title: "Explore", path: "", icon: Compass },
   { title: "Messages", path: "/messages", icon: MessageSquare },
-  { title: "Calendar", path: "/calendar", icon: Calendar },
-  { title: "Finances", path: "/finances", icon: DollarSign },
-  { title: "Lifecycle", path: "/lifecycle", icon: Repeat },
-];
-
-const documentItems: NavItem[] = [
-  { title: "Files", path: "/files", icon: FolderOpen },
-  { title: "Reports", path: "/reports", icon: FileText },
-  { title: "Requests", path: "/requests", icon: MailQuestion },
   {
     title: "Questionnaire",
     path: "/questionnaire",
@@ -65,6 +61,15 @@ const documentItems: NavItem[] = [
     icon: FileEdit,
     roles: ["director"],
   },
+];
+
+const projectItems: NavItem[] = [
+  { title: "Lifecycle", path: "/lifecycle", icon: Repeat },
+  { title: "Calendar", path: "/calendar", icon: Calendar },
+  { title: "Finances", path: "/finances", icon: DollarSign },
+  { title: "Files", path: "/files", icon: FolderOpen },
+  { title: "Reports", path: "/reports", icon: FileText },
+  { title: "Requests", path: "/requests", icon: MailQuestion },
 ];
 
 // Settings is accessed from the user profile menu, not the nav
@@ -145,14 +150,11 @@ export function AppSidebar() {
   const isMobile = useIsMobile();
   const pathname = usePathname();
   const router = useRouter();
-  const { user, activeProject, projects, switchProject } = useProject();
+  const { user } = useProject();
   const { cancelRequest, clearChat, newSession } = useChat();
   const [isUserMenuOpen, setIsUserMenuOpen] = useState(false);
-  const [isProjectMenuOpen, setIsProjectMenuOpen] = useState(false);
   const userMenuRef = useRef<HTMLDivElement>(null);
-  const projectMenuRef = useRef<HTMLDivElement>(null);
   const userMenuButtonRef = useRef<HTMLButtonElement>(null);
-  const projectMenuButtonRef = useRef<HTMLButtonElement>(null);
 
   // On mobile the sidebar is an off-canvas overlay that always shows its full
   // (expanded) content; `open` only drives whether it's slid in or parked off
@@ -270,37 +272,17 @@ export function AppSidebar() {
     return () => document.removeEventListener("mousedown", handleClickOutside);
   }, []);
 
-  // Close project menu when clicking outside
+  // Escape closes the account menu and returns focus to its trigger.
   useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (
-        projectMenuRef.current &&
-        !projectMenuRef.current.contains(event.target as Node)
-      ) {
-        setIsProjectMenuOpen(false);
-      }
-    };
-    document.addEventListener("mousedown", handleClickOutside);
-    return () => document.removeEventListener("mousedown", handleClickOutside);
-  }, []);
-
-  // Escape closes whichever dropdown is open and returns focus to its trigger.
-  useEffect(() => {
-    if (!isUserMenuOpen && !isProjectMenuOpen) return;
+    if (!isUserMenuOpen) return;
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key !== "Escape") return;
-      if (isUserMenuOpen) {
-        setIsUserMenuOpen(false);
-        userMenuButtonRef.current?.focus();
-      }
-      if (isProjectMenuOpen) {
-        setIsProjectMenuOpen(false);
-        projectMenuButtonRef.current?.focus();
-      }
+      setIsUserMenuOpen(false);
+      userMenuButtonRef.current?.focus();
     };
     document.addEventListener("keydown", handleKeyDown);
     return () => document.removeEventListener("keydown", handleKeyDown);
-  }, [isUserMenuOpen, isProjectMenuOpen]);
+  }, [isUserMenuOpen]);
 
   // On mobile the sidebar is a slide-over: Escape and route changes dismiss it.
   useEffect(() => {
@@ -325,7 +307,6 @@ export function AppSidebar() {
     items.filter(
       (item) => !item.roles || (userRole && item.roles.includes(userRole)),
     );
-  const showProjectSwitcher = userRole === "director" || userRole === "member";
 
   return (
     <>
@@ -409,75 +390,8 @@ export function AppSidebar() {
           </button>
         </div>
 
-        {/* Project Switcher (directors/members only) */}
-        {showProjectSwitcher && !isCollapsed && (
-          <div
-            ref={projectMenuRef}
-            className="relative px-3 py-3 border-b border-sbi-dark-border/30"
-          >
-            <button
-              ref={projectMenuButtonRef}
-              type="button"
-              onClick={() => setIsProjectMenuOpen(!isProjectMenuOpen)}
-              aria-haspopup="menu"
-              aria-expanded={isProjectMenuOpen}
-              className="w-full flex items-center justify-between px-3 py-2 rounded-lg bg-sbi-dark-card/40 border border-sbi-dark-border/30 hover:border-sbi-green/30 transition-colors cursor-pointer"
-            >
-              <div className="flex flex-col text-left min-w-0">
-                <span className="text-[10px] tracking-widest uppercase text-sbi-muted">
-                  Project
-                </span>
-                <span className="text-sm text-white truncate">
-                  {activeProject?.companyName || "Select project"}
-                </span>
-              </div>
-              <ChevronUp
-                className={`size-4 text-sbi-muted transition-transform ${isProjectMenuOpen ? "" : "rotate-180"}`}
-              />
-            </button>
-            {isProjectMenuOpen && (
-              <div
-                role="menu"
-                aria-label="Switch project"
-                className="absolute top-full left-3 right-3 mt-1 bg-sbi-dark border border-sbi-dark-border/50 rounded-lg overflow-hidden shadow-2xl shadow-black/50 z-50"
-              >
-                {projects.map((project) => (
-                  <button
-                    key={project.projectId}
-                    type="button"
-                    role="menuitem"
-                    onClick={() => {
-                      switchProject(project.projectId);
-                      setIsProjectMenuOpen(false);
-                      projectMenuButtonRef.current?.focus();
-                    }}
-                    className={`w-full text-left px-4 py-2.5 text-sm transition-colors cursor-pointer ${
-                      activeProject?.projectId === project.projectId
-                        ? "text-sbi-green bg-sbi-green/5"
-                        : "text-white/70 hover:text-white hover:bg-white/5"
-                    }`}
-                  >
-                    {project.companyName}
-                  </button>
-                ))}
-              </div>
-            )}
-          </div>
-        )}
-
-        {/* Client project label (clients only) */}
-        {!showProjectSwitcher && !isCollapsed && activeProject && (
-          <div className="px-3 py-3 border-b border-sbi-dark-border/30">
-            <div className="px-3 py-2">
-              <span className="text-[10px] tracking-widest uppercase text-sbi-muted">
-                Project
-              </span>
-              <p className="text-sm text-white truncate">
-                {activeProject.companyName}
-              </p>
-            </div>
-          </div>
-        )}
+        {/* The active project lives in the top bar (ProjectSwitcher) so it stays
+            visible regardless of the sidebar's collapsed state. */}
 
         {/* Navigation. On Explore the primary nav stays fixed at its natural height
           and the chat-history list takes the remaining space with its own scroll;
@@ -489,9 +403,9 @@ export function AppSidebar() {
               showChatHistory ? "shrink-0" : "flex-1",
             )}
           >
-            {/* Main Navigation */}
+            {/* General (cross-project) Navigation */}
             <div className="space-y-1">
-              {filterByRole(mainItems).map((item) => (
+              {filterByRole(generalItems).map((item) => (
                 <NavLink
                   key={item.title}
                   item={item}
@@ -505,16 +419,16 @@ export function AppSidebar() {
             {/* Divider */}
             <div className="my-4 mx-3 h-px bg-linear-to-r from-transparent via-sbi-dark-border/50 to-transparent" />
 
-            {/* Documents Section */}
+            {/* Project Section — scoped to the active project (header switcher) */}
             <div className="space-y-1">
               {!isCollapsed && (
                 <div className="px-3 mb-2">
                   <span className="text-[10px] tracking-[0.2em] uppercase text-sbi-muted font-light">
-                    Documents
+                    Project
                   </span>
                 </div>
               )}
-              {filterByRole(documentItems).map((item) => (
+              {filterByRole(projectItems).map((item) => (
                 <NavLink
                   key={item.title}
                   item={item}


### PR DESCRIPTION
## Summary

Restructures the dashboard chrome so the **sidebar is pure navigation** and the **active project lives in the top bar**.

### Sidebar — grouped by scope
Replaces the old `main` / `Documents` split with a scope-based grouping:
- **General** (cross-project): Explore, Messages, Questionnaire / Form Builder
- **Project** (follows the active project): Lifecycle, Calendar, Finances, Files, Reports, Requests

### Top-bar `ProjectSwitcher` (new)
- Moves the switcher out of the sidebar into the header — **always visible regardless of sidebar collapse** (directors on the icon rail previously had no project context).
- Dropdown for directors/members; static label for clients.
- Matches the adjacent `ProjectStatusBar` `StatusIndicator` language: stacked eyebrow + light value, no boxed pill, hairline green hover underline. Dropdown uses the app menu pattern (rounded panel, eyebrow header, green dot + check on the active project).
- Header restructured so the sidebar-trigger inset mirrors the right edge.

Pure frontend, no backend or schema changes.

## Files
- `components/dashboard/common/ProjectSwitcher.tsx` (new)
- `components/dashboard/common/app-sidebar.tsx` (regroup, remove in-sidebar switcher)
- `components/dashboard/common/ProjectStatusBar.tsx` (left-padding alignment)
- `app/dashboard/layout.tsx` (header: mount switcher)

## Test
Verified: `bun build` green, `biome` clean. Switch projects in the header → the Project nav group is the set that follows it.
