### PR TITLE
feat(messages): role-matrix, participant-based messaging (+ group conversations)

### DIFF
--- a/frontend/app/dashboard/messages/DetailPane.tsx
+++ b/frontend/app/dashboard/messages/DetailPane.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { useParams } from "next/navigation";
-import { MessageThread } from "@/components/dashboard/messages/MessageThread";
-import { useCmdK } from "@/components/dashboard/messages/cmdk/CommandPalette";
 import { useActor } from "@/components/dashboard/messages/ActorContext";
+import { useCmdK } from "@/components/dashboard/messages/cmdk/CommandPalette";
+import { MessageThread } from "@/components/dashboard/messages/MessageThread";
 
 /**
  * Mounted ONCE inside the messages layout. Reads the active conversation
@@ -39,8 +39,6 @@ export function DetailPane() {
   }
 
   const role = actor.role;
-  const isDirector = role === "director";
-  const isMember = role === "member";
 
   const convo = conversations.find((c) => c.id === conversationId);
   const displayName = convo?.name ?? `Conversation ${conversationId}`;
@@ -67,8 +65,7 @@ export function DetailPane() {
         <MessageThread
           key={conversationId}
           conversationId={conversationId}
-          senderRole={isDirector ? "director" : "client"}
-          readOnly={isMember}
+          senderRole={role}
         />
       </div>
     </>

--- a/frontend/app/dashboard/messages/layout.tsx
+++ b/frontend/app/dashboard/messages/layout.tsx
@@ -1,9 +1,9 @@
 import type { ReactNode } from "react";
 import { Messages } from "@/components/dashboard/messages";
+import { ActorProvider } from "@/components/dashboard/messages/ActorContext";
+import { CreateConversationModalProvider } from "@/components/dashboard/messages/CreateConversationModalContext";
 import { DirectorMessages } from "@/components/dashboard/messages/DirectorMessages";
 import { MemberMessages } from "@/components/dashboard/messages/MemberMessages";
-import { CreateConversationModalProvider } from "@/components/dashboard/messages/CreateConversationModalContext";
-import { ActorProvider } from "@/components/dashboard/messages/ActorContext";
 import { resolveActor } from "@/lib/project/resolve-actor";
 import { CmdKShell } from "./CmdKShell";
 import { DetailPane } from "./DetailPane";
@@ -27,9 +27,7 @@ export default async function MessagesLayout({
 
   const role = actor.profile.role;
   const profileId = actor.profile.id;
-  // Members are read-only: no create provider, no composer downstream.
   const isMember = role === "member";
-  const projectIds = actor.projects.map((p) => p.projectId);
 
   const shell = (
     <ActorProvider actor={{ role, profileId }}>
@@ -39,7 +37,7 @@ export default async function MessagesLayout({
             {role === "director" ? (
               <DirectorMessages profileId={profileId} />
             ) : isMember ? (
-              <MemberMessages projectIds={projectIds} />
+              <MemberMessages profileId={profileId} />
             ) : (
               <Messages />
             )}
@@ -58,10 +56,8 @@ export default async function MessagesLayout({
     </ActorProvider>
   );
 
-  if (isMember) {
-    return shell;
-  }
-
+  // Every role can now start conversations (gated by the matrix), so the create
+  // modal provider wraps all of them.
   return (
     <CreateConversationModalProvider>{shell}</CreateConversationModalProvider>
   );

--- a/frontend/components/dashboard/messages/CreateConversationModal.tsx
+++ b/frontend/components/dashboard/messages/CreateConversationModal.tsx
@@ -76,118 +76,45 @@ export function CreateConversationModal({
   const [candidates, setCandidates] = useState<Candidate[]>([]);
   const [selected, setSelected] = useState<Set<number>>(new Set());
 
-  // Load the people this caller is allowed to message.
+  // Load the people this caller is allowed to message. The matrix + project
+  // rules (and the directory read) live in the list_messageable_profiles RPC,
+  // so the picker doesn't need broad profiles/project_members read access.
   useEffect(() => {
-    if (!opened || !myRole || myProfileId === null) return;
+    if (!opened || myProfileId === null) return;
     setSearch("");
     setSelected(new Set());
 
     const load = async () => {
       setLoading(true);
       const supabase = createClient();
-      const next: Candidate[] = [];
-
-      // Internal (director/member) recipients allowed for this role.
-      const internalRoles: Role[] =
-        myRole === "director"
-          ? ["director", "member"]
-          : myRole === "member"
-            ? ["member", "director"]
-            : ["director"]; // client -> directors
-
-      if (myRole === "client") {
-        // Clients only see directors on their active project.
-        const projId = activeProject?.projectId ?? null;
-        if (projId !== null) {
-          const { data } = await supabase
-            .from("project_members")
-            .select("profile_id, role, profiles(id, name, role)")
-            .eq("project_id", projId)
-            .eq("role", "director");
-          for (const row of data ?? []) {
-            // Supabase types a to-one embed as an array; it is a single row.
-            const prof = row.profiles as unknown as {
-              id: number;
-              name: string | null;
-              role: Role;
-            } | null;
-            if (prof && prof.id !== myProfileId) {
-              next.push({
-                profileId: prof.id,
-                name: prof.name ?? `Director ${prof.id}`,
-                role: "director",
-              });
-            }
-          }
-        }
-      } else {
-        const { data } = await supabase
-          .from("profiles")
-          .select("id, name, role")
-          .in("role", internalRoles)
-          .order("name", { ascending: true });
-        for (const p of data ?? []) {
-          if ((p.id as number) === myProfileId) continue;
-          next.push({
-            profileId: p.id as number,
-            name: (p.name as string) ?? `Person ${p.id}`,
-            role: p.role as Role,
-          });
-        }
-      }
-
-      // Client recipients (directors only): clients of the caller's projects.
-      if (myRole === "director") {
-        const { data: myProjs } = await supabase
-          .from("project_members")
-          .select("project_id")
-          .eq("profile_id", myProfileId);
-        const projIds = [
-          ...new Set(
-            (myProjs ?? []).map((r) => r.project_id as number).filter(Boolean),
-          ),
-        ];
-        if (projIds.length > 0) {
-          const { data } = await supabase
-            .from("project_members")
-            .select(
-              "profile_id, project_id, role, profiles(id, name), projects(id, company_name)",
-            )
-            .in("project_id", projIds)
-            .eq("role", "owner");
-          for (const row of data ?? []) {
-            // To-one embeds: typed as arrays, single rows at runtime.
-            const prof = row.profiles as unknown as {
-              id: number;
-              name: string | null;
-            } | null;
-            const proj = row.projects as unknown as {
-              id: number;
-              company_name: string | null;
-            } | null;
-            if (prof) {
-              next.push({
-                profileId: prof.id,
-                name: prof.name ?? `Client ${prof.id}`,
-                role: "client",
-                projectId: (row.project_id as number) ?? proj?.id,
-                projectName: proj?.company_name ?? undefined,
-              });
-            }
-          }
-        }
-      }
-
-      // De-dup by profile id (a person could appear once).
+      const { data } = await supabase.rpc("list_messageable_profiles");
+      const rows = (data ?? []) as {
+        profile_id: number;
+        name: string | null;
+        role: Role;
+        project_id: number | null;
+        project_name: string | null;
+      }[];
       const seen = new Set<number>();
-      setCandidates(
-        next.filter((c) => !seen.has(c.profileId) && seen.add(c.profileId)),
-      );
+      const next: Candidate[] = [];
+      for (const r of rows) {
+        if (seen.has(r.profile_id)) continue;
+        seen.add(r.profile_id);
+        next.push({
+          profileId: r.profile_id,
+          name: r.name ?? `Person ${r.profile_id}`,
+          role: r.role,
+          projectId: r.project_id ?? undefined,
+          projectName: r.project_name ?? undefined,
+        });
+      }
+      next.sort((a, b) => a.name.localeCompare(b.name));
+      setCandidates(next);
       setLoading(false);
     };
 
     void load();
-  }, [opened, myRole, myProfileId, activeProject?.projectId]);
+  }, [opened, myProfileId]);
 
   const visible = useMemo(() => {
     const q = search.trim().toLowerCase();

--- a/frontend/components/dashboard/messages/CreateConversationModal.tsx
+++ b/frontend/components/dashboard/messages/CreateConversationModal.tsx
@@ -146,11 +146,29 @@ export function CreateConversationModal({
     return client?.projectId ?? null;
   }, [myRole, activeProject?.projectId, selectedCandidates]);
 
+  // A director can multi-select clients, but the conversation pins to ONE project
+  // (every client participant must belong to it). Clients from different projects
+  // would make the create RPC reject the others, so block it up front with a
+  // clear message rather than surfacing a confusing server error.
+  const multipleClientProjects = useMemo(
+    () =>
+      new Set(
+        selectedCandidates
+          .filter((c) => c.role === "client")
+          .map((c) => c.projectId),
+      ).size > 1,
+    [selectedCandidates],
+  );
+
   const hasClient =
     myRole === "client" || selectedCandidates.some((c) => c.role === "client");
   const projectMissing = hasClient && derivedProject === null;
   const canSubmit =
-    selected.size > 0 && !projectMissing && !submitting && !loading;
+    selected.size > 0 &&
+    !projectMissing &&
+    !multipleClientProjects &&
+    !submitting &&
+    !loading;
 
   const toggle = (id: number) =>
     setSelected((prev) => {
@@ -295,7 +313,12 @@ export function CreateConversationModal({
           )}
         </div>
 
-        {hasClient ? (
+        {multipleClientProjects ? (
+          <p className="text-xs leading-relaxed text-amber-400/90">
+            Clients from different projects can't share a conversation. Keep the
+            selected clients to a single project.
+          </p>
+        ) : hasClient ? (
           <p className="text-xs leading-relaxed text-sbi-muted">
             {projectMissing
               ? "Select an active project to message a client."

--- a/frontend/components/dashboard/messages/CreateConversationModal.tsx
+++ b/frontend/components/dashboard/messages/CreateConversationModal.tsx
@@ -1,46 +1,55 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { Check } from "lucide-react";
 import { useRouter } from "next/navigation";
-import { Modal, TextField, btnPrimary, btnGhost } from "@/components/dashboard/common/ui";
-import { createClient } from "@/lib/supabase/client";
-import { useProject } from "@/lib/project/project-context";
+import { useEffect, useMemo, useState } from "react";
+import {
+  btnGhost,
+  btnPrimary,
+  Modal,
+  TextField,
+} from "@/components/dashboard/common/ui";
 import { toastError } from "@/lib/notifications";
+import { useProject } from "@/lib/project/project-context";
+import { createClient } from "@/lib/supabase/client";
+import { cn } from "@/lib/utils";
 import type { Conversation } from "./ConversationList";
 
 /**
- * One project-aware create flow for both roles.
+ * Start a conversation with one or more people, gated by the role matrix:
+ *   director -> directors, members, clients
+ *   member   -> members, directors
+ *   client   -> directors
  *
- * - Director: pick a client project by name, then the conversation is scoped
- *   to that project and its owner profile.
- * - Client: the conversation is scoped to the active project; pick which
- *   director (resolved by name, no department jargon) to talk to.
- *
- * Before inserting, an existing conversation for (client, director, project)
- * is looked up and opened instead of creating a duplicate (P2 duplicate
- * guard). Supabase tables, columns and the batched name-resolution shape
- * (Conversation) are preserved exactly.
+ * The picker only offers people the caller may message. Internal recipients
+ * (directors/members) are project-independent; a client recipient pins the
+ * conversation to that client's project. Selecting >1 recipient makes a group.
+ * Creation goes through the create_conversation RPC, which re-enforces the
+ * matrix and the project rules server-side and dedupes existing threads.
  */
 
-interface ProjectOption {
-  id: number;
-  companyName: string;
-}
+type Role = "director" | "member" | "client";
 
-interface DirectorOption {
-  id: number;
+interface Candidate {
+  profileId: number;
   name: string;
+  role: Role;
+  /** For client candidates: the project the conversation would be scoped to. */
+  projectId?: number;
+  projectName?: string;
 }
 
 interface CreateConversationModalProps {
   opened: boolean;
   onClose: () => void;
-  /** "director" picks a client project; "client" picks a director. */
-  mode: "director" | "client";
-  /** Director's own profile id (required in director mode). */
-  profileId?: number;
   onConversationCreated?: (conversation: Conversation) => void;
 }
+
+const ROLE_LABEL: Record<Role, string> = {
+  director: "Directors",
+  member: "Members",
+  client: "Clients",
+};
 
 function nowLabel(): string {
   return new Date().toLocaleString(undefined, {
@@ -54,257 +63,213 @@ function nowLabel(): string {
 export function CreateConversationModal({
   opened,
   onClose,
-  mode,
-  profileId,
   onConversationCreated,
 }: CreateConversationModalProps) {
   const router = useRouter();
   const { user, activeProject } = useProject();
+  const myProfileId = user?.id ?? null;
+  const myRole = (user?.role ?? null) as Role | null;
 
   const [search, setSearch] = useState("");
+  const [loading, setLoading] = useState(false);
   const [submitting, setSubmitting] = useState(false);
-  const [loadingOptions, setLoadingOptions] = useState(false);
+  const [candidates, setCandidates] = useState<Candidate[]>([]);
+  const [selected, setSelected] = useState<Set<number>>(new Set());
 
-  // Director mode: list of client projects. Client mode: list of directors.
-  const [projects, setProjects] = useState<ProjectOption[]>([]);
-  const [selectedProjectId, setSelectedProjectId] = useState<number | null>(null);
-  const [directors, setDirectors] = useState<DirectorOption[]>([]);
-  const [selectedDirectorId, setSelectedDirectorId] = useState<number | null>(null);
-  // Targets the current user already has a conversation for. Director mode:
-  // project ids. Client mode: director profile ids (scoped to the active
-  // project). Hidden from the picker so it never just bounces to an
-  // existing thread; the duplicate guard still backs this up for races.
-  const [excluded, setExcluded] = useState<Set<number>>(new Set());
-
+  // Load the people this caller is allowed to message.
   useEffect(() => {
-    if (!opened) return;
-
+    if (!opened || !myRole || myProfileId === null) return;
     setSearch("");
-    setSelectedProjectId(null);
-    setSelectedDirectorId(null);
+    setSelected(new Set());
 
     const load = async () => {
-      setLoadingOptions(true);
+      setLoading(true);
       const supabase = createClient();
+      const next: Candidate[] = [];
 
-      if (mode === "director") {
-        const [{ data: projectData }, { data: existing }] = await Promise.all([
-          supabase
-            .from("projects")
-            .select("id, company_name")
-            .order("company_name", { ascending: true }),
-          profileId
-            ? supabase
-                .from("conversations")
-                .select("project_id")
-                .eq("director_profile_id", profileId)
-            : Promise.resolve({
-                data: [] as { project_id: number | null }[],
-              }),
-        ]);
+      // Internal (director/member) recipients allowed for this role.
+      const internalRoles: Role[] =
+        myRole === "director"
+          ? ["director", "member"]
+          : myRole === "member"
+            ? ["member", "director"]
+            : ["director"]; // client -> directors
 
-        setExcluded(
-          new Set(
-            (existing ?? [])
-              .map((c) => c.project_id as number | null)
-              .filter((id): id is number => id !== null),
-          ),
-        );
-        setProjects(
-          (projectData ?? []).map((p) => ({
-            id: p.id as number,
-            companyName: (p.company_name as string) ?? "",
-          })),
-        );
-      } else {
-        const clientId = user?.id ?? null;
+      if (myRole === "client") {
+        // Clients only see directors on their active project.
         const projId = activeProject?.projectId ?? null;
-
-        let existingQuery = supabase
-          .from("conversations")
-          .select("director_profile_id");
-        existingQuery =
-          clientId === null
-            ? existingQuery.is("client_profile_id", null)
-            : existingQuery.eq("client_profile_id", clientId);
-        existingQuery =
-          projId === null
-            ? existingQuery.is("project_id", null)
-            : existingQuery.eq("project_id", projId);
-
-        const [{ data: directorData }, { data: existing }] =
-          await Promise.all([
-            supabase
-              .from("profiles")
-              .select("id, name")
-              .eq("role", "director")
-              .order("name", { ascending: true }),
-            existingQuery,
-          ]);
-
-        setExcluded(
-          new Set(
-            (existing ?? [])
-              .map((c) => c.director_profile_id as number | null)
-              .filter((id): id is number => id !== null),
-          ),
-        );
-        setDirectors(
-          (directorData ?? []).map((d) => ({
-            id: d.id as number,
-            name: (d.name as string) ?? "",
-          })),
-        );
+        if (projId !== null) {
+          const { data } = await supabase
+            .from("project_members")
+            .select("profile_id, role, profiles(id, name, role)")
+            .eq("project_id", projId)
+            .eq("role", "director");
+          for (const row of data ?? []) {
+            // Supabase types a to-one embed as an array; it is a single row.
+            const prof = row.profiles as unknown as {
+              id: number;
+              name: string | null;
+              role: Role;
+            } | null;
+            if (prof && prof.id !== myProfileId) {
+              next.push({
+                profileId: prof.id,
+                name: prof.name ?? `Director ${prof.id}`,
+                role: "director",
+              });
+            }
+          }
+        }
+      } else {
+        const { data } = await supabase
+          .from("profiles")
+          .select("id, name, role")
+          .in("role", internalRoles)
+          .order("name", { ascending: true });
+        for (const p of data ?? []) {
+          if ((p.id as number) === myProfileId) continue;
+          next.push({
+            profileId: p.id as number,
+            name: (p.name as string) ?? `Person ${p.id}`,
+            role: p.role as Role,
+          });
+        }
       }
 
-      setLoadingOptions(false);
+      // Client recipients (directors only): clients of the caller's projects.
+      if (myRole === "director") {
+        const { data: myProjs } = await supabase
+          .from("project_members")
+          .select("project_id")
+          .eq("profile_id", myProfileId);
+        const projIds = [
+          ...new Set(
+            (myProjs ?? []).map((r) => r.project_id as number).filter(Boolean),
+          ),
+        ];
+        if (projIds.length > 0) {
+          const { data } = await supabase
+            .from("project_members")
+            .select(
+              "profile_id, project_id, role, profiles(id, name), projects(id, company_name)",
+            )
+            .in("project_id", projIds)
+            .eq("role", "owner");
+          for (const row of data ?? []) {
+            // To-one embeds: typed as arrays, single rows at runtime.
+            const prof = row.profiles as unknown as {
+              id: number;
+              name: string | null;
+            } | null;
+            const proj = row.projects as unknown as {
+              id: number;
+              company_name: string | null;
+            } | null;
+            if (prof) {
+              next.push({
+                profileId: prof.id,
+                name: prof.name ?? `Client ${prof.id}`,
+                role: "client",
+                projectId: (row.project_id as number) ?? proj?.id,
+                projectName: proj?.company_name ?? undefined,
+              });
+            }
+          }
+        }
+      }
+
+      // De-dup by profile id (a person could appear once).
+      const seen = new Set<number>();
+      setCandidates(
+        next.filter((c) => !seen.has(c.profileId) && seen.add(c.profileId)),
+      );
+      setLoading(false);
     };
 
-    load();
-  }, [opened, mode, profileId, user?.id, activeProject?.projectId]);
+    void load();
+  }, [opened, myRole, myProfileId, activeProject?.projectId]);
 
-  const filteredProjects = useMemo(() => {
+  const visible = useMemo(() => {
     const q = search.trim().toLowerCase();
-    const base = projects.filter((p) => !excluded.has(p.id));
-    if (!q) return base;
-    return base.filter((p) => p.companyName.toLowerCase().includes(q));
-  }, [projects, excluded, search]);
+    const base = q
+      ? candidates.filter((c) => c.name.toLowerCase().includes(q))
+      : candidates;
+    // Group by role in a stable order.
+    const order: Role[] = ["director", "member", "client"];
+    return order
+      .map((role) => ({
+        role,
+        items: base.filter((c) => c.role === role),
+      }))
+      .filter((g) => g.items.length > 0);
+  }, [candidates, search]);
 
-  const filteredDirectors = useMemo(() => {
-    const q = search.trim().toLowerCase();
-    const base = directors.filter((d) => !excluded.has(d.id));
-    if (!q) return base;
-    return base.filter((d) => d.name.toLowerCase().includes(q));
-  }, [directors, excluded, search]);
+  const selectedCandidates = useMemo(
+    () => candidates.filter((c) => selected.has(c.profileId)),
+    [candidates, selected],
+  );
 
-  // True when nothing is startable at all (every option already has a
-  // thread), vs. merely filtered out by the search box.
-  const noStartable =
-    !loadingOptions &&
-    (mode === "director"
-      ? projects.length > 0 &&
-        projects.every((p) => excluded.has(p.id))
-      : directors.length > 0 &&
-        directors.every((d) => excluded.has(d.id)));
+  // Project derivation: client caller -> active project; otherwise a selected
+  // client pins the project; internal-only -> no project.
+  const derivedProject = useMemo(() => {
+    if (myRole === "client") {
+      return activeProject?.projectId ?? null;
+    }
+    const client = selectedCandidates.find((c) => c.role === "client");
+    return client?.projectId ?? null;
+  }, [myRole, activeProject?.projectId, selectedCandidates]);
 
+  const hasClient =
+    myRole === "client" || selectedCandidates.some((c) => c.role === "client");
+  const projectMissing = hasClient && derivedProject === null;
   const canSubmit =
-    mode === "director" ? selectedProjectId !== null : selectedDirectorId !== null;
+    selected.size > 0 && !projectMissing && !submitting && !loading;
 
-  const openExistingOrCreate = async (
-    clientProfileId: number | null,
-    directorProfileId: number,
-    projectId: number | null,
-    displayName: string,
-  ) => {
-    const supabase = createClient();
-
-    // P2 duplicate guard: reuse an existing thread for this triple.
-    let existingQuery = supabase
-      .from("conversations")
-      .select("id")
-      .eq("director_profile_id", directorProfileId);
-
-    existingQuery =
-      clientProfileId === null
-        ? existingQuery.is("client_profile_id", null)
-        : existingQuery.eq("client_profile_id", clientProfileId);
-
-    existingQuery =
-      projectId === null
-        ? existingQuery.is("project_id", null)
-        : existingQuery.eq("project_id", projectId);
-
-    const { data: existing } = await existingQuery
-      .order("created_at", { ascending: true })
-      .limit(1)
-      .maybeSingle();
-
-    if (existing?.id) {
-      router.push(`/dashboard/messages/${existing.id}`);
-      onClose();
-      return;
-    }
-
-    const { data: conversation, error: convoError } = await supabase
-      .from("conversations")
-      .insert({
-        client_profile_id: clientProfileId,
-        director_profile_id: directorProfileId,
-        project_id: projectId,
-      })
-      .select("id")
-      .single();
-
-    if (convoError || !conversation) {
-      toastError(
-        convoError?.message ?? "The conversation could not be created.",
-        "Could not start conversation",
-      );
-      return;
-    }
-
-    const conversationId = conversation.id as number;
-
-    onConversationCreated?.({
-      id: String(conversationId),
-      name: displayName,
-      lastMessage: "",
-      timestamp: nowLabel(),
-      unread: false,
-      lastActivity: Date.now(),
+  const toggle = (id: number) =>
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
     });
 
-    router.push(`/dashboard/messages/${conversationId}`);
-    onClose();
-  };
-
   const handleCreate = async () => {
-    if (submitting) return;
+    if (!canSubmit) return;
     setSubmitting(true);
-
     try {
       const supabase = createClient();
-      const {
-        data: { user: authUser },
-        error: userError,
-      } = await supabase.auth.getUser();
-
-      if (userError || !authUser) {
-        toastError("Your session has expired. Sign in again.", "Not signed in");
+      const { data, error } = await supabase.rpc("create_conversation", {
+        _participant_profile_ids: Array.from(selected),
+        _project_id: derivedProject,
+      });
+      if (error || data == null) {
+        toastError(
+          error?.message ?? "The conversation could not be created.",
+          "Could not start conversation",
+        );
         return;
       }
+      const conversationId = data as number;
 
-      if (mode === "director") {
-        if (selectedProjectId === null || !profileId) return;
+      const names = selectedCandidates.map((c) => c.name);
+      const name =
+        names.length <= 2
+          ? names.join(", ")
+          : `${names[0]}, ${names[1]} +${names.length - 2}`;
 
-        const project = projects.find((p) => p.id === selectedProjectId);
-
-        // Resolve the project's owner profile (the client side of the thread).
-        const { data: ownerMembership } = await supabase
-          .from("project_members")
-          .select("profile_id")
-          .eq("project_id", selectedProjectId)
-          .eq("role", "owner")
-          .maybeSingle();
-
-        await openExistingOrCreate(
-          ownerMembership?.profile_id ?? null,
-          profileId,
-          selectedProjectId,
-          project?.companyName ?? "Conversation",
-        );
-      } else {
-        if (selectedDirectorId === null || !user) return;
-
-        const director = directors.find((d) => d.id === selectedDirectorId);
-
-        await openExistingOrCreate(
-          user.id,
-          selectedDirectorId,
-          activeProject?.projectId ?? null,
-          director?.name ?? activeProject?.companyName ?? "Conversation",
-        );
-      }
+      onConversationCreated?.({
+        id: String(conversationId),
+        name,
+        lastMessage: "",
+        timestamp: nowLabel(),
+        unread: false,
+        lastActivity: Date.now(),
+      });
+      router.push(`/dashboard/messages/${conversationId}`);
+      onClose();
     } catch (err) {
       toastError(
         err instanceof Error ? err.message : "Unexpected error.",
@@ -315,80 +280,105 @@ export function CreateConversationModal({
     }
   };
 
-  const title = mode === "director" ? "New conversation" : "Message a director";
-  const searchLabel = mode === "director" ? "Project" : "Director";
-  const placeholder =
-    mode === "director" ? "Search projects by name" : "Search directors by name";
-
-  const rows =
-    mode === "director"
-      ? filteredProjects.map((p) => ({
-          key: p.id,
-          label: p.companyName || `Project ${p.id}`,
-          selected: selectedProjectId === p.id,
-          onSelect: () => setSelectedProjectId(p.id),
-        }))
-      : filteredDirectors.map((d) => ({
-          key: d.id,
-          label: d.name || `Director ${d.id}`,
-          selected: selectedDirectorId === d.id,
-          onSelect: () => setSelectedDirectorId(d.id),
-        }));
-
   return (
-    <Modal opened={opened} onClose={onClose} title={title} size="sm">
+    <Modal opened={opened} onClose={onClose} title="New conversation" size="sm">
       <div className="flex flex-col gap-4">
-        {mode === "client" && activeProject ? (
-          <p className="text-xs text-sbi-muted leading-relaxed">
-            This conversation will be scoped to{" "}
-            <span className="text-white">{activeProject.companyName}</span>.
-          </p>
-        ) : null}
-
         <TextField
-          label={searchLabel}
+          label="To"
           value={search}
           onChange={setSearch}
-          placeholder={placeholder}
+          placeholder="Search people by name"
           autoFocus
         />
 
-        <div className="max-h-56 overflow-y-auto custom-scrollbar rounded-md border border-sbi-dark-border/50 divide-y divide-sbi-dark-border/40">
-          {loadingOptions ? (
+        {selectedCandidates.length > 0 ? (
+          <div className="flex flex-wrap gap-1.5">
+            {selectedCandidates.map((c) => (
+              <button
+                key={c.profileId}
+                type="button"
+                onClick={() => toggle(c.profileId)}
+                className="flex items-center gap-1.5 rounded-full border border-sbi-green/30 bg-sbi-green/5 px-2.5 py-1 text-xs text-white transition-colors hover:border-sbi-green/50"
+              >
+                {c.name}
+                <span className="text-sbi-muted-dark">×</span>
+              </button>
+            ))}
+          </div>
+        ) : null}
+
+        <div className="max-h-56 divide-y divide-sbi-dark-border/40 overflow-y-auto rounded-md border border-sbi-dark-border/50 custom-scrollbar">
+          {loading ? (
             <div className="flex flex-col">
               {[0, 1, 2].map((i) => (
                 <div key={i} className="px-3 py-2.5">
-                  <div className="h-3.5 w-40 rounded bg-sbi-dark-card/80 animate-pulse" />
+                  <div className="h-3.5 w-40 animate-pulse rounded bg-sbi-dark-card/80" />
                 </div>
               ))}
             </div>
-          ) : rows.length === 0 ? (
+          ) : visible.length === 0 ? (
             <p className="px-3 py-3 text-xs text-sbi-muted">
-              {noStartable
-                ? mode === "director"
-                  ? "You already have a conversation for every project."
-                  : "You already have a conversation with every director."
-                : mode === "director"
-                  ? "No projects match that search."
-                  : "No directors match that search."}
+              {candidates.length === 0
+                ? "There is no one you can start a conversation with yet."
+                : "No people match that search."}
             </p>
           ) : (
-            rows.map((r) => (
-              <button
-                key={r.key}
-                type="button"
-                onClick={r.onSelect}
-                className={`w-full text-left px-3 py-2.5 text-sm transition-colors cursor-pointer ${
-                  r.selected
-                    ? "bg-sbi-dark-card text-white"
-                    : "text-sbi-muted hover:bg-sbi-dark-card/50 hover:text-white"
-                }`}
-              >
-                {r.label}
-              </button>
+            visible.map((group) => (
+              <div key={group.role}>
+                <p className="bg-sbi-dark/40 px-3 py-1.5 text-[0.7rem] uppercase tracking-[0.2em] text-sbi-muted-dark">
+                  {ROLE_LABEL[group.role]}
+                </p>
+                {group.items.map((c) => {
+                  const isSelected = selected.has(c.profileId);
+                  return (
+                    <button
+                      key={c.profileId}
+                      type="button"
+                      onClick={() => toggle(c.profileId)}
+                      className={cn(
+                        "flex w-full items-center gap-3 px-3 py-2.5 text-left text-sm transition-colors",
+                        isSelected
+                          ? "bg-sbi-dark-card text-white"
+                          : "text-sbi-muted hover:bg-sbi-dark-card/50 hover:text-white",
+                      )}
+                    >
+                      <span
+                        className={cn(
+                          "flex size-4 shrink-0 items-center justify-center rounded border transition-colors",
+                          isSelected
+                            ? "border-sbi-green bg-sbi-green/20 text-sbi-green"
+                            : "border-sbi-dark-border",
+                        )}
+                      >
+                        {isSelected ? (
+                          <Check className="size-3" strokeWidth={2.5} />
+                        ) : null}
+                      </span>
+                      <span className="min-w-0 flex-1 truncate">{c.name}</span>
+                      {c.role === "client" && c.projectName ? (
+                        <span className="shrink-0 text-[0.7rem] uppercase tracking-[0.15em] text-sbi-muted-dark">
+                          {c.projectName}
+                        </span>
+                      ) : null}
+                    </button>
+                  );
+                })}
+              </div>
             ))
           )}
         </div>
+
+        {hasClient ? (
+          <p className="text-xs leading-relaxed text-sbi-muted">
+            {projectMissing
+              ? "Select an active project to message a client."
+              : "This conversation includes a client and is scoped to their project."}
+          </p>
+        ) : selected.size > 1 ? (
+          <p className="text-xs leading-relaxed text-sbi-muted">
+            This will be a group conversation.
+          </p>
+        ) : null}
 
         <div className="flex justify-end gap-2 pt-1">
           <button type="button" className={btnGhost} onClick={onClose}>
@@ -398,9 +388,9 @@ export function CreateConversationModal({
             type="button"
             className={btnPrimary}
             onClick={handleCreate}
-            disabled={!canSubmit || submitting}
+            disabled={!canSubmit}
           >
-            {submitting ? "Opening" : "Open conversation"}
+            {submitting ? "Opening" : "Start conversation"}
           </button>
         </div>
       </div>

--- a/frontend/components/dashboard/messages/DirectorMessages.tsx
+++ b/frontend/components/dashboard/messages/DirectorMessages.tsx
@@ -233,7 +233,9 @@ export function DirectorMessages({ profileId }: DirectorMessagesProps) {
         opened={open}
         onClose={() => setOpen(false)}
         onConversationCreated={(convo) =>
-          setConversations((prev) => [convo, ...prev])
+          setConversations((prev) =>
+            prev.some((c) => c.id === convo.id) ? prev : [convo, ...prev],
+          )
         }
       />
     </div>

--- a/frontend/components/dashboard/messages/DirectorMessages.tsx
+++ b/frontend/components/dashboard/messages/DirectorMessages.tsx
@@ -1,16 +1,16 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
-import { usePathname } from "next/navigation";
 import { MessageSquarePlus } from "lucide-react";
-import { ConversationList, type Conversation } from "./ConversationList";
-import { CreateConversationModal } from "./CreateConversationModal";
-import { useCreateConversationModal } from "./CreateConversationModalContext";
-import { fetchReadMap } from "./read-state";
-import { createClient } from "@/lib/supabase/client";
+import { usePathname } from "next/navigation";
+import { useCallback, useEffect, useState } from "react";
 import { prefetchConv } from "@/lib/messages/prefetch";
 import { setTabUnreadCount } from "@/lib/messages/tab-title";
+import { createClient } from "@/lib/supabase/client";
+import { type Conversation, ConversationList } from "./ConversationList";
+import { CreateConversationModal } from "./CreateConversationModal";
+import { useCreateConversationModal } from "./CreateConversationModalContext";
 import { useCmdK } from "./cmdk/CommandPalette";
+import { loadActorConversations } from "./load-conversations";
 
 interface DirectorMessagesProps {
   profileId?: number;
@@ -34,7 +34,7 @@ export function DirectorMessages({ profileId }: DirectorMessagesProps) {
     if (cmdK && conversations.length > 0) {
       cmdK.setConversations(conversations);
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [conversations]);
 
   const context = useCreateConversationModal();
@@ -44,112 +44,16 @@ export function DirectorMessages({ profileId }: DirectorMessagesProps) {
 
   const loadConversations = useCallback(async () => {
     if (!profileId) return;
-
     setLoading(true);
     setErrored(false);
-
-    const supabase = createClient();
-
-    const { data: convos, error: convoError } = await supabase
-      .from("conversations")
-      .select("id, client_profile_id, project_id")
-      .eq("director_profile_id", profileId)
-      .order("created_at", { ascending: false });
-
-    if (convoError) {
+    try {
+      const supabase = createClient();
+      setConversations(await loadActorConversations(supabase, profileId));
+    } catch {
       setErrored(true);
+    } finally {
       setLoading(false);
-      return;
     }
-
-    if (!convos || convos.length === 0) {
-      setConversations([]);
-      setLoading(false);
-      return;
-    }
-
-    // Batch-fetch client names from profiles
-    const clientProfileIds = [...new Set(convos.map((c) => c.client_profile_id).filter(Boolean))] as number[];
-    const clientMap = new Map<number, string>();
-
-    if (clientProfileIds.length > 0) {
-      const { data: profiles } = await supabase
-        .from("profiles")
-        .select("id, name")
-        .in("id", clientProfileIds);
-
-      if (profiles) {
-        for (const p of profiles) {
-          clientMap.set(p.id, p.name ?? "");
-        }
-      }
-    }
-
-    // Batch-fetch project names
-    const projectIds = [...new Set(convos.map((c) => c.project_id).filter(Boolean))] as number[];
-    const projectMap = new Map<number, string>();
-    if (projectIds.length > 0) {
-      const { data: projectsData } = await supabase
-        .from("projects")
-        .select("id, company_name")
-        .in("id", projectIds);
-      if (projectsData) {
-        for (const p of projectsData) {
-          projectMap.set(p.id, p.company_name ?? "");
-        }
-      }
-    }
-
-    // Fetch latest message per conversation (parallel, limit 1 each)
-    const convoIds = convos.map((c) => c.id);
-    const latestMessageMap = new Map<number, { content: string; created_at: string }>();
-
-    await Promise.all(convoIds.map(async (cid) => {
-      const { data: latest } = await supabase
-        .from("messages")
-        .select("content, created_at")
-        .eq("conversation_id", cid)
-        .order("created_at", { ascending: false })
-        .limit(1)
-        .maybeSingle();
-
-      if (latest) {
-        latestMessageMap.set(cid as number, {
-          content: latest.content ?? "",
-          created_at: latest.created_at as string,
-        });
-      }
-    }));
-
-    const readMap = await fetchReadMap();
-
-    const result: Conversation[] = convos.map((convo) => {
-      // Resolve peer name; fall back to project/company, never "Client"/ID.
-      const clientName = clientMap.get(convo.client_profile_id as number);
-      const projectName = convo.project_id ? projectMap.get(convo.project_id as number) : undefined;
-      const latest = latestMessageMap.get(convo.id as number);
-      const activityMs = latest ? new Date(latest.created_at).getTime() : 0;
-      const id = String(convo.id);
-      return {
-        id,
-        name: clientName || projectName || `Conversation ${id}`,
-        projectName: projectName || undefined,
-        lastMessage: latest?.content ?? (latest ? "Attachment" : ""),
-        timestamp: latest
-          ? new Date(latest.created_at).toLocaleString(undefined, {
-              month: "short",
-              day: "numeric",
-              hour: "2-digit",
-              minute: "2-digit",
-            })
-          : "",
-        unread: activityMs > 0 && activityMs > (readMap[id] ?? 0),
-        lastActivity: activityMs,
-      };
-    });
-
-    setConversations(result);
-    setLoading(false);
   }, [profileId]);
 
   useEffect(() => {
@@ -161,7 +65,9 @@ export function DirectorMessages({ profileId }: DirectorMessagesProps) {
   // avoid opening 100 simultaneous Supabase connections.
   useEffect(() => {
     if (conversations.length === 0) return;
-    const sorted = [...conversations].sort((a, b) => (b.lastActivity ?? 0) - (a.lastActivity ?? 0));
+    const sorted = [...conversations].sort(
+      (a, b) => (b.lastActivity ?? 0) - (a.lastActivity ?? 0),
+    );
     const toWarm = sorted.slice(0, 100).map((c) => c.id);
 
     (async () => {
@@ -200,7 +106,10 @@ export function DirectorMessages({ profileId }: DirectorMessagesProps) {
   // Unfiltered postgres_changes does not deliver here, so subscribe with a
   // per-conversation filter (mirrors the proven thread pattern) plus a
   // filtered conversations-insert listener for brand-new conversations.
-  const convoIdsKey = conversations.map((c) => c.id).sort().join(",");
+  const convoIdsKey = conversations
+    .map((c) => c.id)
+    .sort()
+    .join(",");
   useEffect(() => {
     const supabase = createClient();
     const ids = convoIdsKey ? convoIdsKey.split(",") : [];
@@ -268,6 +177,7 @@ export function DirectorMessages({ profileId }: DirectorMessagesProps) {
     });
 
     if (profileId) {
+      // A new participant row for me means I was added to a conversation.
       const convCh = supabase.channel(
         `messages:list:director:conv:${profileId}`,
       );
@@ -276,8 +186,8 @@ export function DirectorMessages({ profileId }: DirectorMessagesProps) {
         {
           event: "INSERT",
           schema: "public",
-          table: "conversations",
-          filter: `director_profile_id=eq.${profileId}`,
+          table: "conversation_participants",
+          filter: `profile_id=eq.${profileId}`,
         },
         () => {
           loadConversations();
@@ -322,8 +232,6 @@ export function DirectorMessages({ profileId }: DirectorMessagesProps) {
       <CreateConversationModal
         opened={open}
         onClose={() => setOpen(false)}
-        mode="director"
-        profileId={profileId}
         onConversationCreated={(convo) =>
           setConversations((prev) => [convo, ...prev])
         }

--- a/frontend/components/dashboard/messages/MemberMessages.tsx
+++ b/frontend/components/dashboard/messages/MemberMessages.tsx
@@ -224,7 +224,9 @@ export function MemberMessages({ profileId }: MemberMessagesProps) {
         opened={open}
         onClose={() => setOpen(false)}
         onConversationCreated={(convo) =>
-          setConversations((prev) => [convo, ...prev])
+          setConversations((prev) =>
+            prev.some((c) => c.id === convo.id) ? prev : [convo, ...prev],
+          )
         }
       />
     </div>

--- a/frontend/components/dashboard/messages/MemberMessages.tsx
+++ b/frontend/components/dashboard/messages/MemberMessages.tsx
@@ -1,25 +1,28 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { MessageSquarePlus } from "lucide-react";
 import { usePathname } from "next/navigation";
-import { ConversationList, type Conversation } from "./ConversationList";
-import { fetchReadMap } from "./read-state";
-import { createClient } from "@/lib/supabase/client";
+import { useCallback, useEffect, useState } from "react";
 import { prefetchConv } from "@/lib/messages/prefetch";
 import { setTabUnreadCount } from "@/lib/messages/tab-title";
+import { createClient } from "@/lib/supabase/client";
+import { type Conversation, ConversationList } from "./ConversationList";
+import { CreateConversationModal } from "./CreateConversationModal";
+import { useCreateConversationModal } from "./CreateConversationModalContext";
 import { useCmdK } from "./cmdk/CommandPalette";
+import { loadActorConversations } from "./load-conversations";
 
 interface MemberMessagesProps {
-  /** Project ids the member belongs to (read-only scope). */
-  projectIds: number[];
+  /** The member's own profile id (the participant key). */
+  profileId?: number;
 }
 
 /**
- * Members are READ-ONLY: they can browse the conversations on their projects
- * but get no create affordance (and no composer in the thread). They never
- * fall into the client compose path.
+ * Members can hold conversations with other members and with directors (per the
+ * role matrix). Like every role their inbox is participant-based: they see the
+ * conversations they're in, internal or otherwise.
  */
-export function MemberMessages({ projectIds }: MemberMessagesProps) {
+export function MemberMessages({ profileId }: MemberMessagesProps) {
   const pathname = usePathname();
   const [conversations, setConversations] = useState<Conversation[]>([]);
   const [loading, setLoading] = useState(true);
@@ -37,134 +40,39 @@ export function MemberMessages({ projectIds }: MemberMessagesProps) {
     if (cmdK && conversations.length > 0) {
       cmdK.setConversations(conversations);
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [conversations]);
 
-  const loadConversations = useCallback(async () => {
-    if (projectIds.length === 0) {
-      setConversations([]);
-      setLoading(false);
-      return;
-    }
+  const context = useCreateConversationModal();
+  const [localOpen, setLocalOpen] = useState(false);
+  const open = context?.open ?? localOpen;
+  const setOpen = context?.setOpen ?? setLocalOpen;
 
+  const loadConversations = useCallback(async () => {
+    if (!profileId) return;
     setLoading(true);
     setErrored(false);
-
-    const supabase = createClient();
-
-    const { data: convos, error: convoError } = await supabase
-      .from("conversations")
-      .select("id, client_profile_id, director_profile_id, project_id")
-      .in("project_id", projectIds)
-      .order("created_at", { ascending: false });
-
-    if (convoError) {
+    try {
+      const supabase = createClient();
+      setConversations(await loadActorConversations(supabase, profileId));
+    } catch {
       setErrored(true);
+    } finally {
       setLoading(false);
-      return;
     }
-
-    if (!convos || convos.length === 0) {
-      setConversations([]);
-      setLoading(false);
-      return;
-    }
-
-    // Batch-fetch director names (the member's project-side counterpart shown).
-    const directorProfileIds = [...new Set(convos.map((c) => c.director_profile_id).filter(Boolean))] as number[];
-    const directorMap = new Map<number, string>();
-
-    if (directorProfileIds.length > 0) {
-      const { data: profiles } = await supabase
-        .from("profiles")
-        .select("id, name")
-        .in("id", directorProfileIds);
-
-      if (profiles) {
-        for (const p of profiles) {
-          directorMap.set(p.id, p.name ?? "");
-        }
-      }
-    }
-
-    // Batch-fetch project names
-    const convoProjectIds = [...new Set(convos.map((c) => c.project_id).filter(Boolean))] as number[];
-    const projectMap = new Map<number, string>();
-    if (convoProjectIds.length > 0) {
-      const { data: projectsData } = await supabase
-        .from("projects")
-        .select("id, company_name")
-        .in("id", convoProjectIds);
-      if (projectsData) {
-        for (const p of projectsData) {
-          projectMap.set(p.id, p.company_name ?? "");
-        }
-      }
-    }
-
-    // Fetch latest message per conversation (parallel, limit 1 each)
-    const convoIds = convos.map((c) => c.id);
-    const latestMessageMap = new Map<number, { content: string; created_at: string }>();
-
-    await Promise.all(convoIds.map(async (cid) => {
-      const { data: latest } = await supabase
-        .from("messages")
-        .select("content, created_at")
-        .eq("conversation_id", cid)
-        .order("created_at", { ascending: false })
-        .limit(1)
-        .maybeSingle();
-
-      if (latest) {
-        latestMessageMap.set(cid as number, {
-          content: latest.content ?? "",
-          created_at: latest.created_at as string,
-        });
-      }
-    }));
-
-    const readMap = await fetchReadMap();
-
-    const result: Conversation[] = convos.map((convo) => {
-      const directorName = directorMap.get(convo.director_profile_id as number);
-      const projectName = convo.project_id ? projectMap.get(convo.project_id as number) : undefined;
-      const latest = latestMessageMap.get(convo.id as number);
-      const activityMs = latest ? new Date(latest.created_at).getTime() : 0;
-      const id = String(convo.id);
-      return {
-        id,
-        name: projectName || directorName || `Conversation ${id}`,
-        projectName: projectName || undefined,
-        lastMessage: latest?.content ?? (latest ? "Attachment" : ""),
-        timestamp: latest
-          ? new Date(latest.created_at).toLocaleString(undefined, {
-              month: "short",
-              day: "numeric",
-              hour: "2-digit",
-              minute: "2-digit",
-            })
-          : "",
-        unread: activityMs > 0 && activityMs > (readMap[id] ?? 0),
-        lastActivity: activityMs,
-      };
-    });
-
-    setConversations(result);
-    setLoading(false);
-  }, [projectIds]);
+  }, [profileId]);
 
   useEffect(() => {
     loadConversations();
   }, [loadConversations]);
 
-  // Prefetch up to 100 most-recently-active conversations into IDB so
-  // switching to them feels instant (no skeleton). Batched 5 at a time to
-  // avoid opening 100 simultaneous Supabase connections.
+  // Prefetch up to 100 most-recently-active conversations into IDB.
   useEffect(() => {
     if (conversations.length === 0) return;
-    const sorted = [...conversations].sort((a, b) => (b.lastActivity ?? 0) - (a.lastActivity ?? 0));
+    const sorted = [...conversations].sort(
+      (a, b) => (b.lastActivity ?? 0) - (a.lastActivity ?? 0),
+    );
     const toWarm = sorted.slice(0, 100).map((c) => c.id);
-
     (async () => {
       for (let i = 0; i < toWarm.length; i += 5) {
         await Promise.all(toWarm.slice(i, i + 5).map((id) => prefetchConv(id)));
@@ -172,9 +80,7 @@ export function MemberMessages({ projectIds }: MemberMessagesProps) {
     })();
   }, [conversations]);
 
-  // When a conversation becomes the active route, persistently clear its
-  // unread in local state (not just visually suppress) — otherwise the
-  // green tick reappears the moment you navigate to another conversation.
+  // Clear unread on the active conversation persistently.
   useEffect(() => {
     const m = pathname?.match(/\/messages\/(\d+)/);
     const activeId = m ? m[1] : null;
@@ -197,14 +103,12 @@ export function MemberMessages({ projectIds }: MemberMessagesProps) {
     return () => setTabUnreadCount(0);
   }, [conversations, pathname]);
 
-  // Realtime: keep the list live when a message arrives (no reload).
-  // Unfiltered postgres_changes does not deliver here, so subscribe with a
-  // per-conversation filter (mirrors the proven thread pattern). Members
-  // have no resolvable profile id, so any inbound message is treated as
-  // unread unless its conversation is the open one. Members span multiple
-  // project ids (cannot filter conversations by IN), so brand-new
-  // conversations for members require a reload (acceptable edge).
-  const convoIdsKey = conversations.map((c) => c.id).sort().join(",");
+  // Realtime: live updates per conversation + a participant-insert listener for
+  // conversations I'm newly added to.
+  const convoIdsKey = conversations
+    .map((c) => c.id)
+    .sort()
+    .join(",");
   useEffect(() => {
     const supabase = createClient();
     const ids = convoIdsKey ? convoIdsKey.split(",") : [];
@@ -217,6 +121,7 @@ export function MemberMessages({ projectIds }: MemberMessagesProps) {
         sender_profile_id: number | null;
       };
       const convoId = String(row.conversation_id);
+      const fromMe = profileId != null && row.sender_profile_id === profileId;
       const isActive =
         typeof window !== "undefined" &&
         window.location.pathname === `/dashboard/messages/${convoId}`;
@@ -239,7 +144,7 @@ export function MemberMessages({ projectIds }: MemberMessagesProps) {
                   minute: "2-digit",
                 }),
                 lastActivity: activityMs,
-                unread: !isActive,
+                unread: !fromMe && !isActive,
               }
             : c,
         );
@@ -249,11 +154,6 @@ export function MemberMessages({ projectIds }: MemberMessagesProps) {
       });
     };
 
-    // Supabase delivers reliably only with ONE postgres_changes binding
-    // per channel (the working thread pattern). Multiple bindings on a
-    // single channel silently drop events, so use a separate
-    // single-binding channel per conversation. Members span multiple
-    // projects, so brand-new conversations still need a reload.
     const channels = ids.map((id) => {
       const ch = supabase.channel(`messages:list:member:msg:${id}`);
       ch.on(
@@ -270,15 +170,45 @@ export function MemberMessages({ projectIds }: MemberMessagesProps) {
       return ch;
     });
 
+    if (profileId) {
+      const convCh = supabase.channel(`messages:list:member:conv:${profileId}`);
+      convCh.on(
+        "postgres_changes",
+        {
+          event: "INSERT",
+          schema: "public",
+          table: "conversation_participants",
+          filter: `profile_id=eq.${profileId}`,
+        },
+        () => {
+          loadConversations();
+        },
+      );
+      convCh.subscribe();
+      channels.push(convCh);
+    }
+
     return () => {
       for (const ch of channels) supabase.removeChannel(ch);
     };
-  }, [convoIdsKey, loadConversations]);
+  }, [convoIdsKey, loadConversations, profileId]);
 
   return (
     <div className="flex flex-col min-h-0 h-full w-full">
       <div className="flex items-center justify-between px-4 py-4 shrink-0">
         <h2 className="text-lg font-light text-white">Messages</h2>
+        <button
+          type="button"
+          onClick={() => setOpen(true)}
+          className="group flex items-center justify-center p-1 rounded transition-colors cursor-pointer focus:outline-none"
+          aria-label="New conversation"
+        >
+          <MessageSquarePlus
+            size={18}
+            strokeWidth={1.5}
+            className="text-sbi-muted group-hover:text-sbi-green transition-colors"
+          />
+        </button>
       </div>
 
       <ConversationList
@@ -288,6 +218,14 @@ export function MemberMessages({ projectIds }: MemberMessagesProps) {
         errored={errored}
         onRetry={loadConversations}
         onPrefetch={prefetchConv}
+      />
+
+      <CreateConversationModal
+        opened={open}
+        onClose={() => setOpen(false)}
+        onConversationCreated={(convo) =>
+          setConversations((prev) => [convo, ...prev])
+        }
       />
     </div>
   );

--- a/frontend/components/dashboard/messages/MessageThread.tsx
+++ b/frontend/components/dashboard/messages/MessageThread.tsx
@@ -87,7 +87,10 @@ interface UnfurlData {
 interface ThreadMessage {
   id: number;
   text: string | null;
-  senderRole: "client" | "director";
+  senderRole: "client" | "director" | "member";
+  /** Sender's profile id. Ownership ("is this mine") is by identity, not role,
+   *  so same-role and group threads render correctly. */
+  senderProfileId?: number | null;
   createdAt: string;
   editedAt?: string | null;
   replyToId?: number | null;
@@ -576,7 +579,11 @@ function PinnedStrip({ pinnedMessages, onJump }: PinnedStripProps) {
               />
               <div className="min-w-0">
                 <div className="text-[10px] uppercase tracking-[0.04em] text-sbi-muted-dark mb-0.5">
-                  {m.senderRole === "director" ? "Director" : "Client"}
+                  {m.senderRole === "director"
+                    ? "Director"
+                    : m.senderRole === "member"
+                      ? "Member"
+                      : "Client"}
                 </div>
                 <div className="text-[11px] text-white truncate">
                   {m.text || "(attachment)"}
@@ -627,7 +634,7 @@ function PermissionPrompt({ onEnable, onDismiss }: PermissionPromptProps) {
 
 interface MessageThreadProps {
   conversationId?: string | null;
-  senderRole?: "client" | "director";
+  senderRole?: "client" | "director" | "member";
   readOnly?: boolean;
   basePath?: string;
   /** Conversations array to feed into Cmd+K switcher (optional). */
@@ -793,7 +800,7 @@ export function MessageThread({
     const { data, error } = await supabase
       .from("messages")
       .select(
-        "id, content, sender_role, created_at, edited_at, reply_to_id, is_pinned, pinned_at, message_attachments(id, path, name, mime_type, meta, sort_index), message_unfurls(url, title, description, image_url, site_name)",
+        "id, content, sender_role, sender_profile_id, created_at, edited_at, reply_to_id, is_pinned, pinned_at, message_attachments(id, path, name, mime_type, meta, sort_index), message_unfurls(url, title, description, image_url, site_name)",
       )
       .eq("conversation_id", Number(conversationId))
       .lt("created_at", oldestCreatedAt.current)
@@ -858,7 +865,9 @@ export function MessageThread({
       return {
         id: row.id,
         text: row.content ?? null,
-        senderRole: (row.sender_role as "client" | "director") ?? "client",
+        senderRole:
+          (row.sender_role as "client" | "director" | "member") ?? "client",
+        senderProfileId: (row.sender_profile_id as number | null) ?? null,
         createdAt: (row.created_at as string) ?? new Date().toISOString(),
         editedAt:
           ((row as Record<string, unknown>).edited_at as string | null) ?? null,
@@ -926,7 +935,7 @@ export function MessageThread({
       supabase
         .from("messages")
         .select(
-          "id, content, sender_role, created_at, edited_at, reply_to_id, is_pinned, pinned_at, message_attachments(id, path, name, mime_type, meta, sort_index), message_unfurls(url, title, description, image_url, site_name)",
+          "id, content, sender_role, sender_profile_id, created_at, edited_at, reply_to_id, is_pinned, pinned_at, message_attachments(id, path, name, mime_type, meta, sort_index), message_unfurls(url, title, description, image_url, site_name)",
         )
         .eq("conversation_id", Number(conversationId))
         .order("created_at", { ascending: false })
@@ -1008,7 +1017,9 @@ export function MessageThread({
       return {
         id: row.id,
         text: row.content ?? null,
-        senderRole: (row.sender_role as "client" | "director") ?? "client",
+        senderRole:
+          (row.sender_role as "client" | "director" | "member") ?? "client",
+        senderProfileId: (row.sender_profile_id as number | null) ?? null,
         createdAt: (row.created_at as string) ?? new Date().toISOString(),
         editedAt:
           ((row as Record<string, unknown>).edited_at as string | null) ?? null,
@@ -1063,7 +1074,7 @@ export function MessageThread({
       newDividerBeforeId.current = null;
       const firstUnseenPeer = mapped.find(
         (m) =>
-          m.senderRole !== senderRole &&
+          m.senderProfileId !== senderProfileId &&
           new Date(m.createdAt).getTime() > lastReadMs,
       );
       newDividerBeforeId.current = firstUnseenPeer?.id ?? null;
@@ -1133,6 +1144,7 @@ export function MessageThread({
             id: number;
             content: string | null;
             sender_role: string;
+            sender_profile_id: number | null;
             created_at: string;
             edited_at: string | null;
             reply_to_id: number | null;
@@ -1142,7 +1154,9 @@ export function MessageThread({
           const newMsg: ThreadMessage = {
             id: row.id,
             text: row.content ?? null,
-            senderRole: (row.sender_role as "client" | "director") ?? "client",
+            senderRole:
+              (row.sender_role as "client" | "director" | "member") ?? "client",
+            senderProfileId: (row.sender_profile_id as number | null) ?? null,
             createdAt: (row.created_at as string) ?? new Date().toISOString(),
             editedAt: row.edited_at ?? null,
             replyToId: row.reply_to_id ?? null,
@@ -1167,7 +1181,7 @@ export function MessageThread({
           if (
             typeof document !== "undefined" &&
             document.hidden &&
-            newMsg.senderRole !== senderRole &&
+            newMsg.senderProfileId !== senderProfileId &&
             getNotificationPermission() === "granted"
           ) {
             notifyNewMessage({
@@ -1342,9 +1356,8 @@ export function MessageThread({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [conversationId]);
 
-  // ---- Fetch sender profile id once ----
+  // ---- Fetch the viewer's profile id once (drives message ownership) ----
   useEffect(() => {
-    if (readOnly) return;
     const supabase = createClient();
     supabase.auth.getUser().then(({ data: { user } }) => {
       if (!user) return;
@@ -1357,7 +1370,7 @@ export function MessageThread({
           if (data?.id != null) setSenderProfileId(data.id as number);
         });
     });
-  }, [readOnly]);
+  }, []);
 
   // ---- Presence channel (typing indicator) ----
   useEffect(() => {
@@ -1699,7 +1712,11 @@ export function MessageThread({
     supabase: ReturnType<typeof createClient>,
     text: string | null,
     replyToId?: number | null,
-  ): Promise<{ id: number; uid: string } | null> {
+  ): Promise<{
+    id: number;
+    uid: string;
+    senderProfileId: number | null;
+  } | null> {
     const {
       data: { user },
       error: userError,
@@ -1726,7 +1743,11 @@ export function MessageThread({
       .single();
 
     if (error || !data?.id) return null;
-    return { id: data.id, uid: user.id };
+    return {
+      id: data.id,
+      uid: user.id,
+      senderProfileId: (senderProfile?.id as number | null) ?? null,
+    };
   }
 
   function triggerUnfurl(text: string, messageId: number) {
@@ -1764,12 +1785,25 @@ export function MessageThread({
       return;
     }
 
+    // Backfill the viewer's profile id if the mount-time fetch hadn't landed yet,
+    // so message ownership is correct without waiting for a reload.
+    if (senderProfileId === null && result.senderProfileId !== null) {
+      setSenderProfileId(result.senderProfileId);
+    }
+
     setMessages((prev) => {
       const withoutEcho = prev.filter(
         (m) => m.id === localId || m.id !== result.id,
       );
       return withoutEcho.map((m) =>
-        m.id === localId ? { ...m, id: result.id, status: "sent" } : m,
+        m.id === localId
+          ? {
+              ...m,
+              id: result.id,
+              status: "sent",
+              senderProfileId: result.senderProfileId,
+            }
+          : m,
       );
     });
 
@@ -1826,6 +1860,10 @@ export function MessageThread({
         prev.map((m) => (m.id === localId ? { ...m, status: "failed" } : m)),
       );
       return;
+    }
+
+    if (senderProfileId === null && msgResult.senderProfileId !== null) {
+      setSenderProfileId(msgResult.senderProfileId);
     }
 
     const realMsgId = msgResult.id;
@@ -1915,6 +1953,7 @@ export function MessageThread({
           id: realMsgId,
           attachments: updatedAttachments,
           status: "sent" as const,
+          senderProfileId: msgResult.senderProfileId,
         };
       });
     });
@@ -1973,6 +2012,7 @@ export function MessageThread({
           id: localId,
           text: hasText ? query : null,
           senderRole,
+          senderProfileId,
           createdAt: new Date().toISOString(),
           replyToId: replySnapshot?.id ?? null,
           attachments: optimisticAttachments,
@@ -2256,7 +2296,8 @@ export function MessageThread({
     let found: number | null = null;
     for (const m of messages) {
       if (
-        m.senderRole === senderRole &&
+        m.senderProfileId != null &&
+        m.senderProfileId === senderProfileId &&
         m.status === "sent" &&
         new Date(m.createdAt).getTime() <= otherLastReadAt
       ) {
@@ -2270,7 +2311,8 @@ export function MessageThread({
 
   const renderMessage = useCallback(
     (msg: ThreadMessage, idx: number) => {
-      const isMine = msg.senderRole === senderRole;
+      const isMine =
+        msg.senderProfileId != null && msg.senderProfileId === senderProfileId;
       const isEditing = msg.id === editingMessageId;
       const isHovered = msg.id === hoveredMessageId;
       const isHighlighted = msg.id === highlightedMsgId;
@@ -2283,7 +2325,7 @@ export function MessageThread({
         msg.id === newDividerBeforeId.current;
       const isGroupStart =
         !prev ||
-        prev.senderRole !== msg.senderRole ||
+        prev.senderProfileId !== msg.senderProfileId ||
         showDayHeader ||
         showNewDivider ||
         new Date(msg.createdAt).getTime() - new Date(prev.createdAt).getTime() >
@@ -2460,7 +2502,7 @@ export function MessageThread({
                     <span className="text-[10px] text-sbi-muted-dark font-medium shrink-0">
                       {replyDeleted
                         ? ""
-                        : repliedToMessage?.senderRole === senderRole
+                        : repliedToMessage?.senderProfileId === senderProfileId
                           ? "You:"
                           : "Them:"}
                     </span>
@@ -2802,7 +2844,7 @@ export function MessageThread({
               <div className="flex-1 min-w-0">
                 <div className="text-[10px] uppercase tracking-[0.04em] text-sbi-green font-medium mb-0.5">
                   Replying to{" "}
-                  {replyingTo.senderRole === senderRole
+                  {replyingTo.senderProfileId === senderProfileId
                     ? "yourself"
                     : "the other party"}
                 </div>

--- a/frontend/components/dashboard/messages/index.tsx
+++ b/frontend/components/dashboard/messages/index.tsx
@@ -230,7 +230,11 @@ export function Messages() {
         opened={open}
         onClose={() => setOpen(false)}
         onConversationCreated={(convo) =>
-          setConversations((prev) => [convo, ...prev])
+          setConversations((prev) =>
+            // The create RPC dedupes, so "starting" a chat that already exists
+            // returns the existing id — don't add a second list entry for it.
+            prev.some((c) => c.id === convo.id) ? prev : [convo, ...prev],
+          )
         }
       />
     </div>

--- a/frontend/components/dashboard/messages/index.tsx
+++ b/frontend/components/dashboard/messages/index.tsx
@@ -1,17 +1,17 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
-import { usePathname } from "next/navigation";
 import { MessageSquarePlus } from "lucide-react";
-import { ConversationList, type Conversation } from "./ConversationList";
-import { CreateConversationModal } from "./CreateConversationModal";
-import { useCreateConversationModal } from "./CreateConversationModalContext";
-import { fetchReadMap } from "./read-state";
-import { createClient } from "@/lib/supabase/client";
-import { useProject } from "@/lib/project/project-context";
+import { usePathname } from "next/navigation";
+import { useCallback, useEffect, useState } from "react";
 import { prefetchConv } from "@/lib/messages/prefetch";
 import { setTabUnreadCount } from "@/lib/messages/tab-title";
+import { useProject } from "@/lib/project/project-context";
+import { createClient } from "@/lib/supabase/client";
+import { type Conversation, ConversationList } from "./ConversationList";
+import { CreateConversationModal } from "./CreateConversationModal";
+import { useCreateConversationModal } from "./CreateConversationModalContext";
 import { useCmdK } from "./cmdk/CommandPalette";
+import { loadActorConversations } from "./load-conversations";
 
 /** Client-side conversation list. Click navigates to /messages/[id]. */
 export function Messages() {
@@ -33,7 +33,7 @@ export function Messages() {
     if (cmdK && conversations.length > 0) {
       cmdK.setConversations(conversations);
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [conversations]);
 
   const context = useCreateConversationModal();
@@ -43,112 +43,16 @@ export function Messages() {
 
   const loadConversations = useCallback(async () => {
     if (!user) return;
-
     setLoading(true);
     setErrored(false);
-
-    const supabase = createClient();
-
-    const { data: convos, error: convoError } = await supabase
-      .from("conversations")
-      .select("id, director_profile_id, project_id")
-      .eq("client_profile_id", user.id)
-      .order("created_at", { ascending: false });
-
-    if (convoError) {
+    try {
+      const supabase = createClient();
+      setConversations(await loadActorConversations(supabase, user.id));
+    } catch {
       setErrored(true);
+    } finally {
       setLoading(false);
-      return;
     }
-
-    if (!convos || convos.length === 0) {
-      setConversations([]);
-      setLoading(false);
-      return;
-    }
-
-    // Batch-fetch director names from profiles
-    const directorProfileIds = [...new Set(convos.map((c) => c.director_profile_id).filter(Boolean))] as number[];
-    const directorMap = new Map<number, string>();
-
-    if (directorProfileIds.length > 0) {
-      const { data: profiles } = await supabase
-        .from("profiles")
-        .select("id, name")
-        .in("id", directorProfileIds);
-
-      if (profiles) {
-        for (const p of profiles) {
-          directorMap.set(p.id, p.name ?? "");
-        }
-      }
-    }
-
-    // Batch-fetch project names
-    const projectIds = [...new Set(convos.map((c) => c.project_id).filter(Boolean))] as number[];
-    const projectMap = new Map<number, string>();
-    if (projectIds.length > 0) {
-      const { data: projectsData } = await supabase
-        .from("projects")
-        .select("id, company_name")
-        .in("id", projectIds);
-      if (projectsData) {
-        for (const p of projectsData) {
-          projectMap.set(p.id, p.company_name ?? "");
-        }
-      }
-    }
-
-    // Fetch latest message per conversation (parallel, limit 1 each)
-    const convoIds = convos.map((c) => c.id);
-    const latestMessageMap = new Map<number, { content: string; created_at: string }>();
-
-    await Promise.all(convoIds.map(async (cid) => {
-      const { data: latest } = await supabase
-        .from("messages")
-        .select("content, created_at")
-        .eq("conversation_id", cid)
-        .order("created_at", { ascending: false })
-        .limit(1)
-        .maybeSingle();
-
-      if (latest) {
-        latestMessageMap.set(cid as number, {
-          content: latest.content ?? "",
-          created_at: latest.created_at as string,
-        });
-      }
-    }));
-
-    const readMap = await fetchReadMap();
-
-    const result: Conversation[] = convos.map((convo) => {
-      // Resolve peer name; fall back to project/company, never "Director"/ID.
-      const directorName = directorMap.get(convo.director_profile_id as number);
-      const projectName = convo.project_id ? projectMap.get(convo.project_id as number) : undefined;
-      const latest = latestMessageMap.get(convo.id as number);
-      const activityMs = latest ? new Date(latest.created_at).getTime() : 0;
-      const id = String(convo.id);
-      return {
-        id,
-        name: directorName || projectName || `Conversation ${id}`,
-        projectName: projectName || undefined,
-        lastMessage: latest?.content ?? (latest ? "Attachment" : ""),
-        timestamp: latest
-          ? new Date(latest.created_at).toLocaleString(undefined, {
-              month: "short",
-              day: "numeric",
-              hour: "2-digit",
-              minute: "2-digit",
-            })
-          : "",
-        unread: activityMs > 0 && activityMs > (readMap[id] ?? 0),
-        lastActivity: activityMs,
-      };
-    });
-
-    setConversations(result);
-    setLoading(false);
   }, [user]);
 
   useEffect(() => {
@@ -160,7 +64,9 @@ export function Messages() {
   // avoid opening 100 simultaneous Supabase connections.
   useEffect(() => {
     if (conversations.length === 0) return;
-    const sorted = [...conversations].sort((a, b) => (b.lastActivity ?? 0) - (a.lastActivity ?? 0));
+    const sorted = [...conversations].sort(
+      (a, b) => (b.lastActivity ?? 0) - (a.lastActivity ?? 0),
+    );
     const toWarm = sorted.slice(0, 100).map((c) => c.id);
 
     (async () => {
@@ -199,7 +105,10 @@ export function Messages() {
   // Unfiltered postgres_changes does not deliver here, so subscribe with a
   // per-conversation filter (mirrors the proven thread pattern) plus a
   // filtered conversations-insert listener for brand-new conversations.
-  const convoIdsKey = conversations.map((c) => c.id).sort().join(",");
+  const convoIdsKey = conversations
+    .map((c) => c.id)
+    .sort()
+    .join(",");
   useEffect(() => {
     const supabase = createClient();
     const ids = convoIdsKey ? convoIdsKey.split(",") : [];
@@ -267,16 +176,15 @@ export function Messages() {
     });
 
     if (user) {
-      const convCh = supabase.channel(
-        `messages:list:client:conv:${user.id}`,
-      );
+      // A new participant row for me means I was added to a conversation.
+      const convCh = supabase.channel(`messages:list:client:conv:${user.id}`);
       convCh.on(
         "postgres_changes",
         {
           event: "INSERT",
           schema: "public",
-          table: "conversations",
-          filter: `client_profile_id=eq.${user.id}`,
+          table: "conversation_participants",
+          filter: `profile_id=eq.${user.id}`,
         },
         () => {
           loadConversations();
@@ -321,7 +229,6 @@ export function Messages() {
       <CreateConversationModal
         opened={open}
         onClose={() => setOpen(false)}
-        mode="client"
         onConversationCreated={(convo) =>
           setConversations((prev) => [convo, ...prev])
         }

--- a/frontend/components/dashboard/messages/load-conversations.ts
+++ b/frontend/components/dashboard/messages/load-conversations.ts
@@ -1,0 +1,172 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Conversation } from "./ConversationList";
+import { fetchReadMap } from "./read-state";
+
+/**
+ * Participant-based conversation loader shared by every role's inbox.
+ *
+ * Replaces the old per-role queries that filtered conversations by
+ * client_profile_id / director_profile_id (which only ever surfaced
+ * director<->client threads). A conversation is now a set of
+ * conversation_participants, so a single query — "the conversations I'm a
+ * participant of" — covers client, director, member, internal, and group
+ * threads uniformly. Display name is derived from the OTHER participants
+ * (1:1 -> the peer's name; group -> "A, B +N"), falling back to the project
+ * company name, then a neutral label (never a role word or raw id).
+ */
+export async function loadActorConversations(
+  supabase: SupabaseClient,
+  myProfileId: number,
+): Promise<Conversation[]> {
+  // 1. The conversation ids I belong to.
+  const { data: myParts, error } = await supabase
+    .from("conversation_participants")
+    .select("conversation_id")
+    .eq("profile_id", myProfileId);
+  if (error) throw new Error(error.message);
+
+  const convoIds = [
+    ...new Set((myParts ?? []).map((r) => r.conversation_id as number)),
+  ];
+  if (convoIds.length === 0) return [];
+
+  // 2. Those conversations + 3. all their participants, in parallel.
+  const [{ data: convos }, { data: parts }] = await Promise.all([
+    supabase
+      .from("conversations")
+      .select("id, project_id, created_at")
+      .in("id", convoIds),
+    supabase
+      .from("conversation_participants")
+      .select("conversation_id, profile_id")
+      .in("conversation_id", convoIds),
+  ]);
+
+  // Peer profile ids (everyone but me) and project ids to resolve.
+  const peerIds = [
+    ...new Set(
+      (parts ?? [])
+        .map((p) => p.profile_id as number)
+        .filter((id) => id !== myProfileId),
+    ),
+  ];
+  const projectIds = [
+    ...new Set(
+      (convos ?? []).map((c) => c.project_id as number | null).filter(Boolean),
+    ),
+  ] as number[];
+
+  const [nameMap, projectMap] = await Promise.all([
+    resolveNames(supabase, peerIds),
+    resolveProjects(supabase, projectIds),
+  ]);
+
+  // Group peers per conversation (stable order by profile id).
+  const peersByConvo = new Map<number, number[]>();
+  for (const p of parts ?? []) {
+    const cid = p.conversation_id as number;
+    const pid = p.profile_id as number;
+    if (pid === myProfileId) continue;
+    const arr = peersByConvo.get(cid) ?? [];
+    arr.push(pid);
+    peersByConvo.set(cid, arr);
+  }
+
+  // 4. Latest message per conversation (parallel, limit 1 each).
+  const latestMessageMap = new Map<
+    number,
+    { content: string; created_at: string }
+  >();
+  await Promise.all(
+    convoIds.map(async (cid) => {
+      const { data: latest } = await supabase
+        .from("messages")
+        .select("content, created_at")
+        .eq("conversation_id", cid)
+        .order("created_at", { ascending: false })
+        .limit(1)
+        .maybeSingle();
+      if (latest) {
+        latestMessageMap.set(cid, {
+          content: (latest.content as string) ?? "",
+          created_at: latest.created_at as string,
+        });
+      }
+    }),
+  );
+
+  const readMap = await fetchReadMap();
+
+  return (convos ?? []).map((convo) => {
+    const cid = convo.id as number;
+    const id = String(cid);
+    const peers = (peersByConvo.get(cid) ?? [])
+      .sort((a, b) => a - b)
+      .map((pid) => nameMap.get(pid))
+      .filter((n): n is string => Boolean(n));
+    const projectName = convo.project_id
+      ? projectMap.get(convo.project_id as number)
+      : undefined;
+
+    let name: string;
+    if (peers.length === 0) {
+      name = projectName || `Conversation ${id}`;
+    } else if (peers.length <= 2) {
+      name = peers.join(", ");
+    } else {
+      name = `${peers[0]}, ${peers[1]} +${peers.length - 2}`;
+    }
+
+    const latest = latestMessageMap.get(cid);
+    const activityMs = latest ? new Date(latest.created_at).getTime() : 0;
+
+    return {
+      id,
+      name,
+      projectName: projectName || undefined,
+      lastMessage: latest?.content ?? (latest ? "Attachment" : ""),
+      timestamp: latest
+        ? new Date(latest.created_at).toLocaleString(undefined, {
+            month: "short",
+            day: "numeric",
+            hour: "2-digit",
+            minute: "2-digit",
+          })
+        : "",
+      unread: activityMs > 0 && activityMs > (readMap[id] ?? 0),
+      lastActivity: activityMs,
+    };
+  });
+}
+
+async function resolveNames(
+  supabase: SupabaseClient,
+  ids: number[],
+): Promise<Map<number, string>> {
+  const map = new Map<number, string>();
+  if (ids.length === 0) return map;
+  const { data } = await supabase
+    .from("profiles")
+    .select("id, name")
+    .in("id", ids);
+  for (const p of data ?? []) {
+    map.set(p.id as number, (p.name as string) ?? "");
+  }
+  return map;
+}
+
+async function resolveProjects(
+  supabase: SupabaseClient,
+  ids: number[],
+): Promise<Map<number, string>> {
+  const map = new Map<number, string>();
+  if (ids.length === 0) return map;
+  const { data } = await supabase
+    .from("projects")
+    .select("id, company_name")
+    .in("id", ids);
+  for (const p of data ?? []) {
+    map.set(p.id as number, (p.company_name as string) ?? "");
+  }
+  return map;
+}

--- a/frontend/components/dashboard/messages/load-conversations.ts
+++ b/frontend/components/dashboard/messages/load-conversations.ts
@@ -30,8 +30,11 @@ export async function loadActorConversations(
   ];
   if (convoIds.length === 0) return [];
 
-  // 2. Those conversations + 3. all their participants, in parallel.
-  const [{ data: convos }, { data: parts }] = await Promise.all([
+  // 2. Those conversations + 3. all their participants, in parallel. Surface a
+  // real query error (RLS denial, network) instead of silently rendering an
+  // empty inbox — RLS filtering returns fewer rows with NO error, so a populated
+  // `error` is a genuine failure the caller should show.
+  const [convoRes, partsRes] = await Promise.all([
     supabase
       .from("conversations")
       .select("id, project_id, created_at")
@@ -41,6 +44,10 @@ export async function loadActorConversations(
       .select("conversation_id, profile_id")
       .in("conversation_id", convoIds),
   ]);
+  if (convoRes.error) throw new Error(convoRes.error.message);
+  if (partsRes.error) throw new Error(partsRes.error.message);
+  const convos = convoRes.data;
+  const parts = partsRes.data;
 
   // Peer profile ids (everyone but me) and project ids to resolve.
   const peerIds = [
@@ -72,28 +79,27 @@ export async function loadActorConversations(
     peersByConvo.set(cid, arr);
   }
 
-  // 4. Latest message per conversation (parallel, limit 1 each).
+  // 4. Latest message per conversation — one set-based RPC (DISTINCT ON) instead
+  // of N parallel single-row queries.
   const latestMessageMap = new Map<
     number,
     { content: string; created_at: string }
   >();
-  await Promise.all(
-    convoIds.map(async (cid) => {
-      const { data: latest } = await supabase
-        .from("messages")
-        .select("content, created_at")
-        .eq("conversation_id", cid)
-        .order("created_at", { ascending: false })
-        .limit(1)
-        .maybeSingle();
-      if (latest) {
-        latestMessageMap.set(cid, {
-          content: (latest.content as string) ?? "",
-          created_at: latest.created_at as string,
-        });
-      }
-    }),
+  const { data: latestRows, error: latestErr } = await supabase.rpc(
+    "latest_conversation_messages",
+    { _ids: convoIds },
   );
+  if (latestErr) throw new Error(latestErr.message);
+  for (const row of (latestRows ?? []) as Array<{
+    conversation_id: number;
+    content: string | null;
+    created_at: string;
+  }>) {
+    latestMessageMap.set(row.conversation_id, {
+      content: row.content ?? "",
+      created_at: row.created_at,
+    });
+  }
 
   const readMap = await fetchReadMap();
 
@@ -145,12 +151,15 @@ async function resolveNames(
 ): Promise<Map<number, string>> {
   const map = new Map<number, string>();
   if (ids.length === 0) return map;
-  const { data } = await supabase
-    .from("profiles")
-    .select("id, name")
-    .in("id", ids);
-  for (const p of data ?? []) {
-    map.set(p.id as number, (p.name as string) ?? "");
+  // Resolve peer names through a SECURITY DEFINER RPC that returns only (id,
+  // name) for co-participants — direct SELECT on profiles is no longer granted to
+  // co-participants (it leaked email/eid/discord_id of everyone in a thread).
+  const { data, error } = await supabase.rpc("get_conversation_peer_names", {
+    _ids: ids,
+  });
+  if (error) throw new Error(error.message);
+  for (const p of (data ?? []) as Array<{ id: number; name: string | null }>) {
+    map.set(p.id, p.name ?? "");
   }
   return map;
 }
@@ -161,10 +170,11 @@ async function resolveProjects(
 ): Promise<Map<number, string>> {
   const map = new Map<number, string>();
   if (ids.length === 0) return map;
-  const { data } = await supabase
+  const { data, error } = await supabase
     .from("projects")
     .select("id, company_name")
     .in("id", ids);
+  if (error) throw new Error(error.message);
   for (const p of data ?? []) {
     map.set(p.id as number, (p.company_name as string) ?? "");
   }

--- a/frontend/lib/messages/conv-types.ts
+++ b/frontend/lib/messages/conv-types.ts
@@ -30,7 +30,8 @@ export interface CachedAttachment {
 export interface CachedMessage {
   id: number;
   text: string | null;
-  senderRole: "client" | "director";
+  senderRole: "client" | "director" | "member";
+  senderProfileId?: number | null;
   createdAt: string;
   editedAt?: string | null;
   replyToId?: number | null;

--- a/frontend/lib/messages/prefetch.ts
+++ b/frontend/lib/messages/prefetch.ts
@@ -3,10 +3,15 @@
  * instant. No-ops if a fresh snapshot (< 30s old) already exists.
  */
 
-import { createClient } from "@/lib/supabase/client";
-import { getCachedConv, setCachedConv, type CachedMessage, type CachedAttachment } from "./conv-cache";
-import { signWithCache } from "./attachment-cache";
 import { fetchLastRead } from "@/components/dashboard/messages/read-state";
+import { createClient } from "@/lib/supabase/client";
+import { signWithCache } from "./attachment-cache";
+import {
+  type CachedAttachment,
+  type CachedMessage,
+  getCachedConv,
+  setCachedConv,
+} from "./conv-cache";
 
 const FRESH_THRESHOLD_MS = 30 * 1000; // 30 seconds
 
@@ -22,7 +27,7 @@ export async function prefetchConv(convId: string): Promise<void> {
     supabase
       .from("messages")
       .select(
-        "id, content, sender_role, created_at, edited_at, reply_to_id, is_pinned, pinned_at, message_attachments(id, path, name, mime_type, meta, sort_index), message_unfurls(url, title, description, image_url, site_name)",
+        "id, content, sender_role, sender_profile_id, created_at, edited_at, reply_to_id, is_pinned, pinned_at, message_attachments(id, path, name, mime_type, meta, sort_index), message_unfurls(url, title, description, image_url, site_name)",
       )
       .eq("conversation_id", Number(convId))
       .order("created_at", { ascending: true }),
@@ -37,15 +42,27 @@ export async function prefetchConv(convId: string): Promise<void> {
       : [];
     const attachments: CachedAttachment[] = rawAttachments
       .slice()
-      .sort((a: { sort_index: number }, b: { sort_index: number }) => a.sort_index - b.sort_index)
-      .map((a: { id: number; path: string; name: string; mime_type: string | null; meta: unknown; sort_index: number }) => ({
-        id: a.id,
-        path: a.path,
-        name: a.name,
-        mimeType: a.mime_type,
-        meta: (a.meta as CachedAttachment["meta"]) ?? null,
-        signedUrl: null,
-      }));
+      .sort(
+        (a: { sort_index: number }, b: { sort_index: number }) =>
+          a.sort_index - b.sort_index,
+      )
+      .map(
+        (a: {
+          id: number;
+          path: string;
+          name: string;
+          mime_type: string | null;
+          meta: unknown;
+          sort_index: number;
+        }) => ({
+          id: a.id,
+          path: a.path,
+          name: a.name,
+          mimeType: a.mime_type,
+          meta: (a.meta as CachedAttachment["meta"]) ?? null,
+          signedUrl: null,
+        }),
+      );
     // 1:1 join — PostgREST returns object|null, not an array. Handle both.
     type RawUnfurl = {
       url: string;
@@ -65,14 +82,19 @@ export async function prefetchConv(convId: string): Promise<void> {
     return {
       id: row.id,
       text: row.content ?? null,
-      senderRole: (row.sender_role as "client" | "director") ?? "client",
+      senderRole:
+        (row.sender_role as "client" | "director" | "member") ?? "client",
+      senderProfileId: (row.sender_profile_id as number | null) ?? null,
       createdAt: (row.created_at as string) ?? new Date().toISOString(),
-      editedAt: (row as Record<string, unknown>).edited_at as string | null ?? null,
-      replyToId: (row as Record<string, unknown>).reply_to_id as number | null ?? null,
+      editedAt:
+        ((row as Record<string, unknown>).edited_at as string | null) ?? null,
+      replyToId:
+        ((row as Record<string, unknown>).reply_to_id as number | null) ?? null,
       attachments,
       status: "sent" as const,
       isPinned: Boolean((row as Record<string, unknown>).is_pinned),
-      pinnedAt: ((row as Record<string, unknown>).pinned_at as string | null) ?? null,
+      pinnedAt:
+        ((row as Record<string, unknown>).pinned_at as string | null) ?? null,
       unfurl: firstUnfurl ?? null,
     };
   });
@@ -86,7 +108,10 @@ export async function prefetchConv(convId: string): Promise<void> {
   }
 
   if (allPaths.length > 0) {
-    const urlMap = await signWithCache(supabase, allPaths, { width: 560, quality: 75 });
+    const urlMap = await signWithCache(supabase, allPaths, {
+      width: 560,
+      quality: 75,
+    });
     for (const m of mapped) {
       for (const a of m.attachments) {
         if (a.path && urlMap.has(a.path)) {
@@ -99,8 +124,7 @@ export async function prefetchConv(convId: string): Promise<void> {
   // Compute divider: first unseen peer message after last read.
   // We don't know the senderRole here, so we skip it (divider computed properly
   // in loadMessages when the thread actually opens).
-  const newDividerBeforeId =
-    getCachedConv(convId)?.newDividerBeforeId ?? null;
+  const newDividerBeforeId = getCachedConv(convId)?.newDividerBeforeId ?? null;
 
   setCachedConv(convId, {
     messages: mapped,

--- a/supabase/migrations/20260614000000_conversation_participants.sql
+++ b/supabase/migrations/20260614000000_conversation_participants.sql
@@ -1,0 +1,69 @@
+-- ===========================================================================
+-- Messaging, phase 1: generalized conversation participants (ADDITIVE).
+--
+-- Today a conversation is a rigid (client_profile_id, director_profile_id,
+-- project_id) triple, so only director<->client threads can exist. To support
+-- the full messaging matrix (director<->director, member<->member,
+-- director<->member, ...) and group conversations, a conversation becomes a set
+-- of participants via this join table.
+--
+-- This migration is deliberately ADDITIVE and changes NO existing behavior:
+--   * the conversations.client_profile_id / director_profile_id columns and ALL
+--     current RLS on conversations/messages are left intact;
+--   * conversation_participants is populated for existing threads but not yet
+--     read by any policy or app code.
+-- Participant-based visibility and the role-pair creation matrix land in a
+-- later migration, together with the UI, so live messaging is never broken
+-- mid-build.
+--
+-- project_id becomes nullable here so internal (director/member) DMs can exist
+-- without being filed under a client project.
+-- ===========================================================================
+
+CREATE TABLE IF NOT EXISTS public.conversation_participants (
+  conversation_id bigint NOT NULL
+    REFERENCES public.conversations(id) ON DELETE CASCADE,
+  profile_id bigint NOT NULL
+    REFERENCES public.profiles(id) ON DELETE CASCADE,
+  role_at_join text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (conversation_id, profile_id)
+);
+
+CREATE INDEX IF NOT EXISTS conversation_participants_profile_id_idx
+  ON public.conversation_participants (profile_id);
+
+-- Internal DMs are not tied to a client project.
+ALTER TABLE public.conversations ALTER COLUMN project_id DROP NOT NULL;
+
+-- Backfill: each existing thread's client + director become participants.
+INSERT INTO public.conversation_participants (conversation_id, profile_id, role_at_join)
+SELECT c.id, c.client_profile_id, 'client'
+FROM public.conversations c
+WHERE c.client_profile_id IS NOT NULL
+ON CONFLICT DO NOTHING;
+
+INSERT INTO public.conversation_participants (conversation_id, profile_id, role_at_join)
+SELECT c.id, c.director_profile_id, 'director'
+FROM public.conversations c
+WHERE c.director_profile_id IS NOT NULL
+ON CONFLICT DO NOTHING;
+
+-- RLS: enable, with a TRANSITIONAL read policy — you can see participant rows of
+-- a conversation you can already see via the current client/director columns.
+-- (Full participant-based read/write policies replace this with the UI.)
+ALTER TABLE public.conversation_participants ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "View participants of visible conversations" ON public.conversation_participants;
+CREATE POLICY "View participants of visible conversations" ON public.conversation_participants
+  FOR SELECT TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.conversations c
+      WHERE c.id = conversation_participants.conversation_id
+        AND (
+          c.client_profile_id = public.user_profile_id(auth.uid())
+          OR c.director_profile_id = public.user_profile_id(auth.uid())
+        )
+    )
+  );

--- a/supabase/migrations/20260614000001_messaging_create_rpc.sql
+++ b/supabase/migrations/20260614000001_messaging_create_rpc.sql
@@ -19,6 +19,7 @@ CREATE OR REPLACE FUNCTION public.can_message(_from_role text, _to_role text)
 RETURNS boolean
 LANGUAGE sql
 IMMUTABLE
+SET search_path TO ''
 AS $$
   SELECT CASE _from_role
     WHEN 'director' THEN _to_role IN ('director', 'member', 'client')

--- a/supabase/migrations/20260614000001_messaging_create_rpc.sql
+++ b/supabase/migrations/20260614000001_messaging_create_rpc.sql
@@ -1,0 +1,190 @@
+-- ===========================================================================
+-- Messaging, phase 2a: matrix helpers + create_conversation RPC (ADDITIVE).
+--
+-- The role matrix and conversation creation are enforced in ONE place — a
+-- SECURITY DEFINER RPC — rather than scattered across RLS INSERT policies (which
+-- can't express "the creator's role may message each invitee's role" cleanly).
+-- This is additive: new functions only, no policy or behavior changes yet. The
+-- new CreateConversationModal calls create_conversation; the participant-based
+-- RLS rewrite that locks down direct inserts lands in phase 2b with the UI.
+--
+-- The matrix:
+--   director -> director, member, client
+--   member   -> member, director
+--   client   -> director
+-- ===========================================================================
+
+-- Directional "may <from_role> start a conversation with <to_role>?"
+CREATE OR REPLACE FUNCTION public.can_message(_from_role text, _to_role text)
+RETURNS boolean
+LANGUAGE sql
+IMMUTABLE
+AS $$
+  SELECT CASE _from_role
+    WHEN 'director' THEN _to_role IN ('director', 'member', 'client')
+    WHEN 'member'   THEN _to_role IN ('member', 'director')
+    WHEN 'client'   THEN _to_role IN ('director')
+    ELSE false
+  END;
+$$;
+
+-- Is the user (by auth uid) a participant of the conversation? SECURITY DEFINER
+-- so RLS policies can call it without recursing into conversation_participants.
+CREATE OR REPLACE FUNCTION public.is_conversation_participant(
+  _conversation_id bigint,
+  _uid uuid
+)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path TO 'pg_catalog', 'public', 'pg_temp'
+AS $$
+  SELECT EXISTS (
+    SELECT 1
+    FROM public.conversation_participants cp
+    JOIN public.profiles pr ON pr.id = cp.profile_id
+    WHERE cp.conversation_id = _conversation_id
+      AND pr.uid = _uid
+  );
+$$;
+
+-- Create (or return an existing duplicate of) a conversation with the given
+-- OTHER participants. The caller is always added. Enforces the role matrix for
+-- every invitee and the project rules:
+--   * if any participant is a client, _project_id is required and every client
+--     (and the caller) must belong to it;
+--   * otherwise it's an internal DM and project is forced NULL.
+-- Returns the conversation id. Dedupes on the exact participant set + project.
+CREATE OR REPLACE FUNCTION public.create_conversation(
+  _participant_profile_ids bigint[],
+  _project_id bigint DEFAULT NULL
+)
+RETURNS bigint
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'pg_catalog', 'public', 'pg_temp'
+AS $$
+DECLARE
+  _caller_uid uuid := auth.uid();
+  _caller_pid bigint;
+  _caller_role text;
+  _all_pids bigint[];
+  _target_pid bigint;
+  _target_role text;
+  _has_client boolean := false;
+  _existing bigint;
+  _new_conv_id bigint;
+BEGIN
+  IF _caller_uid IS NULL THEN
+    RAISE EXCEPTION 'Not authenticated';
+  END IF;
+
+  SELECT id, role::text INTO _caller_pid, _caller_role
+  FROM public.profiles WHERE uid = _caller_uid;
+  IF _caller_pid IS NULL THEN
+    RAISE EXCEPTION 'No profile for caller';
+  END IF;
+
+  -- Full, de-duplicated, sorted participant set (caller + targets).
+  SELECT array_agg(pid ORDER BY pid) INTO _all_pids
+  FROM (
+    SELECT DISTINCT pid
+    FROM (
+      SELECT _caller_pid AS pid
+      UNION
+      SELECT unnest(_participant_profile_ids)
+    ) u
+    WHERE pid IS NOT NULL
+  ) s;
+
+  IF _all_pids IS NULL OR array_length(_all_pids, 1) < 2 THEN
+    RAISE EXCEPTION 'A conversation needs at least one other participant';
+  END IF;
+
+  -- Matrix check for each non-self participant; track whether a client is in.
+  IF _caller_role = 'client' THEN
+    _has_client := true;
+  END IF;
+  FOREACH _target_pid IN ARRAY _all_pids LOOP
+    IF _target_pid = _caller_pid THEN
+      CONTINUE;
+    END IF;
+    SELECT role::text INTO _target_role FROM public.profiles WHERE id = _target_pid;
+    IF _target_role IS NULL THEN
+      RAISE EXCEPTION 'Unknown participant %', _target_pid;
+    END IF;
+    IF NOT public.can_message(_caller_role, _target_role) THEN
+      RAISE EXCEPTION 'Your role (%) may not start a conversation with a %',
+        _caller_role, _target_role;
+    END IF;
+    IF _target_role = 'client' THEN
+      _has_client := true;
+    END IF;
+  END LOOP;
+
+  -- Project rules.
+  IF _has_client THEN
+    IF _project_id IS NULL THEN
+      RAISE EXCEPTION 'A conversation that includes a client must specify a project';
+    END IF;
+    IF EXISTS (
+      SELECT 1
+      FROM unnest(_all_pids) AS pid
+      JOIN public.profiles pr ON pr.id = pid
+      WHERE pr.role::text = 'client'
+        AND NOT EXISTS (
+          SELECT 1 FROM public.project_members pm
+          WHERE pm.profile_id = pid AND pm.project_id = _project_id
+        )
+    ) THEN
+      RAISE EXCEPTION 'A client participant does not belong to the specified project';
+    END IF;
+    IF NOT EXISTS (
+      SELECT 1 FROM public.project_members pm
+      WHERE pm.profile_id = _caller_pid AND pm.project_id = _project_id
+    ) THEN
+      RAISE EXCEPTION 'You do not belong to the specified project';
+    END IF;
+  ELSE
+    _project_id := NULL;
+  END IF;
+
+  -- Dedupe: an existing conversation with the exact same participant set + project.
+  SELECT c.id INTO _existing
+  FROM public.conversations c
+  WHERE c.project_id IS NOT DISTINCT FROM _project_id
+    AND (
+      SELECT array_agg(cp.profile_id ORDER BY cp.profile_id)
+      FROM public.conversation_participants cp
+      WHERE cp.conversation_id = c.id
+    ) = _all_pids
+  LIMIT 1;
+  IF _existing IS NOT NULL THEN
+    RETURN _existing;
+  END IF;
+
+  INSERT INTO public.conversations (project_id)
+  VALUES (_project_id)
+  RETURNING id INTO _new_conv_id;
+
+  INSERT INTO public.conversation_participants (conversation_id, profile_id, role_at_join)
+  SELECT _new_conv_id, pid, (SELECT role::text FROM public.profiles WHERE id = pid)
+  FROM unnest(_all_pids) AS pid;
+
+  RETURN _new_conv_id;
+END;
+$$;
+
+-- Service-role + authenticated may create; the matrix is enforced inside.
+REVOKE EXECUTE ON FUNCTION public.create_conversation(bigint[], bigint) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.create_conversation(bigint[], bigint) FROM anon;
+GRANT EXECUTE ON FUNCTION public.create_conversation(bigint[], bigint) TO authenticated;
+
+-- Helpers are used inside policies; keep them off the anon API surface.
+REVOKE EXECUTE ON FUNCTION public.is_conversation_participant(bigint, uuid) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.is_conversation_participant(bigint, uuid) FROM anon;
+GRANT EXECUTE ON FUNCTION public.is_conversation_participant(bigint, uuid) TO authenticated;
+REVOKE EXECUTE ON FUNCTION public.can_message(text, text) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.can_message(text, text) FROM anon;
+GRANT EXECUTE ON FUNCTION public.can_message(text, text) TO authenticated;

--- a/supabase/migrations/20260614000002_messaging_participant_rls.sql
+++ b/supabase/migrations/20260614000002_messaging_participant_rls.sql
@@ -1,0 +1,46 @@
+-- ===========================================================================
+-- Messaging, phase 2b: participant-based RLS (replaces client/director gating).
+--
+-- APPLY WITH THE UI, NOT BEFORE: this changes conversation/message visibility
+-- and locks conversation creation to the create_conversation RPC, so the old
+-- (client/director) create flow stops working the moment this lands. The new
+-- CreateConversationModal (which calls the RPC) ships in the same change.
+--
+-- conversation_reads stays as-is (its policies are already own-row, so they work
+-- for any participant). Conversations are created only via the SECURITY DEFINER
+-- public.create_conversation (which bypasses RLS and enforces the role matrix),
+-- so there is intentionally no INSERT policy on conversations.
+-- ===========================================================================
+
+-- conversations: a participant can read; no direct insert (RPC only).
+DROP POLICY IF EXISTS "Users can view their own conversations" ON public.conversations;
+DROP POLICY IF EXISTS "Participants can view conversations" ON public.conversations;
+CREATE POLICY "Participants can view conversations" ON public.conversations
+  FOR SELECT TO authenticated
+  USING (public.is_conversation_participant(id, auth.uid()));
+
+DROP POLICY IF EXISTS "Users can create their own conversations" ON public.conversations;
+
+-- messages: participants read and send; senders still edit their own (unchanged).
+DROP POLICY IF EXISTS "Users can view messages in their conversations" ON public.messages;
+DROP POLICY IF EXISTS "Participants can view messages" ON public.messages;
+CREATE POLICY "Participants can view messages" ON public.messages
+  FOR SELECT TO authenticated
+  USING (public.is_conversation_participant(conversation_id, auth.uid()));
+
+DROP POLICY IF EXISTS "Users can send messages in their conversations" ON public.messages;
+DROP POLICY IF EXISTS "Participants can send messages" ON public.messages;
+CREATE POLICY "Participants can send messages" ON public.messages
+  FOR INSERT TO authenticated
+  WITH CHECK (
+    sender_uid = auth.uid()
+    AND public.is_conversation_participant(conversation_id, auth.uid())
+  );
+
+-- conversation_participants: a participant can see the roster (replaces the
+-- transitional policy from phase 1). Inserts happen only via the RPC.
+DROP POLICY IF EXISTS "View participants of visible conversations" ON public.conversation_participants;
+DROP POLICY IF EXISTS "Participants can view co-participants" ON public.conversation_participants;
+CREATE POLICY "Participants can view co-participants" ON public.conversation_participants
+  FOR SELECT TO authenticated
+  USING (public.is_conversation_participant(conversation_id, auth.uid()));

--- a/supabase/migrations/20260614000003_messaging_directory.sql
+++ b/supabase/migrations/20260614000003_messaging_directory.sql
@@ -1,0 +1,92 @@
+-- ===========================================================================
+-- Messaging, phase 2c: directory reads for the matrix.
+--
+-- profiles SELECT was restricted to "own profile" (directors excepted), so
+-- members/clients could not read the NAME of anyone they message — breaking
+-- both the conversation peer-name display and the recipient picker. Two pieces:
+--
+--   1. A co-participant profiles SELECT policy so you can read the profiles of
+--      people you share a conversation with (peer names in the inbox/thread).
+--   2. list_messageable_profiles(): a SECURITY DEFINER RPC returning exactly the
+--      people the caller may start a conversation with (matrix + project rules),
+--      so the picker doesn't need broad profiles/project_members read access.
+-- ===========================================================================
+
+DROP POLICY IF EXISTS "View co-participant profiles" ON public.profiles;
+CREATE POLICY "View co-participant profiles" ON public.profiles
+  FOR SELECT TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.conversation_participants cp_me
+      JOIN public.conversation_participants cp_them
+        ON cp_them.conversation_id = cp_me.conversation_id
+      WHERE cp_me.profile_id = public.user_profile_id(auth.uid())
+        AND cp_them.profile_id = profiles.id
+    )
+  );
+
+CREATE OR REPLACE FUNCTION public.list_messageable_profiles()
+RETURNS TABLE(
+  profile_id bigint,
+  name text,
+  role text,
+  project_id bigint,
+  project_name text
+)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path TO 'pg_catalog', 'public', 'pg_temp'
+AS $$
+DECLARE
+  _caller_pid bigint;
+  _caller_role text;
+BEGIN
+  -- Alias the table: the OUT columns (name, role, project_id) shadow the
+  -- profiles columns, so unqualified references would be ambiguous.
+  SELECT p.id, p.role::text INTO _caller_pid, _caller_role
+  FROM public.profiles p WHERE p.uid = auth.uid();
+  IF _caller_pid IS NULL THEN
+    RETURN;
+  END IF;
+
+  IF _caller_role = 'client' THEN
+    -- Clients may message the directors on their own projects.
+    RETURN QUERY
+      SELECT DISTINCT pr.id, pr.name, pr.role::text, NULL::bigint, NULL::text
+      FROM public.project_members pm_me
+      JOIN public.project_members pm_dir ON pm_dir.project_id = pm_me.project_id
+      JOIN public.profiles pr ON pr.id = pm_dir.profile_id
+      WHERE pm_me.profile_id = _caller_pid
+        AND pr.role::text = 'director'
+        AND pr.id <> _caller_pid;
+    RETURN;
+  END IF;
+
+  -- Directors/members: any internal staff the matrix permits.
+  RETURN QUERY
+    SELECT pr.id, pr.name, pr.role::text, NULL::bigint, NULL::text
+    FROM public.profiles pr
+    WHERE pr.id <> _caller_pid
+      AND pr.role::text IN ('director', 'member')
+      AND public.can_message(_caller_role, pr.role::text);
+
+  -- Directors may also message the clients (owners) of their projects.
+  IF _caller_role = 'director' THEN
+    RETURN QUERY
+      SELECT DISTINCT pr.id, pr.name, pr.role::text, p.id, p.company_name
+      FROM public.project_members pm_me
+      JOIN public.project_members pm_cl
+        ON pm_cl.project_id = pm_me.project_id AND pm_cl.role = 'owner'
+      JOIN public.profiles pr ON pr.id = pm_cl.profile_id
+      JOIN public.projects p ON p.id = pm_cl.project_id
+      WHERE pm_me.profile_id = _caller_pid
+        AND pr.id <> _caller_pid;
+  END IF;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.list_messageable_profiles() FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.list_messageable_profiles() FROM anon;
+GRANT EXECUTE ON FUNCTION public.list_messageable_profiles() TO authenticated;

--- a/supabase/migrations/20260614000004_messaging_review_fixes.sql
+++ b/supabase/migrations/20260614000004_messaging_review_fixes.sql
@@ -1,0 +1,90 @@
+-- ===========================================================================
+-- Messaging review fixes (PR #72): privacy lock-down, latest-message perf,
+-- and realtime for participant inserts.
+--
+-- 1. PRIVACY: the phase-2c "View co-participant profiles" policy granted a SELECT
+--    on the WHOLE profiles row to anyone you share a conversation with — exposing
+--    email, eid, discord_id, department, etc. to every member of a group thread.
+--    Postgres RLS can't restrict columns, so the fix is to drop that broad policy
+--    and expose ONLY (id, name) of your co-participants through a SECURITY DEFINER
+--    RPC. The inbox loader (load-conversations.ts) is the sole consumer; the
+--    thread component only ever reads the viewer's OWN profile (uid = auth.uid()).
+--
+-- 2. PERF: the inbox loaded the latest message per conversation with one query
+--    each (N round-trips). Replace with a single set-based RPC.
+--
+-- 3. REALTIME: conversation_participants was never added to the supabase_realtime
+--    publication, so the "I was added to a conversation" listener never fired.
+-- ===========================================================================
+
+-- 1. Privacy ---------------------------------------------------------------
+
+DROP POLICY IF EXISTS "View co-participant profiles" ON public.profiles;
+
+-- Return only (id, name) for the given profile ids, and only for profiles the
+-- caller actually shares a conversation with. Definer rights let it read profiles
+-- without re-granting broad table access; the co-participant EXISTS check is the
+-- security boundary (a caller can't harvest names for arbitrary ids).
+CREATE OR REPLACE FUNCTION public.get_conversation_peer_names(_ids bigint[])
+RETURNS TABLE(id bigint, name text)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path TO 'pg_catalog', 'public', 'pg_temp'
+AS $$
+  SELECT DISTINCT pr.id, pr.name
+  FROM public.profiles pr
+  WHERE pr.id = ANY(_ids)
+    AND EXISTS (
+      SELECT 1
+      FROM public.conversation_participants cp_me
+      JOIN public.conversation_participants cp_them
+        ON cp_them.conversation_id = cp_me.conversation_id
+      JOIN public.profiles me ON me.id = cp_me.profile_id
+      WHERE me.uid = auth.uid()
+        AND cp_them.profile_id = pr.id
+    );
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.get_conversation_peer_names(bigint[]) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.get_conversation_peer_names(bigint[]) FROM anon;
+GRANT EXECUTE ON FUNCTION public.get_conversation_peer_names(bigint[]) TO authenticated;
+
+-- 2. Latest-message perf ---------------------------------------------------
+
+-- One row per conversation: the most recent message. SECURITY INVOKER so the
+-- caller's "Participants can view messages" RLS still applies (you only get the
+-- latest message of conversations you belong to).
+CREATE OR REPLACE FUNCTION public.latest_conversation_messages(_ids bigint[])
+RETURNS TABLE(conversation_id bigint, content text, created_at timestamptz)
+LANGUAGE sql
+STABLE
+SET search_path TO 'pg_catalog', 'public', 'pg_temp'
+AS $$
+  SELECT DISTINCT ON (m.conversation_id)
+    m.conversation_id, m.content, m.created_at
+  FROM public.messages m
+  WHERE m.conversation_id = ANY(_ids)
+  ORDER BY m.conversation_id, m.created_at DESC;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.latest_conversation_messages(bigint[]) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.latest_conversation_messages(bigint[]) FROM anon;
+GRANT EXECUTE ON FUNCTION public.latest_conversation_messages(bigint[]) TO authenticated;
+
+-- 3. Realtime for participant inserts --------------------------------------
+
+-- profile_id is part of the primary key, so the default replica identity already
+-- carries it for the equality filter the client subscribes with.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_publication_tables
+    WHERE pubname = 'supabase_realtime'
+      AND schemaname = 'public'
+      AND tablename = 'conversation_participants'
+  ) THEN
+    ALTER PUBLICATION supabase_realtime
+      ADD TABLE public.conversation_participants;
+  END IF;
+END $$;


### PR DESCRIPTION
## Summary

Replaces the rigid director↔client-only messaging model with a **role-matrix, participant-based** model that supports director/member/client edges and **group conversations**. Verified end-to-end on the dev server across all three roles.

**The matrix:**
```
director → directors, members, clients
member   → members, directors
client   → directors
```
Internal (director/member) conversations are global DMs; any conversation including a client is scoped to that client's project.

## How it works
- **`conversation_participants`** join table (a conversation is now a set of participants); `conversations.project_id` is nullable for internal DMs. Existing threads backfilled.
- **`create_conversation(participant_ids[], project_id)`** — SECURITY DEFINER RPC enforcing the matrix + project rules for every invitee, deduping the exact participant set, creating atomically.
- **Participant-based RLS** on conversations/messages/participants (creation is RPC-only).
- **`list_messageable_profiles()`** — SECURITY DEFINER RPC backing the recipient picker (returns exactly who the caller may message), plus a co-participant `profiles` read policy so peer names resolve.
- **Identity-based thread ownership** — `MessageThread` now decides "is this mine" by `sender_profile_id`, not `sender_role`, so same-role and group threads render correctly. Members can send.

## Frontend
- `CreateConversationModal` → matrix-filtered, multi-select recipient picker (groups supported) calling the RPC.
- One shared participant-based inbox loader for every role; peer/group display names.
- `MessageThread`/cache carry `senderProfileId`; optimistic sends render on the correct side immediately.

## Migrations (applied to `sbi`)
- `…000000_conversation_participants` — table + backfill + nullable project_id
- `…000001_messaging_create_rpc` — matrix + create_conversation RPC
- `…000002_messaging_participant_rls` — participant RLS
- `…000003_messaging_directory` — co-participant profiles read + list_messageable_profiles

## ⚠️ Deploy coupling
Phase 2b RLS removes the old direct-insert create path, so **this branch's frontend must deploy with these migrations** — the previously-deployed app's "new conversation" breaks under the new RLS (reading existing threads is unaffected).

## Verified on dev server (Playwright, all 3 roles)
Picker matrix (director→all incl. clients w/ projects; member→members/directors; client→directors), create via RPC, participant-scoped visibility, member send, peer-name resolution, and **identity ownership confirmed bidirectional** (a message is right-aligned for its sender, left for everyone else; optimistic send correct immediately). `bun build` green; `tsc` clean; `get_advisors` clean of new issues.

## Follow-ups
- Regenerate `lib/supabase/database.types.ts` (stale; the new RPCs use loose `.rpc()` typing).
- Test accounts left some test threads in the `sbi` DB (director@/member@/client@utsbi.org).
