### PR TITLE
feat(explore): active-project scoping (assistant + files + RAG) and sources panel

### DIFF
--- a/backend/app/explore/agents/explore.py
+++ b/backend/app/explore/agents/explore.py
@@ -7,6 +7,7 @@ async def run_explore_agent_streaming(
     query: str,
     client_id: str,
     access_token: str,
+    project_id: Optional[int] = None,
     history: Optional[List[Dict[str, str]]] = None,
     attachments: Optional[List[Dict[str, str]]] = None,
     model_preference: str = "fast",
@@ -15,11 +16,14 @@ async def run_explore_agent_streaming(
 
     ``access_token`` is the caller's validated Supabase JWT, threaded through to
     the live-data tools so their queries run under the caller's RLS context.
+    ``project_id`` is the caller's active project; it narrows the live-data tools
+    to that project (membership-verified server-side).
     """
     async for event in run_graph_streaming(
         query=query,
         client_id=client_id,
         access_token=access_token,
+        project_id=project_id,
         history=history or [],
         attachments=attachments or [],
         model_preference=model_preference,

--- a/backend/app/explore/agents/graph.py
+++ b/backend/app/explore/agents/graph.py
@@ -13,6 +13,7 @@ async def run_graph_streaming(
     query: str,
     client_id: str,
     access_token: str,
+    project_id: Optional[int] = None,
     history: Optional[List[Dict[str, str]]] = None,
     attachments: Optional[List[Dict[str, str]]] = None,
     model_preference: str = "fast",
@@ -128,7 +129,9 @@ async def run_graph_streaming(
                 logger.warning(f"Failed to parse tool args for {name}: {raw_args!r}")
                 args = {}
 
-            result_text, sources = await execute_tool(name, args, client_id, access_token)
+            result_text, sources = await execute_tool(
+                name, args, client_id, access_token, project_id
+            )
             collected_sources.extend(sources)
 
             messages.append({

--- a/backend/app/explore/agents/tools.py
+++ b/backend/app/explore/agents/tools.py
@@ -44,6 +44,7 @@ from supabase import Client
 
 from app.explore.agents.nodes import rag_service
 from app.explore.db.supabase import user_client
+from app.explore.services.membership import scoped_project_ids as _scoped_project_ids
 
 logger = logging.getLogger(__name__)
 
@@ -208,20 +209,21 @@ TOOLS: List[Dict[str, Any]] = [
 # --- Tool implementations ----------------------------------------------------
 
 async def _search_documents(
-    query: str, project_ids: List[int]
+    query: str, project_ids: List[int], client_id: str
 ) -> Tuple[str, List[Dict[str, Any]]]:
     """Run RAG retrieval scoped to the caller's project(s); return
-    (context_text, sources) for citations."""
+    (context_text, sources) for citations.
+
+    Document search still runs uid-only when the caller has no active project
+    membership, so a user with zero memberships can reach their own legacy
+    (NULL-project) uploads rather than getting a hard "no project" wall.
+    """
     if not query or not query.strip():
         return "No search query was provided.", []
-    if not project_ids:
-        return (
-            "No project is associated with your account, so there are no "
-            "project documents to search.",
-            [],
-        )
 
-    docs = await rag_service.retrieve_relevant(query=query, project_ids=project_ids)
+    docs = await rag_service.retrieve_relevant(
+        query=query, project_ids=project_ids, client_id=client_id
+    )
     if not docs:
         return (
             "No matching passages were found in the project's documents "
@@ -285,65 +287,6 @@ def _search_sbi_knowledge(query: str) -> Tuple[str, List[Dict[str, Any]]]:
 # No project id is ever taken from model/user input; an empty project list short
 # -circuits to a "no data" summary so an unscoped (cross-tenant) query is
 # impossible.
-
-
-async def _caller_project_ids(db: Client, client_id: str) -> List[int]:
-    """Resolve the project ids the caller is a member of. Empty list if none.
-
-    This is the single source of tenant scoping for every live-data tool. A
-    blank ``client_id`` (which should never reach here for an authenticated
-    request) yields ``[]`` so nothing is queried. Queries run on ``db`` (the
-    caller's RLS-scoped client), so RLS applies on top of the manual filters.
-    """
-    if not client_id or not client_id.strip():
-        return []
-
-    def _query() -> List[int]:
-        profile = (
-            db.table("profiles")
-            .select("id")
-            .eq("uid", client_id)
-            .limit(1)
-            .execute()
-        )
-        if not profile.data:
-            return []
-        profile_id = profile.data[0]["id"]
-
-        members = (
-            db.table("project_members")
-            .select("project_id")
-            .eq("profile_id", profile_id)
-            .execute()
-        )
-        ids: List[int] = []
-        for row in members.data or []:
-            pid = row.get("project_id")
-            if pid is not None:
-                ids.append(pid)
-        return ids
-
-    return await asyncio.to_thread(_query)
-
-
-async def _scoped_project_ids(
-    db: Client, client_id: str, project_id: Optional[int]
-) -> List[int]:
-    """The project ids a live-data tool may read for THIS turn.
-
-    Starts from the caller's full membership set (``_caller_project_ids``) and,
-    when the request carries an active ``project_id`` (the project selected in
-    the header), NARROWS the scope to just that project — but only after
-    verifying the caller is actually a member of it. A ``project_id`` the caller
-    does not belong to yields ``[]`` ("no data"), so a spoofed, stale, or
-    cross-tenant id can never widen access or leak another project's rows. When
-    no ``project_id`` is supplied, the caller's full set is used (backward
-    compatible), matching the pre-scoping behavior.
-    """
-    allowed = await _caller_project_ids(db, client_id)
-    if project_id is None:
-        return allowed
-    return [project_id] if project_id in allowed else []
 
 
 def _summarize_counts(label: str, counts: Dict[str, int]) -> str:
@@ -737,7 +680,7 @@ async def execute_tool(
             query = str(args.get("query", "")) if args else ""
             db = user_client(access_token)
             project_ids = await _scoped_project_ids(db, client_id, project_id)
-            return await _search_documents(query, project_ids)
+            return await _search_documents(query, project_ids, client_id)
         if name == "search_sbi_knowledge":
             query = str(args.get("query", "")) if args else ""
             return _search_sbi_knowledge(query)

--- a/backend/app/explore/agents/tools.py
+++ b/backend/app/explore/agents/tools.py
@@ -38,7 +38,7 @@ longer used by these tools.
 import asyncio
 import logging
 from pathlib import Path
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 from supabase import Client
 
@@ -207,15 +207,24 @@ TOOLS: List[Dict[str, Any]] = [
 
 # --- Tool implementations ----------------------------------------------------
 
-async def _search_documents(query: str, client_id: str) -> Tuple[str, List[Dict[str, Any]]]:
-    """Run RAG retrieval; return (context_text, sources) for citations."""
+async def _search_documents(
+    query: str, project_ids: List[int]
+) -> Tuple[str, List[Dict[str, Any]]]:
+    """Run RAG retrieval scoped to the caller's project(s); return
+    (context_text, sources) for citations."""
     if not query or not query.strip():
         return "No search query was provided.", []
+    if not project_ids:
+        return (
+            "No project is associated with your account, so there are no "
+            "project documents to search.",
+            [],
+        )
 
-    docs = await rag_service.retrieve_relevant(query=query, client_id=client_id)
+    docs = await rag_service.retrieve_relevant(query=query, project_ids=project_ids)
     if not docs:
         return (
-            "No matching passages were found in the client's project documents "
+            "No matching passages were found in the project's documents "
             "for this query.",
             [],
         )
@@ -317,15 +326,37 @@ async def _caller_project_ids(db: Client, client_id: str) -> List[int]:
     return await asyncio.to_thread(_query)
 
 
+async def _scoped_project_ids(
+    db: Client, client_id: str, project_id: Optional[int]
+) -> List[int]:
+    """The project ids a live-data tool may read for THIS turn.
+
+    Starts from the caller's full membership set (``_caller_project_ids``) and,
+    when the request carries an active ``project_id`` (the project selected in
+    the header), NARROWS the scope to just that project — but only after
+    verifying the caller is actually a member of it. A ``project_id`` the caller
+    does not belong to yields ``[]`` ("no data"), so a spoofed, stale, or
+    cross-tenant id can never widen access or leak another project's rows. When
+    no ``project_id`` is supplied, the caller's full set is used (backward
+    compatible), matching the pre-scoping behavior.
+    """
+    allowed = await _caller_project_ids(db, client_id)
+    if project_id is None:
+        return allowed
+    return [project_id] if project_id in allowed else []
+
+
 def _summarize_counts(label: str, counts: Dict[str, int]) -> str:
     """Render ``label: a=1, b=2`` for non-zero buckets, in a stable order."""
     parts = [f"{k.replace('_', ' ')}: {v}" for k, v in counts.items() if v]
     return f"{label} — " + (", ".join(parts) if parts else "none") + "."
 
 
-async def _get_lifecycle_status(db: Client, client_id: str) -> str:
-    """Summarize the caller's lifecycle tasks, scoped to their project(s)."""
-    project_ids = await _caller_project_ids(db, client_id)
+async def _get_lifecycle_status(
+    db: Client, client_id: str, project_id: Optional[int]
+) -> str:
+    """Summarize the caller's lifecycle tasks, scoped to the active project."""
+    project_ids = await _scoped_project_ids(db, client_id, project_id)
     if not project_ids:
         return (
             "No project is associated with your account, so there is no "
@@ -398,14 +429,16 @@ async def _get_lifecycle_status(db: Client, client_id: str) -> str:
     return "\n".join(lines)
 
 
-async def _get_questionnaire_status(db: Client, client_id: str) -> str:
+async def _get_questionnaire_status(
+    db: Client, client_id: str, project_id: Optional[int]
+) -> str:
     """Summarize the caller's questionnaire/form status, scoped to them.
 
-    Submissions are scoped to BOTH the caller's project(s) and the caller's own
+    Submissions are scoped to BOTH the active project and the caller's own
     ``user_id`` so one client never sees another client's answers on a shared
-    project. Assignments are scoped to the caller's project(s).
+    project. Assignments are scoped to the active project.
     """
-    project_ids = await _caller_project_ids(db, client_id)
+    project_ids = await _scoped_project_ids(db, client_id, project_id)
     if not project_ids:
         return (
             "No project is associated with your account, so there are no "
@@ -477,14 +510,14 @@ async def _get_questionnaire_status(db: Client, client_id: str) -> str:
     return "\n".join(lines)
 
 
-async def _get_reports(db: Client, client_id: str) -> str:
-    """Summarize reports filed for the caller's project(s).
+async def _get_reports(db: Client, client_id: str, project_id: Optional[int]) -> str:
+    """Summarize reports filed for the active project.
 
     Reports are ``tickets`` rows with ``ticket_type = 'report'``. Scoped to the
-    caller's project(s); a report with no project is never returned to avoid any
+    active project; a report with no project is never returned to avoid any
     cross-tenant leak.
     """
-    project_ids = await _caller_project_ids(db, client_id)
+    project_ids = await _scoped_project_ids(db, client_id, project_id)
     if not project_ids:
         return (
             "No project is associated with your account, so there are no "
@@ -526,15 +559,18 @@ def _fmt_money(amount: float, currency: str = "USD") -> str:
     return f"{symbol}{amount:,.2f}" + ("" if symbol else f" {currency}")
 
 
-async def _get_finance_summary(db: Client, client_id: str) -> str:
-    """Summarize the caller's project budget(s), scoped to their project(s).
+async def _get_finance_summary(
+    db: Client, client_id: str, project_id: Optional[int]
+) -> str:
+    """Summarize the active project's budget, scoped to that project.
 
     Reads ``project_budgets`` (one per project), the ``budget_categories``
     expected amounts (the "budget"), and ``budget_transactions`` (the "spend").
     Every query is scoped to budgets whose ``project_id`` is in the caller's
-    project list, so another tenant's finances can never be returned.
+    (active-project-narrowed) project list, so another tenant's finances can
+    never be returned.
     """
-    project_ids = await _caller_project_ids(db, client_id)
+    project_ids = await _scoped_project_ids(db, client_id, project_id)
     if not project_ids:
         return (
             "No project is associated with your account, so there is no "
@@ -602,15 +638,15 @@ async def _get_finance_summary(db: Client, client_id: str) -> str:
     return "\n".join(lines)
 
 
-async def _get_requests(db: Client, client_id: str) -> str:
-    """Summarize the caller's submitted requests, scoped to their project(s).
+async def _get_requests(db: Client, client_id: str, project_id: Optional[int]) -> str:
+    """Summarize the caller's submitted requests, scoped to the active project.
 
     Requests are ``tickets`` rows with ``ticket_type = 'request'`` (the
     non-report ticket type, mirroring the dashboard's ``fetchRequests`` filter).
-    Scoped to the caller's project(s); a request with no project is never
-    returned to avoid any cross-tenant leak.
+    Scoped to the active project; a request with no project is never returned to
+    avoid any cross-tenant leak.
     """
-    project_ids = await _caller_project_ids(db, client_id)
+    project_ids = await _scoped_project_ids(db, client_id, project_id)
     if not project_ids:
         return (
             "No project is associated with your account, so there are no "
@@ -672,7 +708,11 @@ async def _get_calendar_events(client_id: str) -> str:
 
 
 async def execute_tool(
-    name: str, args: Dict[str, Any], client_id: str, access_token: str
+    name: str,
+    args: Dict[str, Any],
+    client_id: str,
+    access_token: str,
+    project_id: Optional[int] = None,
 ) -> Tuple[str, List[Dict[str, Any]]]:
     """Dispatch a single tool call.
 
@@ -682,32 +722,40 @@ async def execute_tool(
     The five live-data tools build a single RLS-scoped PostgREST client from the
     caller's ``access_token`` (``user_client``) so their queries run under the
     caller's row-level-security context (defense-in-depth on top of the manual
-    ``project_id`` / ``user_id`` filters). ``search_documents`` (RAG RPC is
-    param-scoped + SECURITY DEFINER), ``search_sbi_knowledge`` (static), and
+    ``project_id`` / ``user_id`` filters). ``project_id`` is the caller's ACTIVE
+    project (from the header switcher); it narrows the live tools to that one
+    project after membership is verified server-side (see ``_scoped_project_ids``),
+    so the assistant answers about the project on screen rather than blending all
+    of the caller's projects. ``search_documents`` is likewise scoped: it
+    resolves the same membership-verified project ids and passes them to the RAG
+    RPC (param-scoped + SECURITY DEFINER), so document retrieval is narrowed to
+    the active project too. ``search_sbi_knowledge`` (static) and
     ``get_calendar_events`` (stub) need no database client.
     """
     try:
         if name == "search_documents":
             query = str(args.get("query", "")) if args else ""
-            return await _search_documents(query, client_id)
+            db = user_client(access_token)
+            project_ids = await _scoped_project_ids(db, client_id, project_id)
+            return await _search_documents(query, project_ids)
         if name == "search_sbi_knowledge":
             query = str(args.get("query", "")) if args else ""
             return _search_sbi_knowledge(query)
         if name == "get_lifecycle_status":
             db = user_client(access_token)
-            return await _get_lifecycle_status(db, client_id), []
+            return await _get_lifecycle_status(db, client_id, project_id), []
         if name == "get_questionnaire_status":
             db = user_client(access_token)
-            return await _get_questionnaire_status(db, client_id), []
+            return await _get_questionnaire_status(db, client_id, project_id), []
         if name == "get_reports":
             db = user_client(access_token)
-            return await _get_reports(db, client_id), []
+            return await _get_reports(db, client_id, project_id), []
         if name == "get_finance_summary":
             db = user_client(access_token)
-            return await _get_finance_summary(db, client_id), []
+            return await _get_finance_summary(db, client_id, project_id), []
         if name == "get_requests":
             db = user_client(access_token)
-            return await _get_requests(db, client_id), []
+            return await _get_requests(db, client_id, project_id), []
         if name == "get_calendar_events":
             return await _get_calendar_events(client_id), []
         logger.warning(f"Unknown tool requested: {name}")

--- a/backend/app/explore/api/v1/endpoints/chat.py
+++ b/backend/app/explore/api/v1/endpoints/chat.py
@@ -33,6 +33,7 @@ async def chat(request: ChatRequest, raw_request: Request, auth: AuthContext = D
                 query=request.query,
                 client_id=auth.user_id,
                 access_token=auth.access_token,
+                project_id=request.project_id,
                 history=history,
                 attachments=attachments,
                 model_preference=request.model_preference or "fast",

--- a/backend/app/explore/api/v1/endpoints/documents.py
+++ b/backend/app/explore/api/v1/endpoints/documents.py
@@ -1,27 +1,77 @@
-from fastapi import APIRouter, UploadFile, File, Depends, HTTPException
+from fastapi import APIRouter, UploadFile, File, Form, Depends, HTTPException
 from datetime import datetime
+from typing import Optional
+import asyncio
 
 from app.explore.schemas.document import DocumentUploadResponse
 from app.explore.services.pdf_parser import PDFParser
 from app.explore.services.rag_service import RAGService
-from app.explore.api.deps import get_current_user_id
+from app.explore.api.deps import AuthContext, get_auth_context, get_current_user_id
+from app.explore.db.supabase import user_client
 
 
 router = APIRouter()
 
 
+async def _is_project_member(access_token: str, user_id: str, project_id: int) -> bool:
+    """True if the caller (uid=user_id) is a member of project_id.
+
+    Runs under the caller's RLS context (a client built from the caller's JWT),
+    so it can only observe the caller's own ``project_members`` rows.
+    """
+    db = user_client(access_token)
+
+    def _query() -> bool:
+        prof = (
+            db.table("profiles").select("id").eq("uid", user_id).limit(1).execute()
+        )
+        if not prof.data:
+            return False
+        profile_id = prof.data[0]["id"]
+        mem = (
+            db.table("project_members")
+            .select("project_id")
+            .eq("profile_id", profile_id)
+            .eq("project_id", project_id)
+            .limit(1)
+            .execute()
+        )
+        return bool(mem.data)
+
+    return await asyncio.to_thread(_query)
+
+
 @router.post("/upload", response_model=DocumentUploadResponse)
 async def upload_document(
     file: UploadFile = File(...),
-    user_id: str = Depends(get_current_user_id)
+    project_id: Optional[int] = Form(None),
+    auth: AuthContext = Depends(get_auth_context)
 ):
-    """Upload a PDF document for RAG processing."""
+    """Upload a PDF document for RAG processing.
+
+    ``project_id`` tags the stored chunks so ``search_documents`` retrieves
+    them for that project. The caller MUST be a member of that project; an
+    unauthorized ``project_id`` is rejected (not silently dropped) so a caller
+    can't tag uploads into a project they don't belong to.
+    """
+    user_id = auth.user_id
+
     if not file.filename.endswith('.pdf'):
         raise HTTPException(
             status_code=400,
             detail="Only PDF files are supported at this time"
         )
-    
+
+    # Authorization: a project_id may only be set by a member of that project.
+    # Verified under the caller's RLS context (project_members only exposes the
+    # caller's own memberships), so a non-member's project_id is rejected.
+    if project_id is not None:
+        if not await _is_project_member(auth.access_token, user_id, project_id):
+            raise HTTPException(
+                status_code=403,
+                detail="You are not a member of the specified project."
+            )
+
     try:
         file_bytes = await file.read()
         
@@ -46,7 +96,8 @@ async def upload_document(
             doc_ids = await rag_service.store_document(
                 content=page_data["content"],
                 metadata=page_data["metadata"],
-                client_id=user_id
+                client_id=user_id,
+                project_id=project_id
             )
             all_document_ids.extend(doc_ids)
         

--- a/backend/app/explore/api/v1/endpoints/documents.py
+++ b/backend/app/explore/api/v1/endpoints/documents.py
@@ -1,11 +1,11 @@
 from fastapi import APIRouter, UploadFile, File, Form, Depends, HTTPException
 from datetime import datetime
-from typing import Optional
 import asyncio
 
 from app.explore.schemas.document import DocumentUploadResponse
 from app.explore.services.pdf_parser import PDFParser
 from app.explore.services.rag_service import RAGService
+from app.explore.services.membership import is_project_member
 from app.explore.api.deps import AuthContext, get_auth_context, get_current_user_id
 from app.explore.db.supabase import user_client
 
@@ -13,30 +13,22 @@ from app.explore.db.supabase import user_client
 router = APIRouter()
 
 
-async def _is_project_member(access_token: str, user_id: str, project_id: int) -> bool:
-    """True if the caller (uid=user_id) is a member of project_id.
+async def _is_director(db, user_id: str) -> bool:
+    """True if the caller's ``profiles.role`` is ``director``.
 
-    Runs under the caller's RLS context (a client built from the caller's JWT),
-    so it can only observe the caller's own ``project_members`` rows.
+    Runs under the caller's RLS context (``db`` is built from the caller's JWT),
+    so it only ever reads the caller's own profile row.
     """
-    db = user_client(access_token)
 
     def _query() -> bool:
         prof = (
-            db.table("profiles").select("id").eq("uid", user_id).limit(1).execute()
-        )
-        if not prof.data:
-            return False
-        profile_id = prof.data[0]["id"]
-        mem = (
-            db.table("project_members")
-            .select("project_id")
-            .eq("profile_id", profile_id)
-            .eq("project_id", project_id)
+            db.table("profiles")
+            .select("role")
+            .eq("uid", user_id)
             .limit(1)
             .execute()
         )
-        return bool(mem.data)
+        return bool(prof.data) and prof.data[0].get("role") == "director"
 
     return await asyncio.to_thread(_query)
 
@@ -44,15 +36,16 @@ async def _is_project_member(access_token: str, user_id: str, project_id: int) -
 @router.post("/upload", response_model=DocumentUploadResponse)
 async def upload_document(
     file: UploadFile = File(...),
-    project_id: Optional[int] = Form(None),
+    project_id: int = Form(...),
     auth: AuthContext = Depends(get_auth_context)
 ):
     """Upload a PDF document for RAG processing.
 
-    ``project_id`` tags the stored chunks so ``search_documents`` retrieves
-    them for that project. The caller MUST be a member of that project; an
-    unauthorized ``project_id`` is rejected (not silently dropped) so a caller
-    can't tag uploads into a project they don't belong to.
+    ``project_id`` is required and tags the stored chunks so ``search_documents``
+    retrieves them for that project. The caller MUST be a director AND a member
+    of that project: membership stops cross-project tagging, and the director
+    gate stops any project member from injecting corpus documents (the insert
+    runs as the service role, bypassing RLS, so the check must be explicit).
     """
     user_id = auth.user_id
 
@@ -62,15 +55,22 @@ async def upload_document(
             detail="Only PDF files are supported at this time"
         )
 
-    # Authorization: a project_id may only be set by a member of that project.
-    # Verified under the caller's RLS context (project_members only exposes the
-    # caller's own memberships), so a non-member's project_id is rejected.
-    if project_id is not None:
-        if not await _is_project_member(auth.access_token, user_id, project_id):
-            raise HTTPException(
-                status_code=403,
-                detail="You are not a member of the specified project."
-            )
+    # Authorization, under the caller's RLS context (a client built from the
+    # caller's JWT, so it only observes the caller's own rows):
+    #   1. The caller must be a member of project_id (no cross-project tagging).
+    #   2. The caller must be a director (the directors-only corpus, enforced
+    #      here because store_document inserts via the service role / no RLS).
+    db = user_client(auth.access_token)
+    if not await is_project_member(db, user_id, project_id):
+        raise HTTPException(
+            status_code=403,
+            detail="You are not a member of the specified project."
+        )
+    if not await _is_director(db, user_id):
+        raise HTTPException(
+            status_code=403,
+            detail="Only directors can upload knowledge documents."
+        )
 
     try:
         file_bytes = await file.read()

--- a/backend/app/explore/schemas/chat.py
+++ b/backend/app/explore/schemas/chat.py
@@ -27,6 +27,15 @@ class ChatRequest(BaseModel):
         default=None,
         description="LLM model preference: 'fast' for speed, 'thinking' for complex reasoning"
     )
+    project_id: Optional[int] = Field(
+        default=None,
+        description=(
+            "The caller's active project. Live-data tools are narrowed to this "
+            "project after membership is verified server-side; an id the caller "
+            "is not a member of yields no data. Omit to use all of the caller's "
+            "projects."
+        ),
+    )
 
 
 class SourceDocument(BaseModel):

--- a/backend/app/explore/services/membership.py
+++ b/backend/app/explore/services/membership.py
@@ -1,0 +1,78 @@
+"""Shared project-membership resolution for the Explore backend.
+
+Both the document-upload endpoint and the live-data agent tools need to answer
+the same question — "what projects does this caller belong to?" — by resolving
+``profiles.uid == client_id`` -> ``profiles.id`` -> ``project_members.project_id``.
+This module is the single implementation of that lookup so the two call sites
+can't drift apart.
+
+Every query runs on the CALLER'S RLS-scoped PostgREST client (``db``), so the
+database enforces tenant isolation on top of these manual filters. The blocking
+PostgREST calls are wrapped in ``asyncio.to_thread`` so they don't stall the
+event loop, matching the rest of the backend.
+"""
+
+import asyncio
+from typing import List, Optional
+
+from supabase import Client
+
+
+async def caller_project_ids(db: Client, client_id: str) -> List[int]:
+    """Resolve the project ids the caller is a member of. Empty list if none.
+
+    A blank ``client_id`` (which should never reach here for an authenticated
+    request) yields ``[]`` so nothing is queried.
+    """
+    if not client_id or not client_id.strip():
+        return []
+
+    def _query() -> List[int]:
+        profile = (
+            db.table("profiles")
+            .select("id")
+            .eq("uid", client_id)
+            .limit(1)
+            .execute()
+        )
+        if not profile.data:
+            return []
+        profile_id = profile.data[0]["id"]
+
+        members = (
+            db.table("project_members")
+            .select("project_id")
+            .eq("profile_id", profile_id)
+            .execute()
+        )
+        ids: List[int] = []
+        for row in members.data or []:
+            pid = row.get("project_id")
+            if pid is not None:
+                ids.append(pid)
+        return ids
+
+    return await asyncio.to_thread(_query)
+
+
+async def is_project_member(db: Client, client_id: str, project_id: int) -> bool:
+    """True if the caller (uid=client_id) is a member of ``project_id``."""
+    return project_id in await caller_project_ids(db, client_id)
+
+
+async def scoped_project_ids(
+    db: Client, client_id: str, project_id: Optional[int]
+) -> List[int]:
+    """The project ids a live-data tool may read for THIS turn.
+
+    Starts from the caller's full membership set and, when the request carries
+    an active ``project_id``, NARROWS the scope to just that project — but only
+    after verifying the caller is actually a member of it. A ``project_id`` the
+    caller does not belong to yields ``[]`` ("no data"), so a spoofed, stale, or
+    cross-tenant id can never widen access or leak another project's rows. When
+    no ``project_id`` is supplied, the caller's full set is used.
+    """
+    allowed = await caller_project_ids(db, client_id)
+    if project_id is None:
+        return allowed
+    return [project_id] if project_id in allowed else []

--- a/backend/app/explore/services/rag_service.py
+++ b/backend/app/explore/services/rag_service.py
@@ -40,8 +40,13 @@ class RAGService:
             raise ValueError(f"Failed to generate embedding: {str(e)}")
 
     async def store_document(self, content: str, metadata: Dict[str, Any],
-        client_id: str) -> List[int]:
-        """Chunk, embed, and store a document in Supabase."""
+        client_id: str, project_id: Optional[int] = None) -> List[int]:
+        """Chunk, embed, and store a document in Supabase.
+
+        ``project_id`` tags the document with the project it belongs to so the
+        ``search_documents`` tool can retrieve it for that project's team. The
+        uploader ``uid`` is still recorded for ownership/auditing.
+        """
         chunks = self.pdf_parser.chunk_text(content)
         document_ids = []
 
@@ -58,6 +63,7 @@ class RAGService:
             # Insert into Supabase (using 'uid' column per schema)
             result = supabase.table("client_knowledge").insert({
                 "uid": client_id,
+                "project_id": project_id,
                 "content": chunk,
                 "metadata": chunk_metadata,
                 "embedding": embedding
@@ -68,9 +74,12 @@ class RAGService:
 
         return document_ids
 
-    async def search_documents(self, query: str, client_id: str, limit: int = 5,
+    async def search_documents(self, query: str, project_ids: List[int], limit: int = 5,
         similarity_threshold: float = 0.0) -> List[Dict[str, Any]]:
-        """Search for relevant documents using vector similarity."""
+        """Search for relevant documents using vector similarity, scoped to the
+        caller's (membership-verified) project(s)."""
+        if not project_ids:
+            return []
         try:
             query_embedding = await self.generate_embedding(query)
         except Exception as e:
@@ -83,7 +92,7 @@ class RAGService:
                 {
                     "_query_embedding": query_embedding,
                     "_match_count": limit,
-                    "_filter_uid": client_id,
+                    "_filter_project_ids": project_ids,
                     "_similarity_threshold": similarity_threshold
                 }
             ).execute()
@@ -102,26 +111,26 @@ class RAGService:
                 logger.info(f"Vector search returned {len(documents)} results (top similarity: {documents[0]['similarity_score']:.4f})")
                 return documents
             else:
-                logger.info(f"Vector search returned no results for client {client_id} (threshold={similarity_threshold})")
+                logger.info(f"Vector search returned no results for projects {project_ids} (threshold={similarity_threshold})")
         except Exception as e:
             logger.error(f"RPC match_client_knowledge failed: {e}")
 
         return []
 
-    async def hybrid_search(self, query: str, client_id: str, limit: int = 5,
+    async def hybrid_search(self, query: str, project_ids: List[int], limit: int = 5,
         vector_weight: float = 0.7) -> List[Dict[str, Any]]:
         """Perform hybrid search combining vector similarity and keyword matching."""
         # Get vector search results
         vector_results = await self.search_documents(
             query=query,
-            client_id=client_id,
+            project_ids=project_ids,
             limit=limit * 2
         )
 
         # Get keyword search results
         keyword_results = await self._keyword_search(
             query=query,
-            client_id=client_id,
+            project_ids=project_ids,
             limit=limit * 2
         )
 
@@ -214,35 +223,41 @@ class RAGService:
 
         return documents[:top_n]
 
-    async def retrieve_relevant(self, query: str, client_id: str,
+    async def retrieve_relevant(self, query: str, project_ids: List[int],
         top_n: Optional[int] = None) -> List[Dict[str, Any]]:
         """Retrieve the most relevant documents for a query (two-stage).
 
-        Stage 1: hybrid search widens to ``rerank_candidates`` candidates.
-        Stage 2: the reranker re-scores them and keeps the top ``top_n``.
+        Scoped to ``project_ids`` (the caller's membership-verified active
+        project). Stage 1: hybrid search widens to ``rerank_candidates``
+        candidates. Stage 2: the reranker re-scores them and keeps the top
+        ``top_n``.
 
         This is the entry point chat turns should use; the returned list is the
         single source of truth for both the prompt context and the citation
         sources, keeping the model's ``[n]`` markers aligned with the rendered
         source chips.
         """
+        if not project_ids:
+            return []
         keep = top_n if top_n is not None else settings.rerank_top_n
         candidates = await self.hybrid_search(
             query=query,
-            client_id=client_id,
+            project_ids=project_ids,
             limit=settings.rerank_candidates,
         )
         if not candidates:
             return []
         return await self.rerank(query=query, documents=candidates, top_n=keep)
 
-    async def _keyword_search(self, query: str, client_id: str,
+    async def _keyword_search(self, query: str, project_ids: List[int],
         limit: int = 10) -> List[Dict[str, Any]]:
-        """Perform keyword-based full-text search."""
+        """Perform keyword-based full-text search, scoped to the project(s)."""
+        if not project_ids:
+            return []
         try:
             result = supabase.table("client_knowledge") \
                 .select("id, content, metadata") \
-                .eq("uid", client_id) \
+                .in_("project_id", project_ids) \
                 .text_search("content", query, options={"type": "plain"}) \
                 .execute()
 
@@ -260,18 +275,18 @@ class RAGService:
             ]
         except Exception as e:
             logger.warning(f"Full-text search failed, falling back to ILIKE: {e}")
-            return await self._fallback_keyword_search(query, client_id, limit)
+            return await self._fallback_keyword_search(query, project_ids, limit)
 
-    async def _fallback_keyword_search(self, query: str, client_id: str,
+    async def _fallback_keyword_search(self, query: str, project_ids: List[int],
         limit: int = 10) -> List[Dict[str, Any]]:
         """Fallback keyword search using ILIKE for simple pattern matching."""
         words = query.lower().split()[:3]
-        if not words:
+        if not words or not project_ids:
             return []
 
         result = supabase.table("client_knowledge") \
             .select("id, content, metadata") \
-            .eq("uid", client_id) \
+            .in_("project_id", project_ids) \
             .ilike("content", f"%{words[0]}%") \
             .limit(limit) \
             .execute()
@@ -288,32 +303,6 @@ class RAGService:
             }
             for doc in result.data
         ]
-
-    async def get_context_for_query(self, query: str, client_id: str,
-        attachments: Optional[List[Dict[str, str]]] = None,
-        retrieved_docs: Optional[List[Dict[str, Any]]] = None,
-        max_context_length: int = 200_000) -> str:
-        """Build a context string for the LLM from retrieved documents and attachments.
-
-        If ``retrieved_docs`` is provided, it is used directly (no DB call); this
-        lets callers run a single ``hybrid_search`` per turn and reuse the same
-        ranked docs for both the prompt context and the citation source list,
-        keeping the prompt's ``[n]`` markers aligned with the rendered sources.
-        Falls back to running its own ``hybrid_search`` when ``retrieved_docs`` is
-        None for backward compatibility.
-        """
-        if retrieved_docs is None:
-            retrieved_docs = await self.hybrid_search(
-                query=query,
-                client_id=client_id,
-                limit=5,
-            )
-
-        return self.build_context_string(
-            retrieved_docs=retrieved_docs,
-            attachments=attachments,
-            max_context_length=max_context_length,
-        )
 
     @staticmethod
     def build_context_string(

--- a/backend/app/explore/services/rag_service.py
+++ b/backend/app/explore/services/rag_service.py
@@ -1,4 +1,5 @@
 import logging
+import re
 from typing import List, Dict, Any, Optional
 import httpx
 from openai import AsyncOpenAI
@@ -7,6 +8,12 @@ from app.explore.db.supabase import supabase
 from app.explore.services.pdf_parser import PDFParser
 
 logger = logging.getLogger(__name__)
+
+# Canonical 8-4-4-4-12 UUID, as issued by Supabase auth.
+_UUID_RE = re.compile(
+    r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}",
+    re.IGNORECASE,
+)
 
 
 class RAGService:
@@ -271,13 +278,17 @@ class RAGService:
         legacy NULL-project row. Returns ``None`` when there is nothing to scope
         to (no projects and no client id), signalling the caller to skip.
 
-        ``client_id`` is an auth-provided UUID string, so it is safe to embed.
+        ``client_id`` is embedded verbatim into the filter string, so it must
+        be a UUID; anything else is rejected rather than risk a filter
+        injection from a future non-auth call site.
         """
         clauses: List[str] = []
         if project_ids:
             ids_csv = ",".join(str(pid) for pid in project_ids)
             clauses.append(f"project_id.in.({ids_csv})")
         if client_id:
+            if not _UUID_RE.fullmatch(client_id):
+                raise ValueError(f"client_id is not a valid UUID: {client_id!r}")
             clauses.append(f"and(uid.eq.{client_id},project_id.is.null)")
         return ",".join(clauses) if clauses else None
 

--- a/backend/app/explore/services/rag_service.py
+++ b/backend/app/explore/services/rag_service.py
@@ -74,11 +74,17 @@ class RAGService:
 
         return document_ids
 
-    async def search_documents(self, query: str, project_ids: List[int], limit: int = 5,
+    async def search_documents(self, query: str, project_ids: List[int],
+        client_id: Optional[str] = None, limit: int = 5,
         similarity_threshold: float = 0.0) -> List[Dict[str, Any]]:
         """Search for relevant documents using vector similarity, scoped to the
-        caller's (membership-verified) project(s)."""
-        if not project_ids:
+        caller's (membership-verified) project(s).
+
+        Passing ``client_id`` also surfaces the caller's own legacy documents
+        that were never assigned a project (``project_id IS NULL``), so a user
+        with zero memberships can still reach their pre-scoping uploads.
+        """
+        if not project_ids and not client_id:
             return []
         try:
             query_embedding = await self.generate_embedding(query)
@@ -92,7 +98,8 @@ class RAGService:
                 {
                     "_query_embedding": query_embedding,
                     "_match_count": limit,
-                    "_filter_project_ids": project_ids,
+                    "_filter_uid": client_id,
+                    "_filter_project_ids": project_ids or None,
                     "_similarity_threshold": similarity_threshold
                 }
             ).execute()
@@ -111,19 +118,21 @@ class RAGService:
                 logger.info(f"Vector search returned {len(documents)} results (top similarity: {documents[0]['similarity_score']:.4f})")
                 return documents
             else:
-                logger.info(f"Vector search returned no results for projects {project_ids} (threshold={similarity_threshold})")
+                logger.info(f"Vector search returned no results for projects {project_ids} uid={client_id} (threshold={similarity_threshold})")
         except Exception as e:
             logger.error(f"RPC match_client_knowledge failed: {e}")
 
         return []
 
-    async def hybrid_search(self, query: str, project_ids: List[int], limit: int = 5,
+    async def hybrid_search(self, query: str, project_ids: List[int],
+        client_id: Optional[str] = None, limit: int = 5,
         vector_weight: float = 0.7) -> List[Dict[str, Any]]:
         """Perform hybrid search combining vector similarity and keyword matching."""
         # Get vector search results
         vector_results = await self.search_documents(
             query=query,
             project_ids=project_ids,
+            client_id=client_id,
             limit=limit * 2
         )
 
@@ -131,6 +140,7 @@ class RAGService:
         keyword_results = await self._keyword_search(
             query=query,
             project_ids=project_ids,
+            client_id=client_id,
             limit=limit * 2
         )
 
@@ -224,40 +234,65 @@ class RAGService:
         return documents[:top_n]
 
     async def retrieve_relevant(self, query: str, project_ids: List[int],
+        client_id: Optional[str] = None,
         top_n: Optional[int] = None) -> List[Dict[str, Any]]:
         """Retrieve the most relevant documents for a query (two-stage).
 
         Scoped to ``project_ids`` (the caller's membership-verified active
-        project). Stage 1: hybrid search widens to ``rerank_candidates``
-        candidates. Stage 2: the reranker re-scores them and keeps the top
-        ``top_n``.
+        project) and, when ``client_id`` is given, the caller's own legacy
+        NULL-project documents. Stage 1: hybrid search widens to
+        ``rerank_candidates`` candidates. Stage 2: the reranker re-scores them
+        and keeps the top ``top_n``.
 
         This is the entry point chat turns should use; the returned list is the
         single source of truth for both the prompt context and the citation
         sources, keeping the model's ``[n]`` markers aligned with the rendered
         source chips.
         """
-        if not project_ids:
+        if not project_ids and not client_id:
             return []
         keep = top_n if top_n is not None else settings.rerank_top_n
         candidates = await self.hybrid_search(
             query=query,
             project_ids=project_ids,
+            client_id=client_id,
             limit=settings.rerank_candidates,
         )
         if not candidates:
             return []
         return await self.rerank(query=query, documents=candidates, top_n=keep)
 
+    @staticmethod
+    def _scope_or_filter(
+        project_ids: List[int], client_id: Optional[str]
+    ) -> Optional[str]:
+        """Build the PostgREST ``or`` filter that mirrors the RPC's WHERE: a row
+        matches if it is in the active project set OR it is the caller's own
+        legacy NULL-project row. Returns ``None`` when there is nothing to scope
+        to (no projects and no client id), signalling the caller to skip.
+
+        ``client_id`` is an auth-provided UUID string, so it is safe to embed.
+        """
+        clauses: List[str] = []
+        if project_ids:
+            ids_csv = ",".join(str(pid) for pid in project_ids)
+            clauses.append(f"project_id.in.({ids_csv})")
+        if client_id:
+            clauses.append(f"and(uid.eq.{client_id},project_id.is.null)")
+        return ",".join(clauses) if clauses else None
+
     async def _keyword_search(self, query: str, project_ids: List[int],
+        client_id: Optional[str] = None,
         limit: int = 10) -> List[Dict[str, Any]]:
-        """Perform keyword-based full-text search, scoped to the project(s)."""
-        if not project_ids:
+        """Perform keyword-based full-text search, scoped to the project(s) and
+        the caller's own legacy NULL-project documents."""
+        scope = self._scope_or_filter(project_ids, client_id)
+        if scope is None:
             return []
         try:
             result = supabase.table("client_knowledge") \
                 .select("id, content, metadata") \
-                .in_("project_id", project_ids) \
+                .or_(scope) \
                 .text_search("content", query, options={"type": "plain"}) \
                 .execute()
 
@@ -275,18 +310,22 @@ class RAGService:
             ]
         except Exception as e:
             logger.warning(f"Full-text search failed, falling back to ILIKE: {e}")
-            return await self._fallback_keyword_search(query, project_ids, limit)
+            return await self._fallback_keyword_search(
+                query, project_ids, client_id, limit
+            )
 
     async def _fallback_keyword_search(self, query: str, project_ids: List[int],
+        client_id: Optional[str] = None,
         limit: int = 10) -> List[Dict[str, Any]]:
         """Fallback keyword search using ILIKE for simple pattern matching."""
         words = query.lower().split()[:3]
-        if not words or not project_ids:
+        scope = self._scope_or_filter(project_ids, client_id)
+        if not words or scope is None:
             return []
 
         result = supabase.table("client_knowledge") \
             .select("id, content, metadata") \
-            .in_("project_id", project_ids) \
+            .or_(scope) \
             .ilike("content", f"%{words[0]}%") \
             .limit(limit) \
             .execute()

--- a/frontend/app/api/chat/route.ts
+++ b/frontend/app/api/chat/route.ts
@@ -28,6 +28,10 @@ interface ChatRequestBody {
   // when creating a session; ownership is still enforced by RLS (uid = the
   // authenticated user), so the id is an identifier, not a capability.
   public_id?: string | null;
+  // Active project id: tags a new session and scopes the assistant's live-data
+  // tools. The backend re-verifies the caller's membership, so this is a scope
+  // hint, not a capability.
+  project_id?: number | null;
 }
 
 const UUID_RE =
@@ -71,12 +75,25 @@ export async function POST(request: NextRequest) {
     isNewSession = true;
     // Honor a client-minted uuid so the URL is known before the first response.
     // RLS still scopes the row to this user; a collision just fails the insert.
-    const insertRow: { uid: string; title: string; public_id?: string } = {
+    const insertRow: {
+      uid: string;
+      title: string;
+      public_id?: string;
+      project_id?: number;
+    } = {
       uid: user.id,
       title: body.query.slice(0, 60),
     };
     if (body.public_id && UUID_RE.test(body.public_id)) {
       insertRow.public_id = body.public_id;
+    }
+    // Tag the conversation with the project it was started under (best-effort).
+    if (
+      typeof body.project_id === "number" &&
+      Number.isInteger(body.project_id) &&
+      body.project_id > 0
+    ) {
+      insertRow.project_id = body.project_id;
     }
     const { data: newSession, error: sessionErr } = await supabase
       .from("client_chat_sessions")
@@ -152,6 +169,7 @@ export async function POST(request: NextRequest) {
       attachments: body.attachments ?? [],
       include_sources: body.include_sources ?? true,
       model_preference: modelPreference,
+      project_id: body.project_id ?? null,
     }),
     signal: request.signal,
   });

--- a/frontend/app/api/knowledge/upload/route.ts
+++ b/frontend/app/api/knowledge/upload/route.ts
@@ -1,0 +1,71 @@
+import type { NextRequest } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+
+export const runtime = "nodejs";
+export const maxDuration = 60;
+
+const BACKEND_URL = process.env.BACKEND_URL || "http://localhost:8000";
+
+// PDF only (the backend ingester accepts PDF), capped at 10 MB.
+const MAX_UPLOAD_BYTES = 10 * 1024 * 1024;
+
+function jsonError(status: number, detail: string) {
+  return new Response(JSON.stringify({ detail }), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+/**
+ * Forward a PDF to the backend RAG ingester, tagging it with the active project.
+ * Membership for `project_id` is re-verified by the backend (it rejects a
+ * project the caller doesn't belong to), so this route only checks auth + the
+ * file/shape, mirroring /api/chat/extract.
+ */
+export async function POST(request: NextRequest) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return jsonError(401, "Unauthorized");
+
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+  if (!session?.access_token) return jsonError(401, "No active session");
+
+  const formData = await request.formData();
+
+  const file = formData.get("file");
+  if (!(file instanceof File)) return jsonError(400, "No file provided");
+  if (file.size > MAX_UPLOAD_BYTES) {
+    return jsonError(413, "File too large (max 10 MB)");
+  }
+  const extension = file.name.split(".").pop()?.toLowerCase() ?? "";
+  if (extension !== "pdf") {
+    return jsonError(400, "Only PDF files are supported.");
+  }
+
+  const projectIdRaw = formData.get("project_id");
+  const projectId =
+    typeof projectIdRaw === "string" ? Number(projectIdRaw) : Number.NaN;
+  if (!Number.isInteger(projectId) || projectId <= 0) {
+    return jsonError(400, "A valid project_id is required.");
+  }
+
+  const backendRes = await fetch(`${BACKEND_URL}/api/v1/documents/upload`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${session.access_token}` },
+    body: formData,
+    signal: request.signal,
+  });
+
+  const passthroughHeaders = new Headers();
+  const contentType = backendRes.headers.get("Content-Type");
+  if (contentType) passthroughHeaders.set("Content-Type", contentType);
+
+  return new Response(backendRes.body, {
+    status: backendRes.status,
+    headers: passthroughHeaders,
+  });
+}

--- a/frontend/app/dashboard/files/page.tsx
+++ b/frontend/app/dashboard/files/page.tsx
@@ -147,9 +147,18 @@ export default function FilesPage() {
         );
     };
 
-    const fetchFolderContents = async (path: string, force = false) => {
+    // `isCancelled` lets a project-switch effect abort a stale in-flight load so
+    // it can't overwrite the new project's contents after the switch.
+    const fetchFolderContents = async (
+        path: string,
+        force = false,
+        isCancelled?: () => boolean,
+    ) => {
         setIsLoadingContents(true);
-        const { data, error: fetchError } = await listFolder(path, { force });
+        const { data, error: fetchError, stale } = await listFolder(path, {
+            force,
+        });
+        if (isCancelled?.() || stale) return;
 
         if (fetchError) {
             setError(new StorageError(fetchError.message));
@@ -194,9 +203,15 @@ export default function FilesPage() {
             return;
         }
 
+        // Project-switch guard: if the effect re-runs (project changed) while a
+        // load is in flight, `cancelled` short-circuits every setState below so
+        // a stale load can't overwrite the newly selected project's tree.
+        let cancelled = false;
+
         const bootstrapFolders = async () => {
             setIsLoadingTree(true);
             const rootNodes = await fetchFolderNodes("", true);
+            if (cancelled) return;
             setFolderTree(rootNodes);
             setIsLoadingTree(false);
 
@@ -208,6 +223,7 @@ export default function FilesPage() {
                 setSelectedFolderPath(target.path);
                 setExpandedPaths(new Set([target.path]));
                 const children = await fetchFolderNodes(target.path, true);
+                if (cancelled) return;
                 setFolderTree((prev) =>
                     markChildrenLoaded(prev, target.path, children),
                 );
@@ -219,6 +235,10 @@ export default function FilesPage() {
         };
 
         void bootstrapFolders();
+
+        return () => {
+            cancelled = true;
+        };
     }, [projectId]);
 
     // Reload the open folder's contents on navigation AND on project switch
@@ -226,7 +246,11 @@ export default function FilesPage() {
     // biome-ignore lint/correctness/useExhaustiveDependencies: fetch is stable; project switch must force a reload
     useEffect(() => {
         if (projectId === null) return;
-        void fetchFolderContents(selectedFolderPath, true);
+        let cancelled = false;
+        void fetchFolderContents(selectedFolderPath, true, () => cancelled);
+        return () => {
+            cancelled = true;
+        };
     }, [selectedFolderPath, projectId]);
 
     // ---------------------------------------------------------------------

--- a/frontend/app/dashboard/files/page.tsx
+++ b/frontend/app/dashboard/files/page.tsx
@@ -32,6 +32,7 @@ import {
     moveObject,
     parentOf,
     removePaths,
+    setStorageRoot,
     uploadFile,
 } from "./storage";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
@@ -73,8 +74,9 @@ function FolderSkeletonRow() {
 }
 
 export default function FilesPage() {
-    const { user } = useProject();
+    const { user, activeProject } = useProject();
     const isDirector = user?.role === "director";
+    const projectId = activeProject?.projectId ?? null;
 
     const [files, setFiles] = useState<StorageEntry[]>([]);
     const [subfolders, setSubfolders] = useState<FolderNode[]>([]);
@@ -174,10 +176,27 @@ export default function FilesPage() {
         setIsLoadingContents(false);
     };
 
+    // Re-root storage on the active project and (re)load its tree. Fresh-start
+    // scoping: every project sees only files under its own `{projectId}/`
+    // prefix, so switching projects swaps the whole tree. Keyed on projectId so
+    // it re-runs on switch; the storage root is set synchronously first, before
+    // the contents effect below reads it.
+    // biome-ignore lint/correctness/useExhaustiveDependencies: intentional project-keyed bootstrap
     useEffect(() => {
+        setStorageRoot(projectId !== null ? String(projectId) : null);
+        setFolderTree([]);
+        setSubfolders([]);
+        setFiles([]);
+
+        if (projectId === null) {
+            setIsLoadingTree(false);
+            setIsLoadingContents(false);
+            return;
+        }
+
         const bootstrapFolders = async () => {
             setIsLoadingTree(true);
-            const rootNodes = await fetchFolderNodes("");
+            const rootNodes = await fetchFolderNodes("", true);
             setFolderTree(rootNodes);
             setIsLoadingTree(false);
 
@@ -188,19 +207,27 @@ export default function FilesPage() {
             if (target) {
                 setSelectedFolderPath(target.path);
                 setExpandedPaths(new Set([target.path]));
-                const children = await fetchFolderNodes(target.path);
+                const children = await fetchFolderNodes(target.path, true);
                 setFolderTree((prev) =>
                     markChildrenLoaded(prev, target.path, children),
                 );
+            } else {
+                // Fresh project with no files yet — show the empty root.
+                setSelectedFolderPath("");
+                setExpandedPaths(new Set());
             }
         };
 
         void bootstrapFolders();
-    }, []);
+    }, [projectId]);
 
+    // Reload the open folder's contents on navigation AND on project switch
+    // (the path string may be unchanged across projects, so projectId is a dep).
+    // biome-ignore lint/correctness/useExhaustiveDependencies: fetch is stable; project switch must force a reload
     useEffect(() => {
-        void fetchFolderContents(selectedFolderPath);
-    }, [selectedFolderPath]);
+        if (projectId === null) return;
+        void fetchFolderContents(selectedFolderPath, true);
+    }, [selectedFolderPath, projectId]);
 
     // ---------------------------------------------------------------------
     // Tree node helpers

--- a/frontend/app/dashboard/files/page.tsx
+++ b/frontend/app/dashboard/files/page.tsx
@@ -158,7 +158,13 @@ export default function FilesPage() {
         const { data, error: fetchError, stale } = await listFolder(path, {
             force,
         });
-        if (isCancelled?.() || stale) return;
+        // Clear the spinner even on the abort path: with two rapid switches
+        // both in-flight loads can come back stale, and nothing else would
+        // reset it.
+        if (isCancelled?.() || stale) {
+            setIsLoadingContents(false);
+            return;
+        }
 
         if (fetchError) {
             setError(new StorageError(fetchError.message));

--- a/frontend/app/dashboard/files/storage.ts
+++ b/frontend/app/dashboard/files/storage.ts
@@ -120,11 +120,20 @@ export function isInvalidMoveTarget(
 /**
  * List a folder, returning cached entries when available. Pass
  * `force` to bypass the cache (used right after a write op).
+ *
+ * `stale` is true when the active project root changed (`setStorageRoot`)
+ * while this request was in flight: the result belongs to the OLD project, so
+ * it is neither cached nor trustworthy for the new one. Callers should treat a
+ * stale result as "discard" and not apply it to the current project's UI.
  */
 export async function listFolder(
     path: string,
     opts?: { force?: boolean; limit?: number },
-): Promise<{ data: StorageEntry[]; error: { message: string } | null }> {
+): Promise<{
+    data: StorageEntry[];
+    error: { message: string } | null;
+    stale?: boolean;
+}> {
     if (!opts?.force) {
         const cached = getCachedList(path);
         if (cached) {
@@ -132,9 +141,17 @@ export async function listFolder(
         }
     }
 
+    // Snapshot the root we're listing under; if it changes mid-flight the
+    // result is for a different project and must not poison this one's cache.
+    const rootAtRequest = activeRoot;
+
     const { data, error } = await supabase.storage
         .from(BUCKET)
         .list(withRoot(path), { limit: opts?.limit ?? 200 });
+
+    if (activeRoot !== rootAtRequest) {
+        return { data: [], error: null, stale: true };
+    }
 
     if (error) {
         return { data: [], error };

--- a/frontend/app/dashboard/files/storage.ts
+++ b/frontend/app/dashboard/files/storage.ts
@@ -4,6 +4,35 @@ const supabase = createClient();
 
 export const BUCKET = "Files";
 
+// ---------------------------------------------------------------------------
+// Project scope. Every Storage path is transparently prefixed with
+// `${activeRoot}/`, so each project only ever reads/writes under its own
+// `{projectId}/` subtree. The page works entirely in PROJECT-RELATIVE paths
+// ("" = the project root); this module is the single place that knows the
+// prefix. The RLS policy on storage.objects enforces the same boundary in the
+// database, so this is convenience + correctness, not the security boundary.
+// ---------------------------------------------------------------------------
+
+let activeRoot: string | null = null;
+
+/**
+ * Point the Files module at a project's subtree. Pass the project id (as a
+ * string) to scope all subsequent operations under `${projectId}/`, or `null`
+ * for the unscoped bucket root. Changing the root clears the listing cache so
+ * project-relative keys can never collide across projects.
+ */
+export function setStorageRoot(root: string | null) {
+    if (root === activeRoot) return;
+    activeRoot = root;
+    listCache.clear();
+}
+
+/** Map a project-relative path to its absolute Storage path. */
+function withRoot(path: string): string {
+    if (!activeRoot) return path;
+    return path ? `${activeRoot}/${path}` : activeRoot;
+}
+
 export interface StorageEntry {
     id: string | null;
     name: string;
@@ -105,7 +134,7 @@ export async function listFolder(
 
     const { data, error } = await supabase.storage
         .from(BUCKET)
-        .list(path, { limit: opts?.limit ?? 200 });
+        .list(withRoot(path), { limit: opts?.limit ?? 200 });
 
     if (error) {
         return { data: [], error };
@@ -128,7 +157,7 @@ export async function listFolder(
 export async function collectAllObjectPaths(prefix: string): Promise<string[]> {
     const { data, error } = await supabase.storage
         .from(BUCKET)
-        .list(prefix, { limit: 1000 });
+        .list(withRoot(prefix), { limit: 1000 });
 
     if (error) {
         throw new Error(error.message);
@@ -163,7 +192,7 @@ export async function removePaths(paths: string[]): Promise<void> {
     for (const batch of chunk(paths, 100)) {
         const { data, error } = await supabase.storage
             .from(BUCKET)
-            .remove(batch);
+            .remove(batch.map(withRoot));
         if (error) {
             throw new Error(error.message);
         }
@@ -208,7 +237,7 @@ export async function moveFolder(
         const to = `${newPrefix}${from.slice(oldPrefix.length)}`;
         const { error } = await supabase.storage
             .from(BUCKET)
-            .move(from, to);
+            .move(withRoot(from), withRoot(to));
 
         if (!error) {
             moved.push({ from, to });
@@ -221,7 +250,7 @@ export async function moveFolder(
         for (const m of moved.reverse()) {
             const { error: rbErr } = await supabase.storage
                 .from(BUCKET)
-                .move(m.to, m.from);
+                .move(withRoot(m.to), withRoot(m.from));
             if (rbErr) rollbackOk = false;
         }
 
@@ -240,7 +269,7 @@ export async function moveObject(
 ): Promise<void> {
     const { error } = await supabase.storage
         .from(BUCKET)
-        .move(oldPath, newPath);
+        .move(withRoot(oldPath), withRoot(newPath));
     if (error) {
         throw new Error(error.message);
     }
@@ -252,7 +281,7 @@ export async function uploadFile(
 ): Promise<{ error: { message: string; statusCode?: string } | null }> {
     const { error } = await supabase.storage
         .from(BUCKET)
-        .upload(targetPath, file, { upsert: false });
+        .upload(withRoot(targetPath), file, { upsert: false });
     return { error: error as { message: string; statusCode?: string } | null };
 }
 

--- a/frontend/components/dashboard/explore/DashboardPortal.tsx
+++ b/frontend/components/dashboard/explore/DashboardPortal.tsx
@@ -9,6 +9,7 @@ import { cn } from "@/lib/utils";
 import { AmbientGrid } from "./ui/AmbientGrid";
 import { ChatMessages } from "./ui/ChatMessages";
 import { FloatingNodes } from "./ui/FloatingNodes";
+import { KnowledgeSourcesPanel } from "./ui/KnowledgeSourcesPanel";
 import { PortalHero } from "./ui/PortalHero";
 import { PortalInput } from "./ui/PortalInput";
 import { SourcesPanel } from "./ui/SourcesPanel";
@@ -271,9 +272,12 @@ export function ExplorePortal() {
         >
           <PortalInput animated={false} />
           {showWelcome ? (
-            <div className="mt-4">
-              <SuggestionChips disableAutoAnimation />
-            </div>
+            <>
+              <div className="mt-4">
+                <SuggestionChips disableAutoAnimation />
+              </div>
+              <KnowledgeSourcesPanel className="mt-4" />
+            </>
           ) : (
             <p className="text-center text-xs text-sbi-muted-dark mt-3 font-light">
               AI can make mistakes, so double check responses

--- a/frontend/components/dashboard/explore/ui/KnowledgeSourcesPanel.tsx
+++ b/frontend/components/dashboard/explore/ui/KnowledgeSourcesPanel.tsx
@@ -1,0 +1,196 @@
+"use client";
+
+import { ChevronDown, FileText, Loader2, Plus, Trash2 } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  deleteKnowledgeSource,
+  type KnowledgeSource,
+  listKnowledgeSources,
+  uploadKnowledgeDocument,
+} from "@/lib/api/knowledge";
+import { toastError, toastSuccess } from "@/lib/notifications";
+import { useProject } from "@/lib/project/project-context";
+import { cn } from "@/lib/utils";
+
+/**
+ * Collapsible disclosure of the RAG documents the Explore assistant can pull
+ * from for the active project (its `search_documents` corpus). Read-only for
+ * clients/members; directors can upload PDFs into the index and remove them.
+ * Scoped to the active project; switching projects resets it.
+ */
+export function KnowledgeSourcesPanel({ className }: { className?: string }) {
+  const { user, activeProject } = useProject();
+  const projectId = activeProject?.projectId ?? null;
+  const isDirector = user?.role === "director";
+
+  const [open, setOpen] = useState(false);
+  const [sources, setSources] = useState<KnowledgeSource[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [loaded, setLoaded] = useState(false);
+  const [uploading, setUploading] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const refresh = useCallback(async () => {
+    if (projectId === null) return;
+    setLoading(true);
+    try {
+      setSources(await listKnowledgeSources(projectId));
+      setLoaded(true);
+    } catch (e) {
+      toastError(e instanceof Error ? e.message : "Couldn't load sources");
+    } finally {
+      setLoading(false);
+    }
+  }, [projectId]);
+
+  // Reset whenever the active project changes.
+  useEffect(() => {
+    setLoaded(false);
+    setSources([]);
+  }, []);
+
+  // Load on first expand (and when the project changes while expanded).
+  useEffect(() => {
+    if (open && projectId !== null) void refresh();
+  }, [open, projectId, refresh]);
+
+  const handleUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    e.target.value = "";
+    if (!file || projectId === null) return;
+    setUploading(true);
+    try {
+      await uploadKnowledgeDocument(projectId, file);
+      toastSuccess(`Added ${file.name} to the assistant's sources`);
+      await refresh();
+    } catch (err) {
+      toastError(err instanceof Error ? err.message : "Upload failed");
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  const handleRemove = async (filename: string) => {
+    if (projectId === null) return;
+    try {
+      await deleteKnowledgeSource(projectId, filename);
+      setSources((prev) => prev.filter((s) => s.filename !== filename));
+      toastSuccess(`Removed ${filename}`);
+    } catch (err) {
+      toastError(
+        err instanceof Error ? err.message : "Couldn't remove document",
+      );
+    }
+  };
+
+  if (projectId === null) return null;
+
+  return (
+    <div
+      className={cn(
+        "rounded-xl border border-sbi-dark-border/50 bg-sbi-dark-card/30",
+        className,
+      )}
+    >
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        aria-expanded={open}
+        className="flex w-full items-center gap-2 px-4 py-2.5 text-left"
+      >
+        <FileText className="size-3.5 text-sbi-muted-dark" strokeWidth={1.5} />
+        <span className="text-xs font-light text-sbi-muted">
+          Sources the assistant can use
+        </span>
+        {loaded && (
+          <span className="text-xs font-light tabular-nums text-sbi-muted-dark">
+            {sources.length}
+          </span>
+        )}
+        <ChevronDown
+          className={cn(
+            "ml-auto size-4 text-sbi-muted-dark transition-transform duration-300",
+            open && "rotate-180",
+          )}
+          strokeWidth={1.5}
+        />
+      </button>
+
+      {open && (
+        <div className="border-t border-sbi-dark-border/40 px-2 py-2">
+          {loading && !loaded ? (
+            <div className="flex items-center gap-2 px-2 py-3 text-xs text-sbi-muted-dark">
+              <Loader2 className="size-3.5 animate-spin" strokeWidth={1.5} />
+              Loading sources...
+            </div>
+          ) : sources.length === 0 ? (
+            <p className="px-2 py-3 text-xs font-light leading-relaxed text-sbi-muted-dark">
+              No documents are indexed for this project yet.
+              {isDirector
+                ? " Upload a PDF to let the assistant draw on it."
+                : ""}
+            </p>
+          ) : (
+            <ul className="space-y-0.5">
+              {sources.map((s) => (
+                <li
+                  key={s.filename}
+                  className="group flex items-center gap-3 rounded-lg px-2 py-1.5 transition-colors hover:bg-sbi-dark/40"
+                >
+                  <FileText
+                    className="size-3.5 shrink-0 text-sbi-green/70"
+                    strokeWidth={1.5}
+                  />
+                  <span className="min-w-0 flex-1 truncate text-xs text-white/80">
+                    {s.filename}
+                  </span>
+                  <span className="shrink-0 text-[0.7rem] tabular-nums text-sbi-muted-dark">
+                    {s.chunks} chunk{s.chunks === 1 ? "" : "s"}
+                  </span>
+                  {isDirector && (
+                    <button
+                      type="button"
+                      onClick={() => handleRemove(s.filename)}
+                      aria-label={`Remove ${s.filename}`}
+                      className="shrink-0 text-sbi-muted-dark opacity-0 transition-opacity hover:text-red-400 group-hover:opacity-100"
+                    >
+                      <Trash2 className="size-3.5" strokeWidth={1.5} />
+                    </button>
+                  )}
+                </li>
+              ))}
+            </ul>
+          )}
+
+          {isDirector && (
+            <div className="mt-1 px-1">
+              <button
+                type="button"
+                onClick={() => fileInputRef.current?.click()}
+                disabled={uploading}
+                className="flex items-center gap-2 rounded-lg px-2 py-1.5 text-xs font-light text-sbi-muted transition-colors hover:text-sbi-green disabled:opacity-50"
+              >
+                {uploading ? (
+                  <Loader2
+                    className="size-3.5 animate-spin"
+                    strokeWidth={1.5}
+                  />
+                ) : (
+                  <Plus className="size-3.5" strokeWidth={1.5} />
+                )}
+                {uploading ? "Uploading..." : "Upload PDF"}
+              </button>
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept="application/pdf,.pdf"
+                className="hidden"
+                onChange={handleUpload}
+              />
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/components/dashboard/explore/ui/KnowledgeSourcesPanel.tsx
+++ b/frontend/components/dashboard/explore/ui/KnowledgeSourcesPanel.tsx
@@ -43,11 +43,13 @@ export function KnowledgeSourcesPanel({ className }: { className?: string }) {
     }
   }, [projectId]);
 
-  // Reset whenever the active project changes.
+  // Reset whenever the active project changes (projectId is the trigger, even
+  // though the body only resets state).
+  // biome-ignore lint/correctness/useExhaustiveDependencies: project-keyed reset
   useEffect(() => {
     setLoaded(false);
     setSources([]);
-  }, []);
+  }, [projectId]);
 
   // Load on first expand (and when the project changes while expanded).
   useEffect(() => {

--- a/frontend/lib/api/chat.ts
+++ b/frontend/lib/api/chat.ts
@@ -32,6 +32,9 @@ export interface ChatRequest {
   // Client-minted opaque chat id (uuid) for a brand-new conversation, so the URL
   // is known before the first response. Ignored when session_id is set.
   public_id?: string | null;
+  // Active project id, so the assistant's live-data tools scope to the project
+  // currently selected in the header. Membership is re-verified server-side.
+  project_id?: number | null;
 }
 
 export interface ChatResponse {
@@ -69,6 +72,7 @@ export async function sendChatMessage(
       model_preference: request.model_preference ?? "fast",
       session_id: request.session_id ?? null,
       public_id: request.public_id ?? null,
+      project_id: request.project_id ?? null,
     }),
     signal,
   });

--- a/frontend/lib/api/knowledge.ts
+++ b/frontend/lib/api/knowledge.ts
@@ -62,18 +62,30 @@ export async function listKnowledgeSources(
 }
 
 /** Remove every chunk of a document from the project's index (directors only,
- * enforced by RLS). */
+ * enforced by RLS).
+ *
+ * Documents carry no per-chunk document id, so chunks are grouped/deleted by
+ * `metadata->>filename` (matching `listKnowledgeSources`). `.select("id")`
+ * returns the deleted rows so we can fail loudly when nothing matched — an RLS
+ * block, an already-removed document, or a NULL-metadata row — instead of
+ * reporting a phantom success the optimistic UI would trust. */
 export async function deleteKnowledgeSource(
   projectId: number,
   filename: string,
 ): Promise<void> {
   const supabase = createClient();
-  const { error } = await supabase
+  const { data, error } = await supabase
     .from("client_knowledge")
     .delete()
     .eq("project_id", projectId)
-    .eq("metadata->>filename", filename);
+    .eq("metadata->>filename", filename)
+    .select("id");
   if (error) throw new Error(error.message);
+  if (!data || data.length === 0) {
+    throw new Error(
+      `Couldn't remove "${filename}" — it may have already been deleted or you may not have permission.`,
+    );
+  }
 }
 
 /** Upload a PDF into the project's index via the backend ingester. */

--- a/frontend/lib/api/knowledge.ts
+++ b/frontend/lib/api/knowledge.ts
@@ -1,0 +1,98 @@
+import { createClient } from "@/lib/supabase/client";
+
+/**
+ * The RAG "knowledge" corpus the Explore assistant searches via its
+ * `search_documents` tool lives in the `client_knowledge` table (embedded
+ * chunks), scoped per project. This module surfaces it to the UI: list what a
+ * project has indexed, upload a new PDF into it, and remove a document.
+ *
+ * Reads/deletes go straight through the RLS-scoped Supabase client (project
+ * members can read; project directors can delete). Uploads go through
+ * /api/knowledge/upload, which forwards to the backend ingester (embeddings +
+ * membership re-check).
+ */
+
+export interface KnowledgeSource {
+  /** Original document filename (from chunk metadata). */
+  filename: string;
+  /** Number of embedded chunks stored for this document. */
+  chunks: number;
+  /** Most recent upload timestamp across this document's chunks. */
+  uploadedAt: string | null;
+}
+
+interface ChunkRow {
+  metadata: { filename?: string; upload_date?: string } | null;
+  created_at: string | null;
+}
+
+/** List the project's indexed documents, grouped by filename. */
+export async function listKnowledgeSources(
+  projectId: number,
+): Promise<KnowledgeSource[]> {
+  const supabase = createClient();
+  const { data, error } = await supabase
+    .from("client_knowledge")
+    .select("metadata, created_at")
+    .eq("project_id", projectId);
+  if (error) throw new Error(error.message);
+
+  const byFile = new Map<
+    string,
+    { chunks: number; uploadedAt: string | null }
+  >();
+  for (const row of (data ?? []) as ChunkRow[]) {
+    const filename = row.metadata?.filename ?? "Untitled document";
+    const entry = byFile.get(filename) ?? { chunks: 0, uploadedAt: null };
+    entry.chunks += 1;
+    const when = row.metadata?.upload_date ?? row.created_at;
+    if (when && (!entry.uploadedAt || when > entry.uploadedAt)) {
+      entry.uploadedAt = when;
+    }
+    byFile.set(filename, entry);
+  }
+
+  return Array.from(byFile.entries())
+    .map(([filename, v]) => ({
+      filename,
+      chunks: v.chunks,
+      uploadedAt: v.uploadedAt,
+    }))
+    .sort((a, b) => a.filename.localeCompare(b.filename));
+}
+
+/** Remove every chunk of a document from the project's index (directors only,
+ * enforced by RLS). */
+export async function deleteKnowledgeSource(
+  projectId: number,
+  filename: string,
+): Promise<void> {
+  const supabase = createClient();
+  const { error } = await supabase
+    .from("client_knowledge")
+    .delete()
+    .eq("project_id", projectId)
+    .eq("metadata->>filename", filename);
+  if (error) throw new Error(error.message);
+}
+
+/** Upload a PDF into the project's index via the backend ingester. */
+export async function uploadKnowledgeDocument(
+  projectId: number,
+  file: File,
+): Promise<void> {
+  const form = new FormData();
+  form.append("file", file);
+  form.append("project_id", String(projectId));
+
+  const res = await fetch("/api/knowledge/upload", {
+    method: "POST",
+    body: form,
+  });
+  if (!res.ok) {
+    const err = await res
+      .json()
+      .catch(() => ({ detail: `Upload failed (${res.status})` }));
+    throw new Error(err.detail || `Upload failed (${res.status})`);
+  }
+}

--- a/frontend/lib/chat/chat-context.tsx
+++ b/frontend/lib/chat/chat-context.tsx
@@ -16,6 +16,7 @@ import {
   type SourceDocument,
   sendChatMessage,
 } from "@/lib/api/chat";
+import { useProject } from "@/lib/project/project-context";
 import { createClient } from "@/lib/supabase/client";
 
 export type ModelPreference = "fast" | "thinking";
@@ -118,6 +119,14 @@ export function ChatProvider({ children }: { children: ReactNode }) {
   const cancelledRef = useRef(false);
   const sessionIdRef = useRef<number | null>(null);
 
+  // Active project, read through a ref so runAgent stays stable (no re-creation
+  // on project switch) while always sending the currently-selected project id.
+  // The assistant scopes its live-data tools to this; the backend re-verifies
+  // membership, so it is a scope hint, not a capability.
+  const { activeProject } = useProject();
+  const projectIdRef = useRef<number | null>(activeProject?.projectId ?? null);
+  projectIdRef.current = activeProject?.projectId ?? null;
+
   const isLoading =
     loadingPhase !== "idle" &&
     loadingPhase !== "complete" &&
@@ -219,6 +228,7 @@ export function ChatProvider({ children }: { children: ReactNode }) {
             model_preference: modelPreference,
             session_id: sessionIdRef.current,
             public_id: newPublicId,
+            project_id: projectIdRef.current,
           },
           abortController.signal,
           handlePhase,

--- a/supabase/migrations/20260613000000_files_project_scope.sql
+++ b/supabase/migrations/20260613000000_files_project_scope.sql
@@ -1,0 +1,104 @@
+-- ===========================================================================
+-- Files bucket: scope objects to the caller's project membership.
+--
+-- The Explore "Files" feature now roots every object under a `{projectId}/`
+-- prefix (frontend app/dashboard/files). This migration makes the database
+-- enforce that boundary so a caller can only read/write objects whose first
+-- path segment is a project they belong to.
+--
+-- Before this migration (see 20260603000000_harden_storage_rls):
+--   * SELECT  : any authenticated user could read EVERY object in 'Files'
+--               (no owner/project segment existed to scope on) — so clients
+--               saw all directors' files across all projects.
+--   * INSERT/UPDATE/DELETE : any director, any object (unscoped).
+--
+-- After:
+--   * SELECT  : project members (clients, directors, members of that project).
+--   * INSERT/UPDATE/DELETE : directors who are members of that project.
+--
+-- Membership is resolved exactly like the rest of the app and the Explore AI
+-- tools: profiles.uid = auth.uid() -> profiles.id -> project_members.project_id.
+-- The first path segment (split_part(name, '/', 1)) is the project id.
+--
+-- Fresh-start note: pre-existing objects at the bucket root (no `{projectId}/`
+-- prefix) have a first segment that matches no project id, so they become
+-- invisible to all non-service-role callers. This is intentional — existing
+-- root files are left in place and simply not surfaced in the per-project view.
+--
+-- Idempotent: each policy is DROP ... IF EXISTS then recreated, and the helper
+-- is CREATE OR REPLACE, so the migration is safe to re-apply.
+-- ===========================================================================
+
+-- Helper: is `check_uid` a member of the project named by the FIRST path
+-- segment of `object_name`? SECURITY DEFINER so the policy can read
+-- public.project_members / public.profiles regardless of the caller's own
+-- table grants, mirroring public.is_director.
+CREATE OR REPLACE FUNCTION public.storage_path_project_member(
+  check_uid uuid,
+  object_name text
+)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path TO 'pg_catalog', 'pg_temp'
+AS $$
+  SELECT EXISTS (
+    SELECT 1
+    FROM public.project_members pm
+    JOIN public.profiles pr ON pr.id = pm.profile_id
+    WHERE pr.uid = check_uid
+      AND pm.project_id::text = split_part(object_name, '/', 1)
+  );
+$$;
+
+-- Used only inside RLS policies; do not expose it as a public PostgREST RPC.
+-- Match the hardened posture of public.is_director (authenticated, never anon).
+REVOKE EXECUTE ON FUNCTION public.storage_path_project_member(uuid, text) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.storage_path_project_member(uuid, text) FROM anon;
+GRANT EXECUTE ON FUNCTION public.storage_path_project_member(uuid, text) TO authenticated;
+
+-- SELECT: members of the project the object lives under.
+DROP POLICY IF EXISTS "Allow users to access and upload to buckets 14exqv_0" ON storage.objects;
+CREATE POLICY "Allow users to access and upload to buckets 14exqv_0" ON storage.objects
+  FOR SELECT TO authenticated
+  USING (
+    bucket_id = 'Files'::text
+    AND public.storage_path_project_member(auth.uid(), name)
+  );
+
+-- INSERT: directors who belong to the target project.
+DROP POLICY IF EXISTS "Directors can upload Files" ON storage.objects;
+CREATE POLICY "Directors can upload Files" ON storage.objects
+  FOR INSERT TO authenticated
+  WITH CHECK (
+    bucket_id = 'Files'::text
+    AND public.is_director(auth.uid())
+    AND public.storage_path_project_member(auth.uid(), name)
+  );
+
+-- UPDATE (covers Storage move/rename): directors who belong to the project on
+-- BOTH the source row (USING) and the destination name (WITH CHECK).
+DROP POLICY IF EXISTS "Directors can update Files" ON storage.objects;
+CREATE POLICY "Directors can update Files" ON storage.objects
+  FOR UPDATE TO authenticated
+  USING (
+    bucket_id = 'Files'::text
+    AND public.is_director(auth.uid())
+    AND public.storage_path_project_member(auth.uid(), name)
+  )
+  WITH CHECK (
+    bucket_id = 'Files'::text
+    AND public.is_director(auth.uid())
+    AND public.storage_path_project_member(auth.uid(), name)
+  );
+
+-- DELETE: directors who belong to the project.
+DROP POLICY IF EXISTS "Directors can delete Files" ON storage.objects;
+CREATE POLICY "Directors can delete Files" ON storage.objects
+  FOR DELETE TO authenticated
+  USING (
+    bucket_id = 'Files'::text
+    AND public.is_director(auth.uid())
+    AND public.storage_path_project_member(auth.uid(), name)
+  );

--- a/supabase/migrations/20260613000001_client_knowledge_project_scope.sql
+++ b/supabase/migrations/20260613000001_client_knowledge_project_scope.sql
@@ -1,0 +1,94 @@
+-- ===========================================================================
+-- client_knowledge (RAG documents): scope to project, not just uploader uid.
+--
+-- The Explore AI `search_documents` tool retrieved a caller's documents by
+-- `uid` only, so a director switching projects always got their own uploads
+-- regardless of the active project, and documents weren't shared with the
+-- project team. This adds a `project_id` so retrieval can be narrowed to the
+-- caller's active project (membership-verified in the backend), matching the
+-- live-data tools and the Files bucket.
+--
+-- Backfill is lossless here: every existing row's uploader belongs to exactly
+-- one project, so each row is assigned that project. Rows whose uploader has an
+-- ambiguous (0 or >1) project membership are left NULL and simply won't match a
+-- project-filtered search until reassigned.
+--
+-- Idempotent: column add is IF NOT EXISTS; RPC and policy are DROP/CREATE.
+-- ===========================================================================
+
+ALTER TABLE public.client_knowledge
+  ADD COLUMN IF NOT EXISTS project_id bigint
+  REFERENCES public.projects(id) ON DELETE CASCADE;
+
+-- Backfill from unambiguous single-project uploaders.
+UPDATE public.client_knowledge ck
+SET project_id = sub.pid
+FROM (
+  SELECT pr.uid AS uid,
+         min(pm.project_id) AS pid,
+         count(DISTINCT pm.project_id) AS n
+  FROM public.profiles pr
+  JOIN public.project_members pm ON pm.profile_id = pr.id
+  GROUP BY pr.uid
+) sub
+WHERE ck.uid = sub.uid
+  AND sub.n = 1
+  AND ck.project_id IS NULL;
+
+CREATE INDEX IF NOT EXISTS client_knowledge_project_id_idx
+  ON public.client_knowledge (project_id);
+
+-- Vector search RPC: add an optional project-id array filter. Kept as the last
+-- parameter with a default so existing positional/named callers are unaffected;
+-- the backend now passes `_filter_project_ids` (the caller's membership-verified
+-- active project). The signature change requires DROP + CREATE, so the hardened
+-- grants (service_role only) are re-applied below.
+DROP FUNCTION IF EXISTS public.match_client_knowledge(public.vector, integer, uuid, double precision);
+CREATE OR REPLACE FUNCTION public.match_client_knowledge(
+  _query_embedding public.vector,
+  _match_count integer DEFAULT 5,
+  _filter_uid uuid DEFAULT NULL::uuid,
+  _similarity_threshold double precision DEFAULT 0.5,
+  _filter_project_ids bigint[] DEFAULT NULL::bigint[]
+)
+  RETURNS TABLE(id bigint, content text, metadata jsonb, similarity double precision)
+  LANGUAGE plpgsql
+  SECURITY DEFINER
+  SET search_path TO 'public'
+AS $$
+BEGIN
+  RETURN QUERY
+  SELECT ck.id, ck.content, ck.metadata,
+    1 - (ck.embedding <=> _query_embedding) AS similarity
+  FROM client_knowledge ck
+  WHERE (_filter_project_ids IS NULL OR ck.project_id = ANY(_filter_project_ids))
+    AND (_filter_uid IS NULL OR ck.uid = _filter_uid)
+    AND 1 - (ck.embedding <=> _query_embedding) > _similarity_threshold
+  ORDER BY ck.embedding <=> _query_embedding
+  LIMIT _match_count;
+END;
+$$;
+
+-- Preserve the hardened posture: the RAG functions are service-role only (the
+-- explore backend uses the service role; never anon/authenticated directly).
+REVOKE EXECUTE ON FUNCTION public.match_client_knowledge(public.vector, integer, uuid, double precision, bigint[]) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.match_client_knowledge(public.vector, integer, uuid, double precision, bigint[]) FROM anon;
+REVOKE EXECUTE ON FUNCTION public.match_client_knowledge(public.vector, integer, uuid, double precision, bigint[]) FROM authenticated;
+GRANT EXECUTE ON FUNCTION public.match_client_knowledge(public.vector, integer, uuid, double precision, bigint[]) TO service_role;
+
+-- Defense-in-depth RLS: project members may read their project's documents
+-- (retrieval itself runs as service role, so this guards any direct access).
+-- Additive to the existing uploader-uid policies.
+DROP POLICY IF EXISTS "Project members can view client knowledge" ON public.client_knowledge;
+CREATE POLICY "Project members can view client knowledge" ON public.client_knowledge
+  FOR SELECT TO authenticated
+  USING (
+    project_id IS NOT NULL
+    AND EXISTS (
+      SELECT 1
+      FROM public.project_members pm
+      JOIN public.profiles pr ON pr.id = pm.profile_id
+      WHERE pr.uid = auth.uid()
+        AND pm.project_id = client_knowledge.project_id
+    )
+  );

--- a/supabase/migrations/20260613000002_client_knowledge_director_delete.sql
+++ b/supabase/migrations/20260613000002_client_knowledge_director_delete.sql
@@ -1,0 +1,18 @@
+-- Let a project's directors remove that project's RAG documents (the Explore
+-- Sources panel "remove" action). The pre-existing delete policies only let the
+-- original uploader delete their own rows; this lets any director on the project
+-- manage the corpus, matching the Files-bucket write model.
+DROP POLICY IF EXISTS "Project directors can delete client knowledge" ON public.client_knowledge;
+CREATE POLICY "Project directors can delete client knowledge" ON public.client_knowledge
+  FOR DELETE TO authenticated
+  USING (
+    project_id IS NOT NULL
+    AND public.is_director(auth.uid())
+    AND EXISTS (
+      SELECT 1
+      FROM public.project_members pm
+      JOIN public.profiles pr ON pr.id = pm.profile_id
+      WHERE pr.uid = auth.uid()
+        AND pm.project_id = client_knowledge.project_id
+    )
+  );

--- a/supabase/migrations/20260613000003_client_knowledge_null_project_access.sql
+++ b/supabase/migrations/20260613000003_client_knowledge_null_project_access.sql
@@ -1,0 +1,69 @@
+-- ===========================================================================
+-- client_knowledge: restore uploader-private access to NULL-project documents.
+--
+-- 20260613000001 added `project_id` and narrowed every retrieval path to it,
+-- but its backfill only assigned a project to rows whose uploader belongs to
+-- exactly one project (`sub.n = 1`). Rows left with `project_id IS NULL` became
+-- unreachable everywhere: the `match_client_knowledge` RPC filtered
+-- `ck.project_id = ANY(_filter_project_ids)`, keyword search used
+-- `.in_("project_id", project_ids)`, and the new SELECT RLS policy required
+-- `project_id IS NOT NULL`. That silently hid a user's own legacy uploads.
+--
+-- This restores the uploader's private access to their NULL-project rows while
+-- keeping project sharing for scoped rows:
+--   1. Re-create `match_client_knowledge` so a row matches if EITHER it is in
+--      the active project set OR it is the caller's own NULL-project row.
+--   2. Add a SELECT RLS policy letting uploaders read their own NULL rows.
+--
+-- Idempotent: RPC is DROP/CREATE with grants restated; policy is DROP/CREATE.
+-- ===========================================================================
+
+-- Vector search RPC: a row now matches when it is in the caller's active
+-- project set OR (uid-scoped fallback) it is the caller's own legacy row with
+-- no project. The signature is unchanged from 20260613000001, so DROP + CREATE
+-- with the hardened service-role grants restated below.
+DROP FUNCTION IF EXISTS public.match_client_knowledge(public.vector, integer, uuid, double precision, bigint[]);
+CREATE OR REPLACE FUNCTION public.match_client_knowledge(
+  _query_embedding public.vector,
+  _match_count integer DEFAULT 5,
+  _filter_uid uuid DEFAULT NULL::uuid,
+  _similarity_threshold double precision DEFAULT 0.5,
+  _filter_project_ids bigint[] DEFAULT NULL::bigint[]
+)
+  RETURNS TABLE(id bigint, content text, metadata jsonb, similarity double precision)
+  LANGUAGE plpgsql
+  SECURITY DEFINER
+  SET search_path TO 'public'
+AS $$
+BEGIN
+  RETURN QUERY
+  SELECT ck.id, ck.content, ck.metadata,
+    1 - (ck.embedding <=> _query_embedding) AS similarity
+  FROM client_knowledge ck
+  WHERE (
+      -- Project-scoped rows shared with the active project's team.
+      (_filter_project_ids IS NOT NULL AND ck.project_id = ANY(_filter_project_ids))
+      -- Uploader's own legacy rows that never got a project assigned.
+      OR (_filter_uid IS NOT NULL AND ck.uid = _filter_uid AND ck.project_id IS NULL)
+    )
+    AND 1 - (ck.embedding <=> _query_embedding) > _similarity_threshold
+  ORDER BY ck.embedding <=> _query_embedding
+  LIMIT _match_count;
+END;
+$$;
+
+-- Preserve the hardened posture: the RAG functions are service-role only (the
+-- explore backend uses the service role; never anon/authenticated directly).
+REVOKE EXECUTE ON FUNCTION public.match_client_knowledge(public.vector, integer, uuid, double precision, bigint[]) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.match_client_knowledge(public.vector, integer, uuid, double precision, bigint[]) FROM anon;
+REVOKE EXECUTE ON FUNCTION public.match_client_knowledge(public.vector, integer, uuid, double precision, bigint[]) FROM authenticated;
+GRANT EXECUTE ON FUNCTION public.match_client_knowledge(public.vector, integer, uuid, double precision, bigint[]) TO service_role;
+
+-- Defense-in-depth RLS: let uploaders read their own legacy NULL-project rows.
+-- Additive to the existing project-member SELECT policy (20260613000001) and
+-- the uploader-uid policies from the baseline schema; PostgreSQL ORs permissive
+-- policies, so this only widens access to a user's own orphaned uploads.
+DROP POLICY IF EXISTS "Uploaders can view their own unscoped knowledge" ON public.client_knowledge;
+CREATE POLICY "Uploaders can view their own unscoped knowledge" ON public.client_knowledge
+  FOR SELECT TO authenticated
+  USING (uid = auth.uid() AND project_id IS NULL);


### PR DESCRIPTION
## Summary

Scopes the Explore assistant, the Files bucket, and the RAG corpus to the **active project**, and adds a UI to see/manage what the assistant can draw on. **3 commits, 3 migrations (already applied to the `sbi` project).**

### 1. Assistant active-project scoping (`6bb9e4a`)
The agent's live-data tools and `search_documents` blended **all** of a caller's projects. Now the active project is threaded composer → `/api/chat` → `ChatRequest` → agent → `execute_tool`, and every tool narrows to it via `_scoped_project_ids` (intersects the requested project with the caller's verified `project_members`, so a spoofed/stale id returns no data). `client_knowledge` gains `project_id` (backfilled losslessly) and the `match_client_knowledge` RPC takes `_filter_project_ids`.
- **Security:** `/documents/upload` now **rejects (403)** a `project_id` the caller isn't a member of (was an IDOR).

### 2. Files bucket project-scoping (`291a24a`)
Storage paths are prefixed `{projectId}/` inside `storage.ts`; an RLS policy on `storage.objects` scopes read to project members, write to directors-on-project. Existing root files are left in place (fresh-start).

### 3. RAG sources panel (`751fe4f`)
A collapsible "Sources the assistant can use" panel on the Explore welcome view: members view the project's indexed docs; directors upload PDFs (membership-checked) and remove them (new director-delete policy).

## Migrations (live on `sbi`)
- `20260613000000_files_project_scope` — Files bucket RLS by project membership
- `20260613000001_client_knowledge_project_scope` — `project_id` + RPC filter + member-read RLS
- `20260613000002_client_knowledge_director_delete` — director delete policy

## Follow-up (not in this PR)
- Regenerate `lib/supabase/database.types.ts` (stale on `client_knowledge.project_id`; compiles via loose column typing, worth regenerating).

## Test
`bun build` green; backend `py_compile` + `ruff` clean; frontend `tsc` clean (pre-existing baseline only). Switch projects → live tools, file tree, and document search all track the active project. `get_advisors` clean after the migrations (the one anon-exec helper was locked down).

Depends on nothing; stacks cleanly alongside #70 (disjoint files).
