### PR TITLE
feat(explore): project-locked chats + project context in the system prompt

### DIFF
--- a/backend/app/explore/agents/graph.py
+++ b/backend/app/explore/agents/graph.py
@@ -48,6 +48,8 @@ async def run_graph_streaming(
     from app.explore.agents.prompts import AGENT_SYSTEM_PROMPT
     from app.explore.agents.tools import TOOLS, execute_tool
     from app.explore.core.config import settings
+    from app.explore.db.supabase import user_client
+    from app.explore.services.membership import get_project_context
 
     history = history or []
     attachments = attachments or []
@@ -64,6 +66,21 @@ async def run_graph_streaming(
     messages: List[Dict[str, Any]] = [
         {"role": "system", "content": AGENT_SYSTEM_PROMPT}
     ]
+
+    # When the request carries an active project, inject an authoritative
+    # project-context block right after the static prompt so the model knows
+    # which project it's in (and can answer "what project am I in?"). This is
+    # best-effort: a lookup failure must never block the turn.
+    if project_id is not None:
+        try:
+            project_context = await get_project_context(
+                user_client(access_token), client_id, project_id
+            )
+            if project_context:
+                messages.append({"role": "system", "content": project_context})
+        except Exception:
+            logger.exception("Project-context injection failed; continuing without it")
+
     for msg in history[-10:]:
         role = msg.get("role", "user")
         content = msg.get("content", "")

--- a/backend/app/explore/agents/tools.py
+++ b/backend/app/explore/agents/tools.py
@@ -209,7 +209,7 @@ TOOLS: List[Dict[str, Any]] = [
 # --- Tool implementations ----------------------------------------------------
 
 async def _search_documents(
-    query: str, project_ids: List[int], client_id: str
+    query: str, project_ids: List[int], client_id: str, strict: bool = False
 ) -> Tuple[str, List[Dict[str, Any]]]:
     """Run RAG retrieval scoped to the caller's project(s); return
     (context_text, sources) for citations.
@@ -217,12 +217,16 @@ async def _search_documents(
     Document search still runs uid-only when the caller has no active project
     membership, so a user with zero memberships can reach their own legacy
     (NULL-project) uploads rather than getting a hard "no project" wall.
+
+    When ``strict`` is True (a specific project is active), retrieval is locked
+    to the active project alone — the caller's legacy NULL-project uploads are
+    excluded so another scope's documents can't leak into a project chat.
     """
     if not query or not query.strip():
         return "No search query was provided.", []
 
     docs = await rag_service.retrieve_relevant(
-        query=query, project_ids=project_ids, client_id=client_id
+        query=query, project_ids=project_ids, client_id=client_id, strict=strict
     )
     if not docs:
         return (
@@ -680,7 +684,13 @@ async def execute_tool(
             query = str(args.get("query", "")) if args else ""
             db = user_client(access_token)
             project_ids = await _scoped_project_ids(db, client_id, project_id)
-            return await _search_documents(query, project_ids, client_id)
+            # A specific active project means STRICT scoping: only that project's
+            # documents, never the caller's legacy NULL-project uploads. Inferred
+            # from the actual project_id (not the list, which is single-element
+            # for a no-project user with exactly one membership too).
+            return await _search_documents(
+                query, project_ids, client_id, strict=project_id is not None
+            )
         if name == "search_sbi_knowledge":
             query = str(args.get("query", "")) if args else ""
             return _search_sbi_knowledge(query)

--- a/backend/app/explore/services/membership.py
+++ b/backend/app/explore/services/membership.py
@@ -18,6 +18,68 @@ from typing import List, Optional
 from supabase import Client
 
 
+async def get_project_context(
+    db: Client, client_id: str, project_id: int
+) -> Optional[str]:
+    """Return a short, authoritative project-context block for the system prompt.
+
+    Resolves the active project's name and the caller's role on it, using the
+    same ``profiles.uid -> profiles.id -> project_members`` lookup the rest of
+    this module uses, so a caller can only ever see context for a project they
+    actually belong to. Returns ``None`` when the caller is not a member of
+    ``project_id`` (or the project can't be resolved), so nothing is injected.
+    """
+    if not client_id or not client_id.strip():
+        return None
+
+    def _query() -> Optional[str]:
+        profile = (
+            db.table("profiles")
+            .select("id")
+            .eq("uid", client_id)
+            .limit(1)
+            .execute()
+        )
+        if not profile.data:
+            return None
+        profile_id = profile.data[0]["id"]
+
+        member = (
+            db.table("project_members")
+            .select("role")
+            .eq("profile_id", profile_id)
+            .eq("project_id", project_id)
+            .limit(1)
+            .execute()
+        )
+        if not member.data:
+            return None
+        role = member.data[0].get("role") or "member"
+
+        project = (
+            db.table("projects")
+            .select("company_name")
+            .eq("id", project_id)
+            .limit(1)
+            .execute()
+        )
+        if not project.data:
+            return None
+        company_name = project.data[0].get("company_name") or f"Project {project_id}"
+
+        return (
+            "Current project context (authoritative — the project the user is "
+            "working in right now):\n"
+            f"- Project: {company_name} (project #{project_id})\n"
+            f"- The user's role on this project: {role}\n"
+            "When the user asks which project they're in, answer with the "
+            "project name above. All tool calls are already scoped to this "
+            "project."
+        )
+
+    return await asyncio.to_thread(_query)
+
+
 async def caller_project_ids(db: Client, client_id: str) -> List[int]:
     """Resolve the project ids the caller is a member of. Empty list if none.
 

--- a/backend/app/explore/services/rag_service.py
+++ b/backend/app/explore/services/rag_service.py
@@ -242,7 +242,8 @@ class RAGService:
 
     async def retrieve_relevant(self, query: str, project_ids: List[int],
         client_id: Optional[str] = None,
-        top_n: Optional[int] = None) -> List[Dict[str, Any]]:
+        top_n: Optional[int] = None,
+        strict: bool = False) -> List[Dict[str, Any]]:
         """Retrieve the most relevant documents for a query (two-stage).
 
         Scoped to ``project_ids`` (the caller's membership-verified active
@@ -251,18 +252,24 @@ class RAGService:
         ``rerank_candidates`` candidates. Stage 2: the reranker re-scores them
         and keeps the top ``top_n``.
 
+        When ``strict`` is True (a specific project is active), ``client_id`` is
+        dropped from the scope so ONLY documents belonging to the active project
+        are returned — the caller's legacy NULL-project uploads are NOT mixed in,
+        preventing cross-scope document leakage.
+
         This is the entry point chat turns should use; the returned list is the
         single source of truth for both the prompt context and the citation
         sources, keeping the model's ``[n]`` markers aligned with the rendered
         source chips.
         """
-        if not project_ids and not client_id:
+        effective_client_id = None if strict else client_id
+        if not project_ids and not effective_client_id:
             return []
         keep = top_n if top_n is not None else settings.rerank_top_n
         candidates = await self.hybrid_search(
             query=query,
             project_ids=project_ids,
-            client_id=client_id,
+            client_id=effective_client_id,
             limit=settings.rerank_candidates,
         )
         if not candidates:

--- a/frontend/app/api/chat/route.ts
+++ b/frontend/app/api/chat/route.ts
@@ -70,16 +70,23 @@ export async function POST(request: NextRequest) {
   // Other keys in the session's metadata jsonb are carried forward on every
   // active_leaf_id write so we never clobber them (read once here, not per write).
   let sessionMetadata: Record<string, unknown> = {};
+  // A chat's project is FIXED at creation. For an existing session we forward the
+  // STORED project_id (not the client's current header value), so switching the
+  // active project mid-chat — or reopening an old chat under a different project —
+  // can never silently re-scope the conversation and mix another project's data.
+  let sessionProjectId: number | null = null;
   if (sessionId !== null) {
     const { data: existing } = await supabase
       .from("client_chat_sessions")
-      .select("id, metadata")
+      .select("id, metadata, project_id")
       .eq("id", sessionId)
       .maybeSingle();
     if (!existing) return jsonError(404, "Session not found or not owned");
     if (existing.metadata && typeof existing.metadata === "object") {
       sessionMetadata = existing.metadata as Record<string, unknown>;
     }
+    sessionProjectId =
+      typeof existing.project_id === "number" ? existing.project_id : null;
   } else {
     isNewSession = true;
     // Honor a client-minted uuid so the URL is known before the first response.
@@ -103,6 +110,7 @@ export async function POST(request: NextRequest) {
       body.project_id > 0
     ) {
       insertRow.project_id = body.project_id;
+      sessionProjectId = body.project_id;
     }
     const { data: newSession, error: sessionErr } = await supabase
       .from("client_chat_sessions")
@@ -256,7 +264,8 @@ export async function POST(request: NextRequest) {
       attachments: body.attachments ?? [],
       include_sources: body.include_sources ?? true,
       model_preference: modelPreference,
-      project_id: body.project_id ?? null,
+      // Authoritative: the session's own project, not the live header.
+      project_id: sessionProjectId,
     }),
     signal: request.signal,
   });

--- a/frontend/components/dashboard/common/app-sidebar.tsx
+++ b/frontend/components/dashboard/common/app-sidebar.tsx
@@ -353,7 +353,14 @@ export function AppSidebar() {
         <div className="absolute bottom-0 right-0 w-4 h-4 border-b border-r border-sbi-green/20" />
 
         {/* Header */}
-        <div className="h-16 flex items-center border-b border-sbi-dark-border/30 px-3">
+        <div
+          className={cn(
+            "h-16 flex items-center border-b border-sbi-dark-border/30",
+            // Collapsed rail: center the logo so it lines up with the centered
+            // nav icons below it (expanded: left-aligned with the brand text).
+            isCollapsed ? "justify-center px-0" : "px-3",
+          )}
+        >
           <button
             type="button"
             onClick={handleLogoClick}

--- a/frontend/components/dashboard/explore/ui/ChatHistoryNav.tsx
+++ b/frontend/components/dashboard/explore/ui/ChatHistoryNav.tsx
@@ -21,6 +21,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { type SessionSummary, useChat } from "@/lib/chat/chat-context";
+import { useProject } from "@/lib/project/project-context";
 import { cn } from "@/lib/utils";
 
 // Date buckets, in display order. Sessions arrive already sorted by updated_at desc.
@@ -107,6 +108,8 @@ export function ChatHistoryNav({ focusSearchRef }: ChatHistoryNavProps = {}) {
     deleteSession,
     sessionId,
   } = useChat();
+  const { activeProject } = useProject();
+  const activeProjectId = activeProject?.projectId ?? null;
 
   const [query, setQuery] = useState("");
 
@@ -177,13 +180,18 @@ export function ChatHistoryNav({ focusSearchRef }: ChatHistoryNavProps = {}) {
     }
   };
 
-  const { pinnedSessions, grouped } = useMemo(() => {
+  const { pinnedSessions, grouped, projectCount } = useMemo(() => {
+    // Project-locked sidebar: show the active project's chats, plus untagged
+    // (legacy / project-less) chats so nothing silently disappears. Other
+    // projects' chats are hidden here — the dedicated /dashboard/chats page
+    // remains the unfiltered "all chats" view.
+    const base = sessionList.filter(
+      (s) => s.project_id === activeProjectId || s.project_id == null,
+    );
     const q = query.trim().toLowerCase();
     const filtered = q
-      ? sessionList.filter((s) =>
-          (s.title || "Untitled").toLowerCase().includes(q),
-        )
-      : sessionList;
+      ? base.filter((s) => (s.title || "Untitled").toLowerCase().includes(q))
+      : base;
     const pinnedList = filtered.filter((s) => s.pinned);
     const rest = filtered.filter((s) => !s.pinned);
     const map = new Map<Bucket, SessionSummary[]>();
@@ -196,11 +204,15 @@ export function ChatHistoryNav({ focusSearchRef }: ChatHistoryNavProps = {}) {
     const groups = BUCKET_ORDER.map(
       (b) => [b, map.get(b) ?? []] as const,
     ).filter(([, arr]) => arr.length > 0);
-    return { pinnedSessions: pinnedList, grouped: groups };
-  }, [sessionList, query]);
+    return {
+      pinnedSessions: pinnedList,
+      grouped: groups,
+      projectCount: base.length,
+    };
+  }, [sessionList, query, activeProjectId]);
 
   const loading = !sessionsLoaded;
-  const hasAny = sessionList.length > 0;
+  const hasAny = projectCount > 0;
   const noMatches =
     hasAny && pinnedSessions.length === 0 && grouped.length === 0;
 


### PR DESCRIPTION
## Problem
The Explore AI chat only half-knew its project. `project_id` was sent per-request and tagged on new sessions, but:
1. **Nothing told the model which project it was in** — `AGENT_SYSTEM_PROMPT` had zero project data, so "what project am I in?" was unanswerable (it guessed).
2. **The per-turn `project_id` came from the live header**, not the session — so switching projects mid-chat (or reopening an old chat) could silently re-scope the conversation.
3. **`search_documents` OR'd in the caller's legacy NULL-project uploads** regardless of the active project, leaking docs across scopes.

Net effect (from the report): the assistant couldn't say which project it was in, and cited a $20k budget / 'research papers + syllabus' that didn't match the active 'SBI Test Inc' project.

## Decision
Per discussion: **project-locked chats** + inject **name + key facts** into the prompt.

## Changes
**Backend (FastAPI — must be redeployed to take effect):**
- `graph.py` + `services/membership.py`: when a project is active, inject an authoritative *Current project context* system message (project name + the caller's role), **membership-verified** (only a project you belong to) and **fail-open** (a lookup error never blocks the turn). Budget left to `get_finance_summary` to avoid a heavy per-turn query + prompt drift.
- `rag_service.py` + `tools.py`: `search_documents` runs **strict** when a project is active — drops the `_filter_uid` OR so only the active project's documents are returned. No legacy cross-scope leakage. (No RPC SQL changed.)

**Frontend:**
- `app/api/chat/route.ts`: a chat's project is now **authoritative from the session's stored `project_id`** (forwarded to the backend), not the client's current header — switching projects or reopening an old chat can't re-scope it.
- `ChatHistoryNav`: the Explore sidebar is **filtered to the active project** (untagged/legacy chats stay visible so nothing disappears; other projects' chats are hidden). `/dashboard/chats` remains the unfiltered all-chats view.
- `app-sidebar.tsx`: **center the logo** in the collapsed icon rail so it lines up with the nav icons below (the reported misalignment).

## Verification
- Frontend production build passes; Biome clean. Backend `py_compile` clean (no backend test framework in repo).

## Notes / possible follow-ups
- **Backend redeploy required** for the injection + strict scoping (frontend proxies to `BACKEND_URL`).
- Optional: clear the open chat when you switch projects (today an off-project chat stays open but is correctly scoped to its own project — no data mixing, just a list/visible-thread mismatch). Left out to avoid discarding an in-progress chat on an accidental switch.
- Optional: backfill legacy NULL-project sessions/docs to a project, or add a 'General' space, if you later want stricter separation.