### PR TITLE
fix(explore): stuck chat loader + per-section loading skeletons

### DIFF
--- a/frontend/app/dashboard/calendar/loading.tsx
+++ b/frontend/app/dashboard/calendar/loading.tsx
@@ -1,0 +1,32 @@
+import { DashboardShell, PageHeader } from "@/components/dashboard/common/ui";
+
+export default function CalendarLoading() {
+  return (
+    <DashboardShell>
+      <PageHeader title="Calendar" subtitle="Loading…" />
+
+      {/* View toggle + search row (CalendarHeader) */}
+      <div className="mb-4 flex items-center justify-between gap-4 shrink-0 animate-pulse">
+        <div className="h-9 w-44 rounded-md bg-white/5" />
+        <div className="h-9 w-56 rounded-md bg-white/5" />
+      </div>
+
+      {/* Month grid skeleton — weekday header + 5 rows of 7 day cells */}
+      <div className="flex-1 min-h-0 flex flex-col animate-pulse">
+        <div className="grid grid-cols-7 gap-px mb-px">
+          {Array.from({ length: 7 }).map((_, i) => (
+            <div key={i} className="h-6 rounded bg-white/5" />
+          ))}
+        </div>
+        <div className="grid flex-1 grid-cols-7 grid-rows-5 gap-px">
+          {Array.from({ length: 35 }).map((_, i) => (
+            <div
+              key={i}
+              className="rounded border border-sbi-dark-border/50 bg-sbi-dark-card/30"
+            />
+          ))}
+        </div>
+      </div>
+    </DashboardShell>
+  );
+}

--- a/frontend/app/dashboard/chats/loading.tsx
+++ b/frontend/app/dashboard/chats/loading.tsx
@@ -1,0 +1,26 @@
+import { DashboardShell, PageHeader, Panel } from "@/components/dashboard/common/ui";
+
+export default function ChatsLoading() {
+  return (
+    <DashboardShell className="max-w-3xl">
+      <PageHeader title="Chats" subtitle="Loading…" />
+
+      {/* Search field skeleton */}
+      <div className="mb-4 shrink-0 animate-pulse">
+        <div className="h-10 w-full rounded-md bg-white/5" />
+      </div>
+
+      {/* Conversation list skeleton — stacked rows */}
+      <Panel className="flex-1 min-h-0 overflow-hidden">
+        <div className="animate-pulse divide-y divide-sbi-dark-border/40">
+          {Array.from({ length: 7 }).map((_, i) => (
+            <div key={i} className="flex items-center gap-3 py-3.5">
+              <div className="h-4 flex-1 rounded bg-white/5" />
+              <div className="h-3 w-12 shrink-0 rounded bg-white/5" />
+            </div>
+          ))}
+        </div>
+      </Panel>
+    </DashboardShell>
+  );
+}

--- a/frontend/app/dashboard/files/loading.tsx
+++ b/frontend/app/dashboard/files/loading.tsx
@@ -1,0 +1,46 @@
+import { DashboardShell, PageHeader, Panel, SectionLabel } from "@/components/dashboard/common/ui";
+
+export default function FilesLoading() {
+  return (
+    <DashboardShell>
+      <PageHeader
+        title="Client Document Portal"
+        subtitle="Browse and download files shared on your project."
+      />
+
+      <div className="flex flex-1 min-h-0 gap-6">
+        {/* Folder tree sidebar */}
+        <Panel className="w-64 shrink-0 overflow-hidden" padded>
+          <SectionLabel className="mb-4">Folders</SectionLabel>
+          <ul className="space-y-2 text-sm animate-pulse">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <li key={i} className="flex items-center gap-2 px-2 py-1">
+                <span className="w-4" />
+                <div className="h-3 w-32 rounded bg-white/5" />
+              </li>
+            ))}
+          </ul>
+        </Panel>
+
+        {/* Breadcrumb + file grid */}
+        <main className="flex-1 min-w-0 flex flex-col">
+          <div className="mb-6 h-5 w-48 shrink-0 animate-pulse rounded bg-white/5" />
+          <div className="grid gap-3 [grid-template-columns:repeat(auto-fill,minmax(220px,1fr))]">
+            {Array.from({ length: 8 }).map((_, i) => (
+              <div
+                key={i}
+                className="flex min-h-[3.75rem] items-center gap-3 rounded-lg border border-sbi-dark-border/50 bg-sbi-dark-card/30 px-4 py-3 animate-pulse"
+              >
+                <div className="h-4 w-4 shrink-0 rounded bg-white/5" />
+                <div className="min-w-0 flex-1">
+                  <div className="mb-1.5 h-4 w-3/5 rounded bg-white/5" />
+                  <div className="h-3 w-2/5 rounded bg-white/5" />
+                </div>
+              </div>
+            ))}
+          </div>
+        </main>
+      </div>
+    </DashboardShell>
+  );
+}

--- a/frontend/app/dashboard/finances/loading.tsx
+++ b/frontend/app/dashboard/finances/loading.tsx
@@ -1,0 +1,53 @@
+import { DashboardShell, PageHeader, SectionLabel } from "@/components/dashboard/common/ui";
+
+export default function FinancesLoading() {
+  return (
+    <DashboardShell>
+      <PageHeader title="Finances" subtitle="Loading…" />
+
+      <main className="flex-1 overflow-hidden">
+        <div className="flex flex-col gap-8 animate-pulse">
+          {/* Overview stat tiles — 4 across */}
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+            {Array.from({ length: 4 }).map((_, i) => (
+              <div
+                key={i}
+                className="h-28 rounded-xl border border-sbi-dark-border/50 bg-sbi-dark-card/30"
+              />
+            ))}
+          </div>
+
+          {/* Spend chart */}
+          <div className="h-64 rounded-xl border border-sbi-dark-border/50 bg-sbi-dark-card/30" />
+
+          {/* Category grid */}
+          <div>
+            <SectionLabel>Spending by Category</SectionLabel>
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+              {Array.from({ length: 3 }).map((_, i) => (
+                <div
+                  key={i}
+                  className="h-32 rounded-xl border border-sbi-dark-border/50 bg-sbi-dark-card/30"
+                />
+              ))}
+            </div>
+          </div>
+
+          {/* Recent transactions table */}
+          <div>
+            <SectionLabel>Recent Transactions</SectionLabel>
+            <div className="rounded-xl border border-sbi-dark-border/50 bg-sbi-dark-card/30">
+              <div className="h-10 border-b border-sbi-dark-border/50" />
+              {Array.from({ length: 5 }).map((_, i) => (
+                <div
+                  key={i}
+                  className="h-12 border-b border-sbi-dark-border/30 last:border-b-0"
+                />
+              ))}
+            </div>
+          </div>
+        </div>
+      </main>
+    </DashboardShell>
+  );
+}

--- a/frontend/app/dashboard/lifecycle/loading.tsx
+++ b/frontend/app/dashboard/lifecycle/loading.tsx
@@ -1,0 +1,32 @@
+import { DashboardShell, PageHeader, SectionLabel } from "@/components/dashboard/common/ui";
+
+export default function LifecycleLoading() {
+  return (
+    <DashboardShell>
+      <PageHeader
+        title="Lifecycle"
+        subtitle="Track progress across your active projects"
+      />
+
+      <main className="flex-1 overflow-hidden">
+        <div className="flex flex-col gap-8 animate-pulse">
+          {/* Current focus hero card */}
+          <div>
+            <SectionLabel>Current Focus</SectionLabel>
+            <div className="h-40 rounded-2xl bg-white/5" />
+          </div>
+
+          {/* All projects grid */}
+          <div>
+            <SectionLabel>All Projects</SectionLabel>
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5">
+              {Array.from({ length: 3 }).map((_, i) => (
+                <div key={i} className="h-56 rounded-xl bg-white/5" />
+              ))}
+            </div>
+          </div>
+        </div>
+      </main>
+    </DashboardShell>
+  );
+}

--- a/frontend/app/dashboard/messages/loading.tsx
+++ b/frontend/app/dashboard/messages/loading.tsx
@@ -1,0 +1,43 @@
+export default function MessagesLoading() {
+  return (
+    <div className="flex flex-1 min-h-0 h-full animate-pulse">
+      {/* Conversation list column */}
+      <div className="w-96 shrink-0 overflow-hidden border-r border-sbi-dark-border/40 p-4">
+        <div className="mb-4 h-9 w-full rounded-md bg-white/5" />
+        <div className="space-y-1">
+          {Array.from({ length: 8 }).map((_, i) => (
+            <div key={i} className="flex items-center gap-3 px-2 py-3">
+              <div className="h-9 w-9 shrink-0 rounded-full bg-white/5" />
+              <div className="min-w-0 flex-1">
+                <div className="mb-1.5 h-4 w-2/3 rounded bg-white/5" />
+                <div className="h-3 w-4/5 rounded bg-white/5" />
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Thread column */}
+      <div className="flex flex-1 min-h-0 flex-col overflow-hidden">
+        {/* Thread header */}
+        <div className="flex items-center gap-3 border-b border-sbi-dark-border/40 px-6 py-4">
+          <div className="h-10 w-10 rounded-full bg-white/5" />
+          <div className="h-4 w-40 rounded bg-white/5" />
+        </div>
+
+        {/* Message bubbles */}
+        <div className="flex-1 space-y-4 overflow-hidden p-6">
+          <div className="h-16 w-3/5 rounded-2xl bg-white/5" />
+          <div className="ml-auto h-12 w-2/5 rounded-2xl bg-white/5" />
+          <div className="h-20 w-1/2 rounded-2xl bg-white/5" />
+          <div className="ml-auto h-12 w-1/3 rounded-2xl bg-white/5" />
+        </div>
+
+        {/* Composer */}
+        <div className="border-t border-sbi-dark-border/40 p-4">
+          <div className="h-11 w-full rounded-md bg-white/5" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/dashboard/questionnaire/loading.tsx
+++ b/frontend/app/dashboard/questionnaire/loading.tsx
@@ -1,0 +1,30 @@
+import { DashboardShell, PageHeader } from "@/components/dashboard/common/ui";
+
+export default function QuestionnaireLoading() {
+  return (
+    <DashboardShell>
+      <PageHeader title="Questionnaire" subtitle="Loading…" />
+
+      <main className="flex-1 overflow-hidden">
+        <div className="flex flex-col gap-6 animate-pulse">
+          {/* Toolbar — heading + filter control */}
+          <div className="flex items-center justify-between">
+            <div className="h-6 w-48 rounded bg-white/5" />
+            <div className="h-5 w-36 rounded bg-white/5" />
+          </div>
+
+          {/* Form list table */}
+          <div className="rounded-md border border-sbi-dark-border bg-sbi-dark-card/30">
+            <div className="h-11 border-b border-sbi-dark-border" />
+            {Array.from({ length: 8 }).map((_, i) => (
+              <div
+                key={i}
+                className="h-14 border-b border-sbi-dark-border/50 last:border-b-0"
+              />
+            ))}
+          </div>
+        </div>
+      </main>
+    </DashboardShell>
+  );
+}

--- a/frontend/app/dashboard/reports/loading.tsx
+++ b/frontend/app/dashboard/reports/loading.tsx
@@ -1,0 +1,34 @@
+import { DashboardShell, PageHeader, SectionLabel } from "@/components/dashboard/common/ui";
+
+export default function ReportsLoading() {
+  return (
+    <DashboardShell>
+      <PageHeader title="Reports" subtitle="Loading…" />
+
+      <main className="flex-1 overflow-hidden">
+        <div className="flex flex-col gap-8 animate-pulse">
+          {/* Overview stat tiles — 4 across */}
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+            {Array.from({ length: 4 }).map((_, i) => (
+              <div key={i} className="h-28 rounded-xl bg-white/5" />
+            ))}
+          </div>
+
+          {/* Report history table */}
+          <div>
+            <SectionLabel>Report History</SectionLabel>
+            <div className="rounded-xl border border-sbi-dark-border/50 bg-sbi-dark-card/30">
+              <div className="h-11 border-b border-sbi-dark-border/50" />
+              {Array.from({ length: 6 }).map((_, i) => (
+                <div
+                  key={i}
+                  className="h-14 border-b border-sbi-dark-border/30 last:border-b-0"
+                />
+              ))}
+            </div>
+          </div>
+        </div>
+      </main>
+    </DashboardShell>
+  );
+}

--- a/frontend/app/dashboard/requests/loading.tsx
+++ b/frontend/app/dashboard/requests/loading.tsx
@@ -1,0 +1,32 @@
+import { DashboardShell, PageHeader } from "@/components/dashboard/common/ui";
+
+export default function RequestsLoading() {
+  return (
+    <DashboardShell>
+      <PageHeader title="Requests" subtitle="Loading…" />
+
+      <main className="flex-1 overflow-hidden">
+        <div className="flex flex-col gap-6 animate-pulse">
+          {/* Section label + search/filter row */}
+          <div className="flex items-center justify-between gap-3">
+            <div className="h-4 w-40 rounded bg-white/5" />
+            <div className="flex items-center gap-2">
+              <div className="h-8 w-44 rounded bg-white/5" />
+              <div className="h-8 w-28 rounded bg-white/5" />
+            </div>
+          </div>
+
+          {/* Request history rows */}
+          <div className="space-y-2">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <div
+                key={i}
+                className="h-16 rounded border border-sbi-dark-border/50 bg-sbi-dark-card/30"
+              />
+            ))}
+          </div>
+        </div>
+      </main>
+    </DashboardShell>
+  );
+}

--- a/frontend/app/dashboard/table-comparison/loading.tsx
+++ b/frontend/app/dashboard/table-comparison/loading.tsx
@@ -1,0 +1,35 @@
+export default function TableComparisonLoading() {
+  return (
+    <div className="flex flex-col min-h-screen w-full bg-sbi-dark p-6 md:p-10 space-y-12 overflow-hidden">
+      {/* Page header */}
+      <div className="space-y-3 border-b border-sbi-dark-border pb-6 animate-pulse">
+        <div className="h-8 w-72 rounded bg-white/5" />
+        <div className="h-4 w-full max-w-2xl rounded bg-white/5" />
+      </div>
+
+      {/* Stacked design sections, each a labeled table card */}
+      {Array.from({ length: 3 }).map((_, i) => (
+        <section key={i} className="space-y-4 animate-pulse">
+          <div className="flex items-center gap-3">
+            <div className="h-6 w-6 rounded-full bg-white/5" />
+            <div className="space-y-2">
+              <div className="h-5 w-44 rounded bg-white/5" />
+              <div className="h-3 w-80 rounded bg-white/5" />
+            </div>
+          </div>
+          <div className="rounded-xl border border-sbi-dark-border bg-sbi-dark-card/30 p-6">
+            <div className="rounded-md border border-sbi-dark-border bg-sbi-dark-card/40">
+              <div className="h-11 border-b border-sbi-dark-border" />
+              {Array.from({ length: 5 }).map((_, r) => (
+                <div
+                  key={r}
+                  className="h-12 border-b border-sbi-dark-border/50 last:border-b-0"
+                />
+              ))}
+            </div>
+          </div>
+        </section>
+      ))}
+    </div>
+  );
+}

--- a/frontend/lib/chat/chat-context.tsx
+++ b/frontend/lib/chat/chat-context.tsx
@@ -401,10 +401,15 @@ export function ChatProvider({ children }: { children: ReactNode }) {
           handlePhase,
           (delta) => {
             if (cancelledRef.current || !delta) return;
+            // An answer token means we're past thinking/searching/generating —
+            // clear the global loader on EVERY delta, not just the first. On a
+            // multi-iteration tool turn the message is created early (by the
+            // decision step's reasoning), so a later searching/generating phase
+            // would otherwise leave "Writing response" stuck for the whole answer.
+            setLoadingPhase("complete");
             if (assistantId === null) {
               const id = `assistant-${Date.now()}`;
               assistantId = id;
-              setLoadingPhase("complete");
               setMessages((prev) => [
                 ...prev,
                 {
@@ -494,6 +499,10 @@ export function ChatProvider({ children }: { children: ReactNode }) {
           ]);
           setLoadingPhase("complete");
         }
+        // Streaming finished successfully — force the loader to its terminal
+        // state so it can never linger if the last phase event was a loading
+        // one (a multi-iteration tool turn ends mid-"generating" phase).
+        setLoadingPhase("complete");
         // The backend auto-titles the session after the first turn; refresh the
         // title (and public_id) so the header updates from "Untitled".
         if (sessionIdRef.current !== null)


### PR DESCRIPTION
## 1. Fix: chat loader never resolves (`fix(explore)`)
After the streaming-loop refactor, the chat showed **"Thinking" and "Writing response" simultaneously, stuck forever** even after the answer finished.

**Cause:** `isLoading` derives from `loadingPhase`, which only reset to `complete` on the *first* token. The new multi-iteration loop creates the assistant message early (from the decision step's reasoning), then emits `searching`/`generating` *after* — and later content tokens never re-cleared it, so the loader stuck for the whole answer.

**Fix (frontend-only, no redeploy):** every answer token forces `loadingPhase=complete`, and finalization sets a terminal `complete`, so the loader can't linger regardless of phase-event ordering.

## 2. Feature: per-section loading skeletons (`feat(dashboard)`)
Every dashboard route fell back to the single generic `app/dashboard/loading.tsx`. Added a tailored `loading.tsx` for **calendar, chats, files, finances, lifecycle, messages, questionnaire, reports, requests, table-comparison** — each mirrors its real layout (messages → list + thread columns, files → folder sidebar + grid, finances → stat tiles + chart, …) using the shared `DashboardShell`/`PageHeader`/`Panel` chrome. (`settings` already had one.)

## Verification
`next build` passes. Biome advisory (unchanged).