### PR TITLE
fix(explore): hide internal project # + real Explore loading skeleton

### DIFF
--- a/backend/app/explore/services/membership.py
+++ b/backend/app/explore/services/membership.py
@@ -70,7 +70,7 @@ async def get_project_context(
         return (
             "Current project context (authoritative — the project the user is "
             "working in right now):\n"
-            f"- Project: {company_name} (project #{project_id})\n"
+            f"- Project: {company_name}\n"
             f"- The user's role on this project: {role}\n"
             "When the user asks which project they're in, answer with the "
             "project name above. All tool calls are already scoped to this "

--- a/frontend/app/dashboard/explore/[[...chatId]]/loading.tsx
+++ b/frontend/app/dashboard/explore/[[...chatId]]/loading.tsx
@@ -1,0 +1,29 @@
+// Suspense fallback for the Explore portal. Mirrors the real centered layout —
+// "Hello, X" hero (PortalHero) + the composer (PortalInput) + suggestion chips
+// — instead of the generic dashboard skeleton, so entering Explore doesn't flash
+// an unrelated panels layout. The fixed PortalHeader chrome is drawn by the
+// portal itself; this only fills the content area.
+export default function ExploreLoading() {
+  return (
+    <div className="flex min-h-[calc(100vh-4rem)] flex-col items-center justify-center px-4">
+      <div className="flex w-full max-w-2xl flex-col items-center animate-pulse">
+        {/* Greeting ("Hello, X") */}
+        <div className="h-11 w-72 rounded-lg bg-white/5" />
+        {/* Subtitle ("How can I help you?") */}
+        <div className="mt-5 h-5 w-48 rounded bg-white/5" />
+        {/* Decorative divider line */}
+        <div className="mt-6 h-px w-24 bg-white/10" />
+
+        {/* Composer box */}
+        <div className="mt-10 h-28 w-full rounded-2xl border border-sbi-dark-border/50 bg-sbi-dark-card/30" />
+
+        {/* Suggestion chips */}
+        <div className="mt-4 flex flex-wrap items-center justify-center gap-3">
+          <div className="h-9 w-36 rounded-full bg-white/5" />
+          <div className="h-9 w-36 rounded-full bg-white/5" />
+          <div className="h-9 w-44 rounded-full bg-white/5" />
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Two small fixes from QA.

### 1. Assistant leaked the internal project id
The injected *Current project context* said "Test Corp project **(project #5)**" — the numeric DB id is irrelevant to the user. `membership.py` now injects just the project name.
**Backend redeploy required** to take effect.

### 2. Explore loading skeleton didn't match the UI
The Explore route had no `loading.tsx`, so it fell back to the generic `app/dashboard/loading.tsx` (title + panels) — nothing like the real centered-hero portal. Added a `loading.tsx` that mirrors the actual layout: "Hello, X" hero + subtitle + divider + composer box + 3 suggestion chips.

`next build` passes; `py_compile` clean.