### PR TITLE
perf(explore) + feat(files): faster chat + Document Portal auto-indexes into RAG

### DIFF
--- a/backend/app/explore/agents/graph.py
+++ b/backend/app/explore/agents/graph.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import logging
 from typing import Any, AsyncGenerator, Dict, List, Optional
@@ -21,22 +22,27 @@ async def run_graph_streaming(
     """Run the Explore agent tool-calling loop, yielding SSE events.
 
     Flow:
-      1. On the first turn (empty ``history``) emit a ``title`` event.
-      2. Emit ``phase: thinking``, then run a NON-streaming tool-decision loop
-         (max ``MAX_TOOL_ITERATIONS``) using ``FAST_MODEL`` with ``tools`` and
-         ``tool_choice="auto"``. Each requested tool is executed via
-         ``execute_tool``; ``search_documents`` results contribute citation
-         sources.
-      3. Emit ``phase: generating`` and produce the FINAL answer as a STREAMING
-         completion WITHOUT tools, yielding ``delta`` events per token. On
-         thinking-model turns the model's reasoning tokens stream first as
-         ``reasoning`` events (best-effort; fast models emit none).
+      1. On the first turn (empty ``history``) kick off title generation as a
+         background task so it overlaps the first model call instead of adding a
+         full round-trip of dead air before any token; the ``title`` event is
+         emitted as soon as it's ready.
+      2. Emit ``phase: thinking``, then run a SINGLE STREAMING tool-calling loop
+         (max ``MAX_TOOL_ITERATIONS``) with ``tools`` and ``tool_choice="auto"``.
+         ``delta.content`` streams as ``delta`` events and ``delta.reasoning`` as
+         ``reasoning`` events AS THEY ARRIVE. If a chunk yields tool calls, emit
+         ``phase: searching`` once, execute each via ``execute_tool`` (
+         ``search_documents`` results contribute citation sources), append the
+         results, and loop again — the next iteration is ALSO streamed. A no-tool
+         query therefore starts streaming on the FIRST model call.
+      3. Emit ``phase: generating`` before the answer-only iteration so the UI
+         can flip out of "searching"; the final answer streamed in that same
+         iteration carries [n] citations against the accumulated tool results.
       4. Emit a single ``result`` event with the full answer and sources.
 
-    The SSE contract (title / phase / delta / result) is preserved exactly; a
-    ``reasoning`` event is additive and carries ephemeral thinking tokens that
-    are shown live but never persisted. The endpoint owns the ``session`` event,
-    so it is never emitted here.
+    The SSE contract (title / phase / reasoning / delta / result) is preserved
+    exactly; a ``reasoning`` event is additive and carries ephemeral thinking
+    tokens that are shown live but never persisted. The endpoint owns the
+    ``session`` event, so it is never emitted here.
     """
     # Imported lazily to keep import-time side effects (OpenAI client creation)
     # out of module import and mirror the previous graph.py structure.
@@ -54,10 +60,30 @@ async def run_graph_streaming(
     history = history or []
     attachments = attachments or []
 
-    # First turn: best-effort conversation title (never blocks the turn).
+    # First turn: start best-effort title generation as a background task so it
+    # overlaps the first model call instead of serializing a full round-trip
+    # ahead of it. ``generate_title`` already falls back internally, so the task
+    # never raises. The ``title`` event is flushed (below) the moment it's ready.
+    title_task: Optional["asyncio.Task[str]"] = None
     if not history:
-        title = await generate_title(query)
-        yield {"type": "title", "title": title}
+        title_task = asyncio.create_task(generate_title(query))
+
+    async def _drain_title() -> Optional[Dict[str, Any]]:
+        """Return a ``title`` event if the background title is ready, else None.
+
+        Non-blocking: only resolves the task once it has completed so emitting
+        the title never stalls the token stream.
+        """
+        if title_task is None or not title_task.done():
+            return None
+        try:
+            title = title_task.result()
+        except Exception:
+            # generate_title swallows its own errors, but guard regardless so a
+            # title failure can never crash the turn.
+            logger.exception("Title task failed; skipping title event")
+            return None
+        return {"type": "title", "title": title}
 
     yield {"type": "phase", "phase": "thinking"}
 
@@ -90,54 +116,149 @@ async def run_graph_streaming(
 
     collected_sources: List[Dict[str, Any]] = []
     searched_emitted = False
+    generating_emitted = False
+    sources_msg_index: Optional[int] = None
+    title_emitted = title_task is None
 
-    # --- Tool-decision loop (non-streaming) ---------------------------------
+    model = settings.think_model if model_preference == "thinking" else settings.fast_model
+
+    answer_parts: List[str] = []
+
+    # --- Single streaming tool-calling loop ---------------------------------
+    # Each iteration streams the model's output AS IT ARRIVES. If the model
+    # requests tools we run them and loop again (also streamed); the iteration
+    # that yields no tool calls IS the final answer — there is no separate,
+    # serialized generation call. A simple query thus streams on call #1.
     for iteration in range(MAX_TOOL_ITERATIONS):
+        # Dedupe sources while preserving order so [n] indices stay stable, then
+        # (re)attach the numbered "Available Sources" system message so the model
+        # can cite project facts with [n] markers in the streamed answer. We keep
+        # a single such message and refresh it in place as sources accumulate.
+        if collected_sources:
+            deduped_sources: List[Dict[str, Any]] = []
+            seen_keys: set[str] = set()
+            for s in collected_sources:
+                key = f"{s.get('filename')}:{s.get('page_number')}"
+                if key in seen_keys:
+                    continue
+                seen_keys.add(key)
+                deduped_sources.append(s)
+            collected_sources = deduped_sources
+
+            sources_content = (
+                "Available Sources (cite project facts drawn from these using [n] "
+                "markers, matching the index below; use only these indices):\n"
+                + _format_sources_list(collected_sources)
+            )
+            if sources_msg_index is None:
+                sources_msg_index = len(messages)
+                messages.append({"role": "system", "content": sources_content})
+            else:
+                messages[sources_msg_index]["content"] = sources_content
+
+        # Accumulators for tool_calls streamed incrementally across chunks. Each
+        # entry collects an id, function name, and the concatenated argument
+        # fragments for one tool call (keyed by the streamed choice index).
+        tool_calls_acc: Dict[int, Dict[str, Any]] = {}
+
         try:
-            resp = await openrouter_client.chat.completions.create(
-                model=settings.fast_model,
+            stream = await openrouter_client.chat.completions.create(
+                model=model,
                 messages=messages,
+                stream=True,
                 tools=TOOLS,
                 tool_choice="auto",
+                extra_body={"reasoning": {"effort": "medium"}},
             )
+            async for chunk in stream:
+                if not chunk.choices:
+                    continue
+                delta = chunk.choices[0].delta
+
+                # Reasoning/thinking tokens stream BEFORE the answer. Forward
+                # them as a separate ``reasoning`` event so the UI can show
+                # "Thinking" live; they are ephemeral (not persisted) and never
+                # part of the answer.
+                reasoning = getattr(delta, "reasoning", None)
+                if reasoning:
+                    yield {"type": "reasoning", "text": reasoning}
+
+                content = delta.content
+                if content:
+                    # First answer token: flip the UI out of "thinking"/"searching"
+                    # into "generating" exactly once, on every path (a no-tool
+                    # query never runs the post-tools emission below).
+                    if not generating_emitted:
+                        yield {"type": "phase", "phase": "generating"}
+                        generating_emitted = True
+                    answer_parts.append(content)
+                    yield {"type": "delta", "text": content}
+
+                # Accumulate any tool_call fragments on this chunk. The id and
+                # name arrive once; arguments stream as concatenated fragments.
+                for tc in getattr(delta, "tool_calls", None) or []:
+                    idx = tc.index if tc.index is not None else 0
+                    slot = tool_calls_acc.setdefault(
+                        idx, {"id": None, "name": None, "arguments": ""}
+                    )
+                    if tc.id:
+                        slot["id"] = tc.id
+                    fn = getattr(tc, "function", None)
+                    if fn is not None:
+                        if fn.name:
+                            slot["name"] = fn.name
+                        if fn.arguments:
+                            slot["arguments"] += fn.arguments
+
+                # Flush the title as soon as it's ready, overlapped with the
+                # stream rather than serialized ahead of it.
+                if not title_emitted:
+                    title_event = await _drain_title()
+                    if title_event is not None:
+                        title_emitted = True
+                        yield title_event
         except Exception:
-            # A failure deciding on tools must not crash the turn; fall through
-            # to generation with whatever (if anything) we have so far.
-            logger.exception("Tool-decision call failed; proceeding to generation")
+            # A streaming failure must not crash the turn. Break out; the
+            # fallbacks below surface a graceful message if nothing streamed.
+            logger.exception("Streaming completion failed; ending tool loop")
             break
 
-        message = resp.choices[0].message
-        tool_calls = getattr(message, "tool_calls", None)
+        # Materialize accumulated tool calls in their streamed order.
+        tool_calls = [tool_calls_acc[i] for i in sorted(tool_calls_acc)]
 
         if not tool_calls:
-            # Model is ready to answer; stop deciding and stream the final answer.
+            # No tools requested: the answer already streamed in this iteration.
+            # We're done.
             break
 
-        # Record the assistant's tool-call message so the tool results attach
-        # to the right call ids.
+        # Record the assistant's tool-call message so the tool results attach to
+        # the right call ids.
         messages.append({
             "role": "assistant",
-            "content": message.content or "",
+            "content": "".join(answer_parts) if answer_parts else "",
             "tool_calls": [
                 {
-                    "id": tc.id,
+                    "id": tc["id"] or f"call_{i}",
                     "type": "function",
                     "function": {
-                        "name": tc.function.name,
-                        "arguments": tc.function.arguments or "{}",
+                        "name": tc["name"] or "",
+                        "arguments": tc["arguments"] or "{}",
                     },
                 }
-                for tc in tool_calls
+                for i, tc in enumerate(tool_calls)
             ],
         })
+        # The streamed deltas (if any) belonged to a tool-deciding turn, not the
+        # final answer; reset so they don't leak into the result.
+        answer_parts = []
 
         if not searched_emitted:
             yield {"type": "phase", "phase": "searching"}
             searched_emitted = True
 
-        for tc in tool_calls:
-            name = tc.function.name
-            raw_args = tc.function.arguments or "{}"
+        for i, tc in enumerate(tool_calls):
+            name = tc["name"] or ""
+            raw_args = tc["arguments"] or "{}"
             try:
                 args = json.loads(raw_args) if raw_args.strip() else {}
                 if not isinstance(args, dict):
@@ -153,19 +274,53 @@ async def run_graph_streaming(
 
             messages.append({
                 "role": "tool",
-                "tool_call_id": tc.id,
+                "tool_call_id": tc["id"] or f"call_{i}",
                 "content": result_text,
             })
+
+        # We ran tools; the next iteration produces the (streamed) answer with
+        # tool results in context. Flip the UI out of "searching".
+        if not generating_emitted:
+            yield {"type": "phase", "phase": "generating"}
+            generating_emitted = True
     else:
         # Loop exhausted iterations without the model settling on an answer.
         logger.info(
             f"Tool loop hit MAX_TOOL_ITERATIONS ({MAX_TOOL_ITERATIONS}); "
-            "forcing final generation"
+            "forcing a final tool-free generation"
         )
 
-    # Dedupe sources while preserving order so [n] indices stay stable.
-    deduped_sources: List[Dict[str, Any]] = []
-    seen_keys: set[str] = set()
+    # If we ran tools but never produced an answer (loop exhausted still asking
+    # for tools, or a mid-loop stream error), force one final streamed answer
+    # WITHOUT tools so a tool-happy model still answers instead of erroring out.
+    if not answer_parts and any(m.get("role") == "tool" for m in messages):
+        if not generating_emitted:
+            yield {"type": "phase", "phase": "generating"}
+            generating_emitted = True
+        try:
+            stream = await openrouter_client.chat.completions.create(
+                model=model,
+                messages=messages,
+                stream=True,
+                extra_body={"reasoning": {"effort": "medium"}},
+            )
+            async for chunk in stream:
+                if not chunk.choices:
+                    continue
+                delta = chunk.choices[0].delta
+                reasoning = getattr(delta, "reasoning", None)
+                if reasoning:
+                    yield {"type": "reasoning", "text": reasoning}
+                content = delta.content
+                if content:
+                    answer_parts.append(content)
+                    yield {"type": "delta", "text": content}
+        except Exception:
+            logger.exception("Forced final generation failed")
+
+    # Re-dedupe in case the final iteration added sources after the last refresh.
+    deduped_sources = []
+    seen_keys = set()
     for s in collected_sources:
         key = f"{s.get('filename')}:{s.get('page_number')}"
         if key in seen_keys:
@@ -174,58 +329,17 @@ async def run_graph_streaming(
         deduped_sources.append(s)
     collected_sources = deduped_sources
 
-    # If documents were cited, give the model the numbered source list so it can
-    # attach [n] markers to project facts in the final streamed answer.
-    if collected_sources:
-        messages.append({
-            "role": "system",
-            "content": (
-                "Available Sources (cite project facts drawn from these using [n] "
-                "markers, matching the index below; use only these indices):\n"
-                + _format_sources_list(collected_sources)
-            ),
-        })
-
-    # --- Final answer (streaming, no tools) ---------------------------------
-    yield {"type": "phase", "phase": "generating"}
-
-    model = settings.think_model if model_preference == "thinking" else settings.fast_model
-
-    answer_parts: List[str] = []
-    try:
-        # Request reasoning tokens. Thinking models (think_model) interleave
-        # reasoning before the answer; flash/fast models simply emit none, which
-        # is fine — reasoning is best-effort and never required. OpenRouter takes
-        # the reasoning config via extra_body.
-        stream = await openrouter_client.chat.completions.create(
-            model=model,
-            messages=messages,
-            stream=True,
-            extra_body={"reasoning": {"effort": "medium"}},
-        )
-        async for chunk in stream:
-            if not chunk.choices:
-                continue
-            delta = chunk.choices[0].delta
-            # Reasoning/thinking tokens stream BEFORE the answer. Forward them as
-            # a separate ``reasoning`` event so the UI can show "Thinking" live;
-            # they are ephemeral (not persisted) and never part of the answer.
-            reasoning = getattr(delta, "reasoning", None)
-            if reasoning:
-                yield {"type": "reasoning", "text": reasoning}
-            content = delta.content
-            if content:
-                answer_parts.append(content)
-                yield {"type": "delta", "text": content}
-    except Exception:
-        logger.exception("Final response generation failed")
-        if not answer_parts:
-            err = (
-                "I ran into a problem while generating a response. "
-                "Please try again in a moment, or rephrase your question."
-            )
-            yield {"type": "delta", "text": err}
-            answer_parts.append(err)
+    # If the title never got a chance to flush during the stream (e.g. an early
+    # break or a slow first chunk), await it now so the frontend can still name
+    # the chat. Bounded by generate_title's own internal fallback.
+    if not title_emitted and title_task is not None:
+        try:
+            title = await title_task
+        except Exception:
+            logger.exception("Title task failed; skipping title event")
+            title = None
+        if title:
+            yield {"type": "title", "title": title}
 
     full_answer = "".join(answer_parts).strip()
     if not full_answer:

--- a/backend/app/explore/api/v1/endpoints/documents.py
+++ b/backend/app/explore/api/v1/endpoints/documents.py
@@ -1,16 +1,59 @@
 from fastapi import APIRouter, UploadFile, File, Form, Depends, HTTPException
+from pydantic import BaseModel, Field
 from datetime import datetime
 import asyncio
 
 from app.explore.schemas.document import DocumentUploadResponse
-from app.explore.services.pdf_parser import PDFParser
+from app.explore.services.pdf_parser import PDFParser, extract_text, is_extractable
 from app.explore.services.rag_service import RAGService
 from app.explore.services.membership import is_project_member
 from app.explore.api.deps import AuthContext, get_auth_context, get_current_user_id
-from app.explore.db.supabase import user_client
+from app.explore.db.supabase import user_client, supabase
 
 
 router = APIRouter()
+
+# Supabase Storage bucket that backs the Document Portal "Files" UI.
+_FILES_BUCKET = "Files"
+
+
+class IndexFileRequest(BaseModel):
+    """Index (or re-index) a Document Portal file into the project's RAG corpus."""
+
+    project_id: int = Field(..., description="Project the file belongs to")
+    storage_path: str = Field(
+        ..., description="Project-relative path of the file in the 'Files' bucket"
+    )
+
+
+class ByFileRequest(BaseModel):
+    """Address a single Document Portal file by its project + storage path."""
+
+    project_id: int = Field(..., description="Project the file belongs to")
+    storage_path: str = Field(
+        ..., description="Project-relative path of the file in the 'Files' bucket"
+    )
+
+
+async def _ensure_director_member(auth: AuthContext, project_id: int) -> None:
+    """Authorize a knowledge-mutating call: director AND member of ``project_id``.
+
+    Mirrors ``/upload``: the membership check stops cross-project tagging and the
+    director gate stops any plain member from mutating the corpus. Both run under
+    the caller's RLS context; the actual writes run as the service role (no RLS),
+    so this explicit check is the only gate.
+    """
+    db = user_client(auth.access_token)
+    if not await is_project_member(db, auth.user_id, project_id):
+        raise HTTPException(
+            status_code=403,
+            detail="You are not a member of the specified project.",
+        )
+    if not await _is_director(db, auth.user_id):
+        raise HTTPException(
+            status_code=403,
+            detail="Only directors can manage knowledge documents.",
+        )
 
 
 async def _is_director(db, user_id: str) -> bool:
@@ -145,4 +188,149 @@ async def list_documents(user_id: str = Depends(get_current_user_id), limit: int
         raise HTTPException(
             status_code=500,
             detail=f"Error listing documents: {str(e)}"
+        )
+
+
+@router.post("/knowledge/index-file")
+async def index_file(
+    body: IndexFileRequest,
+    auth: AuthContext = Depends(get_auth_context),
+):
+    """Index a Document Portal file into the project's RAG corpus.
+
+    Downloads ``{project_id}/{storage_path}`` from the "Files" storage bucket via
+    the service client, extracts its text by extension, and stores the chunks
+    tagged ``source='portal'``. Binary/unsupported types are NOT errors — they
+    return ``{"indexed": false, "reason": "unsupported_type"}`` (HTTP 200).
+
+    Re-indexing a replaced file first deletes the prior ``(project_id,
+    storage_path)`` rows so chunks never duplicate. Director + membership gated.
+    """
+    await _ensure_director_member(auth, body.project_id)
+
+    if not is_extractable(body.storage_path):
+        return {"indexed": False, "reason": "unsupported_type"}
+
+    absolute_path = f"{body.project_id}/{body.storage_path}"
+
+    try:
+        file_bytes = await asyncio.to_thread(
+            supabase.storage.from_(_FILES_BUCKET).download, absolute_path
+        )
+    except Exception as e:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Could not download file from storage: {str(e)}",
+        )
+
+    try:
+        content = extract_text(file_bytes=file_bytes, filename=body.storage_path)
+        if content is None:
+            return {"indexed": False, "reason": "unsupported_type"}
+        if not content.strip():
+            return {"indexed": False, "reason": "empty"}
+
+        # Drop any existing chunks for this file so a re-index of a replaced
+        # file doesn't leave stale/duplicate chunks behind.
+        supabase.table("client_knowledge") \
+            .delete() \
+            .eq("project_id", body.project_id) \
+            .eq("storage_path", body.storage_path) \
+            .execute()
+
+        filename = body.storage_path.rsplit("/", 1)[-1]
+        rag_service = RAGService()
+        doc_ids = await rag_service.store_document(
+            content=content,
+            metadata={
+                "filename": filename,
+                "storage_path": body.storage_path,
+                "upload_date": datetime.now().isoformat(),
+            },
+            client_id=auth.user_id,
+            project_id=body.project_id,
+            storage_path=body.storage_path,
+            source="portal",
+        )
+
+        return {"indexed": True, "chunks": len(doc_ids)}
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(
+            status_code=500,
+            detail=f"Error indexing file: {str(e)}",
+        )
+
+
+@router.delete("/knowledge/by-file")
+async def delete_by_file(
+    body: ByFileRequest,
+    auth: AuthContext = Depends(get_auth_context),
+):
+    """Remove every indexed chunk of a Document Portal file from the corpus.
+
+    Deletes ``client_knowledge`` rows matching ``project_id`` AND
+    ``storage_path``. Director + membership gated. Returns ``{"deleted": n}``.
+    """
+    await _ensure_director_member(auth, body.project_id)
+
+    try:
+        result = supabase.table("client_knowledge") \
+            .delete() \
+            .eq("project_id", body.project_id) \
+            .eq("storage_path", body.storage_path) \
+            .execute()
+
+        deleted = len(result.data) if result.data else 0
+        return {"deleted": deleted}
+
+    except Exception as e:
+        raise HTTPException(
+            status_code=500,
+            detail=f"Error deleting file index: {str(e)}",
+        )
+
+
+@router.get("/knowledge/indexed")
+async def list_indexed_files(
+    project_id: int,
+    auth: AuthContext = Depends(get_auth_context),
+):
+    """List the distinct portal files indexed for ``project_id``.
+
+    Returns ``[{"storage_path", "chunks"}]`` grouped by ``storage_path`` over
+    rows with ``source='portal'`` — the data behind the frontend's per-file
+    "indexed" badges. Membership gated (read access for any project member).
+    """
+    db = user_client(auth.access_token)
+    if not await is_project_member(db, auth.user_id, project_id):
+        raise HTTPException(
+            status_code=403,
+            detail="You are not a member of the specified project.",
+        )
+
+    try:
+        result = supabase.table("client_knowledge") \
+            .select("storage_path") \
+            .eq("project_id", project_id) \
+            .eq("source", "portal") \
+            .execute()
+
+        counts: dict[str, int] = {}
+        for row in result.data or []:
+            path = row.get("storage_path")
+            if path:
+                counts[path] = counts.get(path, 0) + 1
+
+        return [
+            {"storage_path": path, "chunks": chunks}
+            for path, chunks in sorted(counts.items())
+        ]
+
+    except Exception as e:
+        raise HTTPException(
+            status_code=500,
+            detail=f"Error listing indexed files: {str(e)}",
         )

--- a/backend/app/explore/services/pdf_parser.py
+++ b/backend/app/explore/services/pdf_parser.py
@@ -1,6 +1,114 @@
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Optional
 from pypdf import PdfReader
 import io
+import os
+
+
+# Plain-text / markup formats whose bytes can be decoded directly as UTF-8.
+_PLAINTEXT_EXTENSIONS = {".txt", ".md"}
+
+# Binary document formats we have a dedicated extractor for.
+_DOCX_EXTENSIONS = {".docx"}
+_PPTX_EXTENSIONS = {".pptx"}
+_XLSX_EXTENSIONS = {".xlsx"}
+_PDF_EXTENSIONS = {".pdf"}
+
+# Every extension the dispatcher can turn into plain text. Anything else
+# (images, archives, audio, ...) is "not indexable" — not an error.
+SUPPORTED_EXTENSIONS = (
+    _PLAINTEXT_EXTENSIONS
+    | _DOCX_EXTENSIONS
+    | _PPTX_EXTENSIONS
+    | _XLSX_EXTENSIONS
+    | _PDF_EXTENSIONS
+)
+
+
+def _file_extension(filename: str) -> str:
+    """Lower-cased extension (including the dot) for ``filename``, or ``""``."""
+    return os.path.splitext(filename)[1].lower()
+
+
+def is_extractable(filename: str) -> bool:
+    """True if a file with this name has a text extractor (by extension)."""
+    return _file_extension(filename) in SUPPORTED_EXTENSIONS
+
+
+def _extract_plaintext(file_bytes: bytes) -> str:
+    """Decode raw text/markdown bytes as UTF-8 (replacing undecodable bytes)."""
+    return file_bytes.decode("utf-8", errors="replace")
+
+
+def _extract_pdf(file_bytes: bytes) -> str:
+    """Concatenate the text of every PDF page into a single string."""
+    reader = PdfReader(io.BytesIO(file_bytes))
+    parts: List[str] = []
+    for page in reader.pages:
+        text = page.extract_text()
+        if text and text.strip():
+            parts.append(text)
+    return "\n\n".join(parts)
+
+
+def _extract_docx(file_bytes: bytes) -> str:
+    """Extract paragraph text from a .docx (Word) document."""
+    from docx import Document
+
+    document = Document(io.BytesIO(file_bytes))
+    parts = [p.text for p in document.paragraphs if p.text and p.text.strip()]
+    return "\n".join(parts)
+
+
+def _extract_pptx(file_bytes: bytes) -> str:
+    """Extract text from every shape across all slides of a .pptx deck."""
+    from pptx import Presentation
+
+    presentation = Presentation(io.BytesIO(file_bytes))
+    parts: List[str] = []
+    for slide in presentation.slides:
+        for shape in slide.shapes:
+            if shape.has_text_frame:
+                text = shape.text_frame.text
+                if text and text.strip():
+                    parts.append(text)
+    return "\n".join(parts)
+
+
+def _extract_xlsx(file_bytes: bytes) -> str:
+    """Extract cell values from every sheet of a .xlsx workbook as TSV rows."""
+    from openpyxl import load_workbook
+
+    workbook = load_workbook(io.BytesIO(file_bytes), read_only=True, data_only=True)
+    parts: List[str] = []
+    for sheet in workbook.worksheets:
+        for row in sheet.iter_rows(values_only=True):
+            cells = [str(c) for c in row if c is not None]
+            if cells:
+                parts.append("\t".join(cells))
+    workbook.close()
+    return "\n".join(parts)
+
+
+def extract_text(file_bytes: bytes, filename: str) -> Optional[str]:
+    """Extract plain text from ``file_bytes`` based on ``filename``'s extension.
+
+    Dispatches to the right extractor for PDF, .txt, .md, .docx, .pptx and
+    .xlsx. Returns ``None`` for any unsupported/binary type (images, archives,
+    ...) — those are "not indexable", which the caller treats as a normal
+    outcome rather than an error.
+    """
+    ext = _file_extension(filename)
+    if ext in _PLAINTEXT_EXTENSIONS:
+        return _extract_plaintext(file_bytes)
+    if ext in _PDF_EXTENSIONS:
+        return _extract_pdf(file_bytes)
+    if ext in _DOCX_EXTENSIONS:
+        return _extract_docx(file_bytes)
+    if ext in _PPTX_EXTENSIONS:
+        return _extract_pptx(file_bytes)
+    if ext in _XLSX_EXTENSIONS:
+        return _extract_xlsx(file_bytes)
+    return None
 
 
 class PDFParser:

--- a/backend/app/explore/services/rag_service.py
+++ b/backend/app/explore/services/rag_service.py
@@ -47,12 +47,19 @@ class RAGService:
             raise ValueError(f"Failed to generate embedding: {str(e)}")
 
     async def store_document(self, content: str, metadata: Dict[str, Any],
-        client_id: str, project_id: Optional[int] = None) -> List[int]:
+        client_id: str, project_id: Optional[int] = None,
+        storage_path: Optional[str] = None, source: str = "manual") -> List[int]:
         """Chunk, embed, and store a document in Supabase.
 
         ``project_id`` tags the document with the project it belongs to so the
         ``search_documents`` tool can retrieve it for that project's team. The
         uploader ``uid`` is still recorded for ownership/auditing.
+
+        ``storage_path`` records the project-relative path of the source file in
+        the "Files" storage bucket (set for files indexed from the Document
+        Portal); ``source`` tags how the chunk entered the corpus ('portal',
+        'chat', or 'manual'). Both default to today's behaviour for existing
+        callers.
         """
         chunks = self.pdf_parser.chunk_text(content)
         document_ids = []
@@ -73,7 +80,9 @@ class RAGService:
                 "project_id": project_id,
                 "content": chunk,
                 "metadata": chunk_metadata,
-                "embedding": embedding
+                "embedding": embedding,
+                "storage_path": storage_path,
+                "source": source
             }).execute()
 
             if result.data and isinstance(result.data, list) and len(result.data) > 0:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -17,4 +17,6 @@ dependencies = [
     "langchain-text-splitters>=1.1.0",
     "python-multipart>=0.0.21",
     "python-docx>=1.1.0",
+    "python-pptx>=1.0.0",
+    "openpyxl>=3.1.0",
 ]

--- a/frontend/app/api/knowledge/by-file/route.ts
+++ b/frontend/app/api/knowledge/by-file/route.ts
@@ -1,0 +1,56 @@
+import type { NextRequest } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+
+export const runtime = "nodejs";
+export const maxDuration = 60;
+
+const BACKEND_URL = process.env.BACKEND_URL || "http://localhost:8000";
+
+function jsonError(status: number, detail: string) {
+  return new Response(JSON.stringify({ detail }), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+/**
+ * Remove every indexed chunk of a Document-Portal file from the project's RAG
+ * corpus. Forwards `{ project_id, storage_path }` to the backend, which
+ * re-verifies membership. Mirrors the auth shape of /api/knowledge/upload.
+ */
+export async function DELETE(request: NextRequest) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return jsonError(401, "Unauthorized");
+
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+  if (!session?.access_token) return jsonError(401, "No active session");
+
+  const body = await request.text();
+
+  const backendRes = await fetch(
+    `${BACKEND_URL}/api/v1/documents/knowledge/by-file`,
+    {
+      method: "DELETE",
+      headers: {
+        Authorization: `Bearer ${session.access_token}`,
+        "Content-Type": "application/json",
+      },
+      body,
+      signal: request.signal,
+    },
+  );
+
+  const passthroughHeaders = new Headers();
+  const contentType = backendRes.headers.get("Content-Type");
+  if (contentType) passthroughHeaders.set("Content-Type", contentType);
+
+  return new Response(backendRes.body, {
+    status: backendRes.status,
+    headers: passthroughHeaders,
+  });
+}

--- a/frontend/app/api/knowledge/index-file/route.ts
+++ b/frontend/app/api/knowledge/index-file/route.ts
@@ -1,0 +1,57 @@
+import type { NextRequest } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+
+export const runtime = "nodejs";
+export const maxDuration = 120;
+
+const BACKEND_URL = process.env.BACKEND_URL || "http://localhost:8000";
+
+function jsonError(status: number, detail: string) {
+  return new Response(JSON.stringify({ detail }), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+/**
+ * Index a Document-Portal file into the project's RAG corpus. Forwards
+ * `{ project_id, storage_path }` to the backend, which re-verifies membership
+ * (it rejects a project the caller doesn't belong to) and pulls the object from
+ * Storage to embed it. Mirrors the auth shape of /api/knowledge/upload.
+ */
+export async function POST(request: NextRequest) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return jsonError(401, "Unauthorized");
+
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+  if (!session?.access_token) return jsonError(401, "No active session");
+
+  const body = await request.text();
+
+  const backendRes = await fetch(
+    `${BACKEND_URL}/api/v1/documents/knowledge/index-file`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${session.access_token}`,
+        "Content-Type": "application/json",
+      },
+      body,
+      signal: request.signal,
+    },
+  );
+
+  const passthroughHeaders = new Headers();
+  const contentType = backendRes.headers.get("Content-Type");
+  if (contentType) passthroughHeaders.set("Content-Type", contentType);
+
+  return new Response(backendRes.body, {
+    status: backendRes.status,
+    headers: passthroughHeaders,
+  });
+}

--- a/frontend/app/api/knowledge/indexed/route.ts
+++ b/frontend/app/api/knowledge/indexed/route.ts
@@ -1,0 +1,52 @@
+import type { NextRequest } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+
+export const runtime = "nodejs";
+export const maxDuration = 60;
+
+const BACKEND_URL = process.env.BACKEND_URL || "http://localhost:8000";
+
+function jsonError(status: number, detail: string) {
+  return new Response(JSON.stringify({ detail }), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+/**
+ * List the Document-Portal files indexed into a project's RAG corpus. Forwards
+ * `?project_id=<n>` to the backend, which re-verifies membership. Mirrors the
+ * auth shape of /api/knowledge/upload.
+ */
+export async function GET(request: NextRequest) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return jsonError(401, "Unauthorized");
+
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+  if (!session?.access_token) return jsonError(401, "No active session");
+
+  const projectId = request.nextUrl.searchParams.get("project_id") ?? "";
+
+  const backendRes = await fetch(
+    `${BACKEND_URL}/api/v1/documents/knowledge/indexed?project_id=${encodeURIComponent(projectId)}`,
+    {
+      method: "GET",
+      headers: { Authorization: `Bearer ${session.access_token}` },
+      signal: request.signal,
+    },
+  );
+
+  const passthroughHeaders = new Headers();
+  const contentType = backendRes.headers.get("Content-Type");
+  if (contentType) passthroughHeaders.set("Content-Type", contentType);
+
+  return new Response(backendRes.body, {
+    status: backendRes.status,
+    headers: passthroughHeaders,
+  });
+}

--- a/frontend/app/dashboard/files/FileCard.tsx
+++ b/frontend/app/dashboard/files/FileCard.tsx
@@ -16,11 +16,14 @@ import {
     ExternalLink,
     Pencil,
     Trash2,
+    Sparkles,
     type LucideIcon,
 } from "lucide-react";
 import { createClient } from "@/lib/supabase/client";
 import { toastError } from "@/lib/notifications";
 import { Modal } from "@/components/dashboard/common/Modal";
+
+type IndexState = "indexed" | "indexing" | "not-indexable";
 
 interface FileCardProps {
     name: string;
@@ -28,6 +31,7 @@ interface FileCardProps {
     draggableId: string;
     updatedAt?: string | null;
     canManage?: boolean;
+    indexState?: IndexState;
     onRename?: () => void;
     onDelete?: () => void;
 }
@@ -68,6 +72,7 @@ export default function FileCard({
     draggableId,
     updatedAt,
     canManage = false,
+    indexState,
     onRename,
     onDelete,
 }: FileCardProps) {
@@ -176,7 +181,33 @@ export default function FileCard({
                     <div className="text-sm font-medium text-white truncate" title={name}>
                         {name}
                     </div>
-                    <div className="text-xs text-sbi-muted">{formattedDate}</div>
+                    <div className="flex items-center gap-2 text-xs text-sbi-muted">
+                        <span>{formattedDate}</span>
+                        {indexState === "indexing" ? (
+                            <span
+                                className="inline-flex items-center gap-1 text-sbi-green/80"
+                                title="Indexing into the assistant's sources"
+                            >
+                                <span className="block h-2.5 w-2.5 rounded-full border-[1.5px] border-sbi-green/70 border-t-transparent animate-spin" />
+                                Indexing…
+                            </span>
+                        ) : indexState === "indexed" ? (
+                            <span
+                                className="inline-flex items-center gap-1 text-sbi-green/80"
+                                title="The assistant can read this file"
+                            >
+                                <Sparkles className="h-3 w-3" strokeWidth={1.5} />
+                                Indexed
+                            </span>
+                        ) : indexState === "not-indexable" ? (
+                            <span
+                                className="text-sbi-muted-dark"
+                                title="This file type isn't indexed for the assistant"
+                            >
+                                Not indexable
+                            </span>
+                        ) : null}
+                    </div>
                 </div>
                 {/* Actions sit over the row's right edge on an opaque fade so
                     the filename stays crisp (never blurred) and just runs

--- a/frontend/app/dashboard/files/page.tsx
+++ b/frontend/app/dashboard/files/page.tsx
@@ -36,6 +36,12 @@ import {
     uploadFile,
 } from "./storage";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+import { KnowledgeSourcesPanel } from "@/components/dashboard/explore/ui/KnowledgeSourcesPanel";
+import {
+    deletePortalFileIndex,
+    indexPortalFile,
+    listIndexedFiles,
+} from "@/lib/api/knowledge";
 import { toastError, toastSuccess } from "@/lib/notifications";
 import { useProject } from "@/lib/project/project-context";
 import {
@@ -49,6 +55,22 @@ import {
     btnPrimary,
     btnGhost,
 } from "@/components/dashboard/common/ui";
+
+// File types the RAG ingester accepts. Uploading one of these auto-indexes it
+// into the project's assistant corpus; anything else is "Not indexable".
+const INDEXABLE_EXTENSIONS = new Set([
+    "pdf",
+    "txt",
+    "md",
+    "docx",
+    "pptx",
+    "xlsx",
+]);
+
+function isIndexable(name: string): boolean {
+    const ext = name.split(".").pop()?.toLowerCase() ?? "";
+    return INDEXABLE_EXTENSIONS.has(ext);
+}
 
 function SkeletonTile() {
     return (
@@ -111,6 +133,31 @@ export default function FilesPage() {
         name: string;
         path: string;
     } | null>(null);
+
+    // RAG index state. `indexedPaths` is the set of project-relative paths the
+    // backend has embedded; `indexingPaths` are uploads whose index call is in
+    // flight. Both drive the per-file badge.
+    const [indexedPaths, setIndexedPaths] = useState<Set<string>>(new Set());
+    const [indexingPaths, setIndexingPaths] = useState<Set<string>>(new Set());
+
+    const refreshIndexedFiles = useCallback(async () => {
+        if (projectId === null) return;
+        try {
+            const indexed = await listIndexedFiles(projectId);
+            setIndexedPaths(new Set(indexed.map((f) => f.storage_path)));
+        } catch {
+            // Non-critical: the badge just won't show. Don't disrupt the page.
+        }
+    }, [projectId]);
+
+    // Load the indexed list on mount and on project switch; clear stale state
+    // first so a previous project's badges never bleed across the switch.
+    useEffect(() => {
+        setIndexedPaths(new Set());
+        setIndexingPaths(new Set());
+        if (projectId === null) return;
+        void refreshIndexedFiles();
+    }, [projectId, refreshIndexedFiles]);
 
     // ---------------------------------------------------------------------
     // Listing — cache-aware. Tree nodes resolve `hasSubfolders` up front by
@@ -506,6 +553,7 @@ export default function FilesPage() {
 
         let okCount = 0;
         const failures: string[] = [];
+        const toIndex: string[] = [];
         for (const file of arr) {
             const targetPath = selectedFolderPath
                 ? `${selectedFolderPath}/${file.name}`
@@ -517,6 +565,7 @@ export default function FilesPage() {
                 );
             } else {
                 okCount += 1;
+                if (isIndexable(file.name)) toIndex.push(targetPath);
             }
         }
 
@@ -533,6 +582,39 @@ export default function FilesPage() {
             toastError(failures.join(" • "), "Some uploads failed");
         }
         await refreshAfterWrite();
+
+        // Best-effort auto-index of every newly uploaded indexable file. Each
+        // path shows "Indexing…" while its call is in flight, then the refreshed
+        // indexed-list flips it to "Indexed". A failed index just clears the
+        // in-flight badge — the storage upload already succeeded.
+        if (projectId !== null && toIndex.length > 0) {
+            setIndexingPaths((prev) => {
+                const next = new Set(prev);
+                for (const p of toIndex) next.add(p);
+                return next;
+            });
+            await Promise.all(
+                toIndex.map(async (path) => {
+                    try {
+                        await indexPortalFile(projectId, path);
+                    } catch (err) {
+                        toastError(
+                            err instanceof Error
+                                ? err.message
+                                : `Couldn't index ${path.split("/").pop()}.`,
+                            "Indexing failed",
+                        );
+                    } finally {
+                        setIndexingPaths((prev) => {
+                            const next = new Set(prev);
+                            next.delete(path);
+                            return next;
+                        });
+                    }
+                }),
+            );
+            await refreshIndexedFiles();
+        }
     };
 
     const onFileInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -661,19 +743,43 @@ export default function FilesPage() {
 
     const handleConfirmDelete = async () => {
         if (!deleteTarget) return;
+        const target = deleteTarget;
         try {
-            if (deleteTarget.kind === "file") {
-                await removePaths([deleteTarget.path]);
+            if (target.kind === "file") {
+                await removePaths([target.path]);
             } else {
-                await deleteFolder(deleteTarget.path);
+                await deleteFolder(target.path);
             }
-            invalidatePrefix(deleteTarget.path);
-            invalidatePath(parentOf(deleteTarget.path));
+            invalidatePrefix(target.path);
+            invalidatePath(parentOf(target.path));
             toastSuccess(
-                `${deleteTarget.kind === "file" ? "File" : "Folder"} "${deleteTarget.name}" deleted.`,
+                `${target.kind === "file" ? "File" : "Folder"} "${target.name}" deleted.`,
             );
             setDeleteTarget(null);
             await refreshAfterWrite();
+
+            // Best-effort cascade into the RAG index — never block or fail the
+            // storage delete on it. For a file, drop its single index; for a
+            // folder, drop every indexed path under that prefix.
+            if (projectId !== null) {
+                const prefix = `${target.path}/`;
+                const toUnindex =
+                    target.kind === "file"
+                        ? indexedPaths.has(target.path)
+                            ? [target.path]
+                            : []
+                        : Array.from(indexedPaths).filter((p) =>
+                              p.startsWith(prefix),
+                          );
+                if (toUnindex.length > 0) {
+                    await Promise.all(
+                        toUnindex.map((p) =>
+                            deletePortalFileIndex(projectId, p).catch(() => {}),
+                        ),
+                    );
+                    await refreshIndexedFiles();
+                }
+            }
         } catch (err) {
             const msg = err instanceof Error ? err.message : String(err);
             toastError(humanizeStorageError(msg, "delete"));
@@ -748,8 +854,15 @@ export default function FilesPage() {
                             ))}
                         </ul>
                     ) : (
-                        <p className="text-sm text-sbi-muted">No folders found</p>
+                        <p className="px-2 py-1 text-xs font-light text-sbi-muted-dark">
+                            No folders yet
+                        </p>
                     )}
+
+                    {/* Read-only disclosure of the project's RAG corpus — what
+                        the Explore assistant can read. Indexing happens via the
+                        Upload button above; this panel no longer uploads. */}
+                    <KnowledgeSourcesPanel className="mt-4" />
                 </Panel>
 
                 <main className="flex-1 min-w-0 overflow-y-auto flex flex-col">
@@ -906,6 +1019,15 @@ export default function FilesPage() {
                                             const fullPath = selectedFolderPath
                                                 ? `${selectedFolderPath}/${item.name}`
                                                 : item.name;
+                                            const indexState = indexingPaths.has(
+                                                fullPath,
+                                            )
+                                                ? "indexing"
+                                                : indexedPaths.has(fullPath)
+                                                  ? "indexed"
+                                                  : isIndexable(item.name)
+                                                    ? undefined
+                                                    : "not-indexable";
                                             return (
                                                 <FileCard
                                                     key={item.name}
@@ -916,6 +1038,7 @@ export default function FilesPage() {
                                                     draggableId={fullPath}
                                                     updatedAt={item.updated_at}
                                                     canManage={isDirector}
+                                                    indexState={indexState}
                                                     onRename={() =>
                                                         openRename(
                                                             "file",

--- a/frontend/components/dashboard/explore/DashboardPortal.tsx
+++ b/frontend/components/dashboard/explore/DashboardPortal.tsx
@@ -9,7 +9,6 @@ import { cn } from "@/lib/utils";
 import { AmbientGrid } from "./ui/AmbientGrid";
 import { ChatMessages } from "./ui/ChatMessages";
 import { FloatingNodes } from "./ui/FloatingNodes";
-import { KnowledgeSourcesPanel } from "./ui/KnowledgeSourcesPanel";
 import { PortalHero } from "./ui/PortalHero";
 import { PortalInput } from "./ui/PortalInput";
 import { SourcesPanel } from "./ui/SourcesPanel";
@@ -306,12 +305,9 @@ export function ExplorePortal() {
         >
           <PortalInput animated={false} />
           {showWelcome ? (
-            <>
-              <div className="mt-4">
-                <SuggestionChips disableAutoAnimation />
-              </div>
-              <KnowledgeSourcesPanel className="mt-4" />
-            </>
+            <div className="mt-4">
+              <SuggestionChips disableAutoAnimation />
+            </div>
           ) : (
             <p className="text-center text-xs text-sbi-muted-dark mt-3 font-light">
               AI can make mistakes, so double check responses

--- a/frontend/components/dashboard/explore/ui/KnowledgeSourcesPanel.tsx
+++ b/frontend/components/dashboard/explore/ui/KnowledgeSourcesPanel.tsx
@@ -1,34 +1,31 @@
 "use client";
 
-import { ChevronDown, FileText, Loader2, Plus, Trash2 } from "lucide-react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { ChevronDown, FileText, Loader2 } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
 import {
-  deleteKnowledgeSource,
   type KnowledgeSource,
   listKnowledgeSources,
-  uploadKnowledgeDocument,
 } from "@/lib/api/knowledge";
-import { toastError, toastSuccess } from "@/lib/notifications";
+import { toastError } from "@/lib/notifications";
 import { useProject } from "@/lib/project/project-context";
 import { cn } from "@/lib/utils";
 
 /**
- * Collapsible disclosure of the RAG documents the Explore assistant can pull
- * from for the active project (its `search_documents` corpus). Read-only for
- * clients/members; directors can upload PDFs into the index and remove them.
- * Scoped to the active project; switching projects resets it.
+ * Collapsible, read-only disclosure of the RAG documents the Explore assistant
+ * can pull from for the active project (its `search_documents` corpus). Lives in
+ * the Files page; indexing now happens via the Document-Portal Upload button
+ * (auto-index on upload), so this panel no longer uploads or deletes — it just
+ * shows what the assistant can read. Scoped to the active project; switching
+ * projects resets it.
  */
 export function KnowledgeSourcesPanel({ className }: { className?: string }) {
-  const { user, activeProject } = useProject();
+  const { activeProject } = useProject();
   const projectId = activeProject?.projectId ?? null;
-  const isDirector = user?.role === "director";
 
   const [open, setOpen] = useState(false);
   const [sources, setSources] = useState<KnowledgeSource[]>([]);
   const [loading, setLoading] = useState(false);
   const [loaded, setLoaded] = useState(false);
-  const [uploading, setUploading] = useState(false);
-  const fileInputRef = useRef<HTMLInputElement>(null);
 
   const refresh = useCallback(async () => {
     if (projectId === null) return;
@@ -56,35 +53,6 @@ export function KnowledgeSourcesPanel({ className }: { className?: string }) {
     if (open && projectId !== null) void refresh();
   }, [open, projectId, refresh]);
 
-  const handleUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    e.target.value = "";
-    if (!file || projectId === null) return;
-    setUploading(true);
-    try {
-      await uploadKnowledgeDocument(projectId, file);
-      toastSuccess(`Added ${file.name} to the assistant's sources`);
-      await refresh();
-    } catch (err) {
-      toastError(err instanceof Error ? err.message : "Upload failed");
-    } finally {
-      setUploading(false);
-    }
-  };
-
-  const handleRemove = async (filename: string) => {
-    if (projectId === null) return;
-    try {
-      await deleteKnowledgeSource(projectId, filename);
-      setSources((prev) => prev.filter((s) => s.filename !== filename));
-      toastSuccess(`Removed ${filename}`);
-    } catch (err) {
-      toastError(
-        err instanceof Error ? err.message : "Couldn't remove document",
-      );
-    }
-  };
-
   if (projectId === null) return null;
 
   return (
@@ -102,7 +70,7 @@ export function KnowledgeSourcesPanel({ className }: { className?: string }) {
       >
         <FileText className="size-3.5 text-sbi-muted-dark" strokeWidth={1.5} />
         <span className="text-xs font-light text-sbi-muted">
-          Sources the assistant can use
+          What the assistant can read
         </span>
         {loaded && (
           <span className="text-xs font-light tabular-nums text-sbi-muted-dark">
@@ -127,17 +95,16 @@ export function KnowledgeSourcesPanel({ className }: { className?: string }) {
             </div>
           ) : sources.length === 0 ? (
             <p className="px-2 py-3 text-xs font-light leading-relaxed text-sbi-muted-dark">
-              No documents are indexed for this project yet.
-              {isDirector
-                ? " Upload a PDF to let the assistant draw on it."
-                : ""}
+              No documents are indexed for this project yet. Upload an indexable
+              file (PDF, Word, text, slides, or a spreadsheet) and it will be
+              added here automatically.
             </p>
           ) : (
             <ul className="space-y-0.5">
               {sources.map((s) => (
                 <li
                   key={s.filename}
-                  className="group flex items-center gap-3 rounded-lg px-2 py-1.5 transition-colors hover:bg-sbi-dark/40"
+                  className="flex items-center gap-3 rounded-lg px-2 py-1.5"
                 >
                   <FileText
                     className="size-3.5 shrink-0 text-sbi-green/70"
@@ -149,47 +116,9 @@ export function KnowledgeSourcesPanel({ className }: { className?: string }) {
                   <span className="shrink-0 text-[0.7rem] tabular-nums text-sbi-muted-dark">
                     {s.chunks} chunk{s.chunks === 1 ? "" : "s"}
                   </span>
-                  {isDirector && (
-                    <button
-                      type="button"
-                      onClick={() => handleRemove(s.filename)}
-                      aria-label={`Remove ${s.filename}`}
-                      className="shrink-0 text-sbi-muted-dark opacity-0 transition-opacity hover:text-red-400 group-hover:opacity-100"
-                    >
-                      <Trash2 className="size-3.5" strokeWidth={1.5} />
-                    </button>
-                  )}
                 </li>
               ))}
             </ul>
-          )}
-
-          {isDirector && (
-            <div className="mt-1 px-1">
-              <button
-                type="button"
-                onClick={() => fileInputRef.current?.click()}
-                disabled={uploading}
-                className="flex items-center gap-2 rounded-lg px-2 py-1.5 text-xs font-light text-sbi-muted transition-colors hover:text-sbi-green disabled:opacity-50"
-              >
-                {uploading ? (
-                  <Loader2
-                    className="size-3.5 animate-spin"
-                    strokeWidth={1.5}
-                  />
-                ) : (
-                  <Plus className="size-3.5" strokeWidth={1.5} />
-                )}
-                {uploading ? "Uploading..." : "Upload PDF"}
-              </button>
-              <input
-                ref={fileInputRef}
-                type="file"
-                accept="application/pdf,.pdf"
-                className="hidden"
-                onChange={handleUpload}
-              />
-            </div>
           )}
         </div>
       )}

--- a/frontend/lib/api/knowledge.ts
+++ b/frontend/lib/api/knowledge.ts
@@ -108,3 +108,75 @@ export async function uploadKnowledgeDocument(
     throw new Error(err.detail || `Upload failed (${res.status})`);
   }
 }
+
+/** One Document-Portal file indexed into the project's RAG corpus. */
+export interface IndexedFile {
+  /** Project-relative Storage path (e.g. "Media/contract.pdf"). */
+  storage_path: string;
+  /** Number of embedded chunks stored for this file. */
+  chunks: number;
+}
+
+/**
+ * Index a Document-Portal file into the project's RAG corpus. `storagePath` is
+ * project-relative (e.g. "Media/contract.pdf"); the backend prefixes it with
+ * `{project_id}/`. Returns `{ indexed: false, reason }` when the backend skips
+ * the file (e.g. unsupported content) rather than throwing.
+ */
+export async function indexPortalFile(
+  projectId: number,
+  storagePath: string,
+): Promise<{ indexed: boolean; chunks?: number; reason?: string }> {
+  const res = await fetch("/api/knowledge/index-file", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ project_id: projectId, storage_path: storagePath }),
+  });
+  if (!res.ok) {
+    const err = await res
+      .json()
+      .catch(() => ({ detail: `Indexing failed (${res.status})` }));
+    throw new Error(err.detail || `Indexing failed (${res.status})`);
+  }
+  return res.json();
+}
+
+/**
+ * Remove every indexed chunk of a Document-Portal file from the project's RAG
+ * corpus. `storagePath` is project-relative.
+ */
+export async function deletePortalFileIndex(
+  projectId: number,
+  storagePath: string,
+): Promise<{ deleted: number }> {
+  const res = await fetch("/api/knowledge/by-file", {
+    method: "DELETE",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ project_id: projectId, storage_path: storagePath }),
+  });
+  if (!res.ok) {
+    const err = await res
+      .json()
+      .catch(() => ({ detail: `Remove failed (${res.status})` }));
+    throw new Error(err.detail || `Remove failed (${res.status})`);
+  }
+  return res.json();
+}
+
+/** List the project's indexed Document-Portal files (project-relative paths). */
+export async function listIndexedFiles(
+  projectId: number,
+): Promise<IndexedFile[]> {
+  const res = await fetch(
+    `/api/knowledge/indexed?project_id=${encodeURIComponent(projectId)}`,
+  );
+  if (!res.ok) {
+    const err = await res
+      .json()
+      .catch(() => ({ detail: `Couldn't load indexed files (${res.status})` }));
+    throw new Error(
+      err.detail || `Couldn't load indexed files (${res.status})`,
+    );
+  }
+  return res.json();
+}

--- a/supabase/migrations/20260614000005_client_knowledge_storage_link.sql
+++ b/supabase/migrations/20260614000005_client_knowledge_storage_link.sql
@@ -1,0 +1,36 @@
+-- ===========================================================================
+-- Link RAG chunks to their source file in the Document Portal (Files bucket).
+--
+-- The Document Portal becomes the project's indexable "drive": every indexable
+-- file dropped there is auto-chunked into client_knowledge so the Explore
+-- assistant can read it. To make that reversible (delete a file -> drop its
+-- chunks) and inspectable ("which files are indexed?"), each chunk records the
+-- project-relative storage path of the file it came from and how it got here.
+--
+-- Additive + idempotent: no existing rows change behavior. Pre-existing chunks
+-- default to source='manual' (the old standalone knowledge uploader) with a
+-- NULL storage_path, exactly matching their current meaning.
+-- ===========================================================================
+
+ALTER TABLE public.client_knowledge
+  ADD COLUMN IF NOT EXISTS storage_path text,
+  ADD COLUMN IF NOT EXISTS source text NOT NULL DEFAULT 'manual';
+
+-- Constrain source to the known origins. Dropped-then-readded so re-running the
+-- migration can't fail on an existing constraint.
+ALTER TABLE public.client_knowledge
+  DROP CONSTRAINT IF EXISTS client_knowledge_source_check;
+ALTER TABLE public.client_knowledge
+  ADD CONSTRAINT client_knowledge_source_check
+  CHECK (source IN ('portal', 'chat', 'manual'));
+
+-- Fast lookups for "is this file indexed?" and delete-by-file cascades.
+CREATE INDEX IF NOT EXISTS client_knowledge_project_storage_idx
+  ON public.client_knowledge (project_id, storage_path);
+
+COMMENT ON COLUMN public.client_knowledge.storage_path IS
+  'Project-relative path of the source file in the Files storage bucket when '
+  'source=portal (e.g. "Media/contract.pdf"); NULL for chat/manual chunks.';
+COMMENT ON COLUMN public.client_knowledge.source IS
+  'Origin of the chunk: portal (auto-indexed Document Portal file), chat '
+  '(per-chat upload), or manual (legacy standalone knowledge uploader).';


### PR DESCRIPTION
## What & why
Batch of fixes from a cleanup session.

### 1. Chat latency (`perf(explore)`)
The agent did a blocking title call + a non-streaming tool-decision round-trip **before** any answer streamed — a simple query paid 2–3 sequential model calls of dead air. Collapsed into **one streaming-with-tools loop**: a no-tool query now streams on the first model call; title generation runs as a background task overlapped with the stream. SSE contract preserved (`title/phase/reasoning/delta/result`); emits `phase:generating` before the first token on every path; forces a final tool-free answer if the loop exhausts iterations.

### 2. Document Portal → project RAG (`feat`, Gemini-style)
The Document Portal (Storage bucket) and the assistant's knowledge (RAG `client_knowledge` table) were two disconnected silos — uploads "vanished" because users used one and looked in the other. Now:
- **Uploading an indexable file** (pdf/txt/md/docx/pptx/xlsx) to the portal **auto-indexes it** into the project RAG (`source='portal'`, linked by `storage_path`). Per-file badges: `Indexing… / Indexed / Not indexable`.
- **Deleting** a file/folder **cascades** the unindex.
- The read-only **"Sources the assistant can use" panel moves out of the chat into the Files page**; the portal Upload is now the single upload path.
- New columns `storage_path` + `source` on `client_knowledge` (additive, idempotent migration).
- Backend: text extraction for the new types + `/documents/knowledge/{index-file,by-file,indexed}` endpoints (director + membership gated, re-index-safe).
- "No folders found" → "No folders yet" polish.

## Ship checklist
- [x] Migration `20260614000005_client_knowledge_storage_link.sql` **already applied to remote** (idempotent if re-run).
- [ ] **Redeploy FastAPI backend** — required for both the latency refactor and the indexing endpoints. New deps: `python-pptx`, `openpyxl`.

## Verification
- `next build` passes; backend `py_compile` clean. Biome lint advisory (tree-wide pre-existing, unchanged).

## Known v1 gap
Renaming an indexed portal file orphans its old-path index (re-index-on-rename not wired).