### PR TITLE
feat(explore): Claude-style process timeline for assistant turns

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,36 @@
+<!--
+Title: use a conventional-commit style summary, e.g.
+  feat(explore): project-locked chats
+  fix(files): cascade RAG index on delete
+  perf(explore): single streaming tool-call loop
+-->
+
+## What & why
+<!-- The problem and the decision. One or two sentences of context, not just a
+     restatement of the diff. Link the issue if there is one (Closes #123). -->
+
+## Changes
+<!-- Bullet the notable changes, grouped by area when it spans the stack. -->
+- **Frontend:**
+- **Backend (FastAPI):**
+- **Database (Supabase):**
+
+## Deploy checklist
+<!-- Tick what applies. The frontend auto-deploys via Vercel; backend and DB do NOT. -->
+- [ ] **Backend redeploy required** — this PR changes `backend/**` (FastAPI does not auto-deploy)
+- [ ] **Migration to apply** — this PR adds files under `supabase/migrations/`; apply with `supabase db push` (or via MCP) after merge
+- [ ] **New env var(s)** — added to `.env.example` and the deployment environment
+- [ ] **New dependency** — `bun.lock` / `backend/pyproject.toml` updated and committed
+- [ ] None of the above — frontend-only, ships with the Vercel deploy
+
+## Verification
+<!-- Evidence, not assertions. What did you actually run / click? -->
+- [ ] `bun build` passes (frontend typecheck + build)
+- [ ] `py_compile` / backend compiles (no backend test framework yet)
+- [ ] Manually tested the change locally — describe the flow:
+
+## Screenshots / recordings
+<!-- For any UI change. Before / after if it's a fix. -->
+
+## Notes / follow-ups
+<!-- Known gaps, deliberate scope cuts, or things to do in a later PR. -->

--- a/backend/app/explore/agents/graph.py
+++ b/backend/app/explore/agents/graph.py
@@ -258,6 +258,11 @@ async def run_graph_streaming(
 
         for i, tc in enumerate(tool_calls):
             name = tc["name"] or ""
+            # Include the iteration in the fallback id so a provider that omits
+            # tool-call ids can't collide across tool-loop iterations — the id is
+            # also the message-history tool_call_id (below), where a duplicate is
+            # independently invalid, and the client keys timeline cards by it.
+            tc_id = tc["id"] or f"call_{iteration}_{i}"
             raw_args = tc["arguments"] or "{}"
             try:
                 args = json.loads(raw_args) if raw_args.strip() else {}
@@ -267,14 +272,24 @@ async def run_graph_streaming(
                 logger.warning(f"Failed to parse tool args for {name}: {raw_args!r}")
                 args = {}
 
+            yield {"type": "tool_call", "id": tc_id, "name": name, "input": args}
+
             result_text, sources = await execute_tool(
                 name, args, client_id, access_token, project_id
             )
             collected_sources.extend(sources)
 
+            yield {"type": "tool_result", "id": tc_id, "name": name, "output": {
+                "sources": [
+                    {"filename": s.get("filename"), "page_number": s.get("page_number")}
+                    for s in sources
+                ],
+                "text": (result_text or "")[:1200],
+            }}
+
             messages.append({
                 "role": "tool",
-                "tool_call_id": tc["id"] or f"call_{i}",
+                "tool_call_id": tc_id,
                 "content": result_text,
             })
 

--- a/frontend/components/dashboard/explore/ui/ChatMessage.tsx
+++ b/frontend/components/dashboard/explore/ui/ChatMessage.tsx
@@ -29,9 +29,10 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import type { SourceDocument } from "@/lib/api/chat";
-import type { DisplayMessage } from "@/lib/chat/chat-context";
+import type { DisplayMessage, TimelineStep } from "@/lib/chat/chat-context";
 import { useChat } from "@/lib/chat/chat-context";
 import { getFileInfo } from "./file-info";
+import { ProcessTimeline } from "./ProcessTimeline";
 
 interface ChatMessageProps {
   message: DisplayMessage;
@@ -160,16 +161,23 @@ function buildMarkdownComponents(sources: SourceDocument[]): Components {
         {processCitations(children, sources)}
       </em>
     ),
-    a: ({ href, children }) => (
-      <a
-        href={href}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="text-sbi-green hover:underline"
-      >
-        {children}
-      </a>
-    ),
+    a: ({ href, children }) => {
+      // Answers (and the RAG documents feeding them) are model-authored, so only
+      // render http(s)/mailto links as clickable — never javascript:/data: etc.
+      // Unsafe schemes degrade to plain text rather than an executable link.
+      const safe = /^(https?:|mailto:)/i.test((href ?? "").trim());
+      if (!safe) return <span className="text-sbi-green">{children}</span>;
+      return (
+        <a
+          href={href}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-sbi-green hover:underline"
+        >
+          {children}
+        </a>
+      );
+    },
     blockquote: ({ children }) => (
       <blockquote className="border-l-2 border-sbi-green/40 pl-4 italic text-sbi-muted">
         {processCitations(children, sources)}
@@ -304,16 +312,30 @@ export function ChatMessage({
   const [isEditing, setIsEditing] = useState(false);
   const [isExpanded, setIsExpanded] = useState(false);
   const [isOverflowing, setIsOverflowing] = useState(false);
-  // "Thinking" section is collapsed by default; toggled per-message.
-  const [showReasoning, setShowReasoning] = useState(false);
   const [editedContent, setEditedContent] = useState(message.content);
   const {
     editAndResend,
     isLoading,
     isStreaming,
+    loadingPhase,
     regenerateResponse,
     switchBranch,
   } = useChat();
+
+  // Inline status shown inside the latest streaming message whenever the model
+  // is working but NOT emitting answer text — a tool pause, the post-tool gap
+  // before the first answer token, or pre-content thinking. `isLoading` is the
+  // right signal: every answer token sets loadingPhase to "complete" (so
+  // isLoading is false while text actively streams) and any working phase
+  // raises it again, so this is true exactly during the "frozen cursor" gaps.
+  const streamStatusLabel =
+    isLatestAssistant && message.isStreaming && isLoading
+      ? loadingPhase === "searching"
+        ? "Searching documents"
+        : loadingPhase === "generating"
+          ? "Writing response"
+          : "Thinking"
+      : undefined;
 
   // Show the ‹ i/n › picker when this message is one of several sibling branches
   // and is backed by a persisted row (dbId) we can switch on.
@@ -375,35 +397,20 @@ export function ChatMessage({
   }, [isEditing]);
 
   const displayContent = message.content;
-  const reasoning = (message.reasoning ?? "").trim();
-  const hasReasoning = !isUser && reasoning.length > 0;
 
-  // Collapsible "Thinking" section — rendered ABOVE the answer on thinking-model
-  // turns. Collapsed by default; ephemeral (reasoning is never persisted).
-  const reasoningSection = hasReasoning ? (
-    <div className="mb-3">
-      <button
-        type="button"
-        onClick={() => setShowReasoning((v) => !v)}
-        aria-expanded={showReasoning}
-        aria-label={showReasoning ? "Hide thinking" : "Show thinking"}
-        className="flex items-center gap-1.5 text-xs font-light text-sbi-muted hover:text-sbi-green transition-colors"
-      >
-        <ChevronDown
-          className={`w-3.5 h-3.5 transition-transform duration-200 ${
-            showReasoning ? "rotate-180" : ""
-          }`}
-          strokeWidth={1.5}
-        />
-        <span>Thinking</span>
-      </button>
-      {showReasoning && (
-        <div className="mt-2 pl-3 border-l border-sbi-dark-border text-sbi-muted font-light text-sm leading-relaxed whitespace-pre-wrap break-words">
-          {reasoning}
-        </div>
-      )}
-    </div>
-  ) : null;
+  // Process timeline (reasoning interleaved with tool calls), shown ABOVE the
+  // answer. Falls back to a single reasoning step for a turn that streamed
+  // reasoning but no steps (defensive — live turns populate `steps`). Ephemeral:
+  // neither steps nor reasoning are persisted, so reloaded turns have no timeline.
+  const timelineSteps: TimelineStep[] =
+    message.steps && message.steps.length > 0
+      ? message.steps
+      : message.reasoning?.trim()
+        ? [{ kind: "reasoning", text: message.reasoning.trim() }]
+        : [];
+  const hasTimeline = !isUser && timelineSteps.length > 0;
+  // The timeline is "done" once answer text exists or the turn stops streaming.
+  const timelineDone = displayContent.trim().length > 0 || !message.isStreaming;
 
   // Truncated content for collapsed view
   const getTruncatedContent = () => {
@@ -635,7 +642,15 @@ export function ChatMessage({
 
       {/* Message content */}
       <div className="flex-1 min-w-0 pt-1">
-        {reasoningSection}
+        {hasTimeline && (
+          <div className="mb-3">
+            <ProcessTimeline
+              steps={timelineSteps}
+              streaming={!!message.isStreaming}
+              done={timelineDone}
+            />
+          </div>
+        )}
         {message.isCancelled ? (
           <>
             {displayContent && (
@@ -667,12 +682,26 @@ export function ChatMessage({
                 plugins={{ code }}
                 components={markdownComponents}
                 shikiTheme={["github-dark", "github-dark"]}
-                isAnimating={message.isStreaming}
+                isAnimating={message.isStreaming && !streamStatusLabel}
                 caret="block"
               >
                 {displayContent}
               </Streamdown>
             </div>
+            {streamStatusLabel && !hasTimeline && (
+              <div className="mt-2 flex items-center gap-2 text-sm font-light text-sbi-muted">
+                <span>{streamStatusLabel}</span>
+                <span className="flex items-center gap-1">
+                  {[0, 150, 300].map((delay) => (
+                    <span
+                      key={delay}
+                      className="h-1.5 w-1.5 rounded-full bg-sbi-green/60 animate-pulse"
+                      style={{ animationDelay: `${delay}ms` }}
+                    />
+                  ))}
+                </span>
+              </div>
+            )}
             {/* Per-source detail lives in the right-edge Sources panel (latest
                 answer) and the inline [n] citation chips; no per-message footer. */}
           </>

--- a/frontend/components/dashboard/explore/ui/ChatMessages.tsx
+++ b/frontend/components/dashboard/explore/ui/ChatMessages.tsx
@@ -99,7 +99,14 @@ export function ChatMessages() {
         </div>
       )}
 
-      {isLoading && <ChatLoading />}
+      {/* Only show the global loader BEFORE the assistant message appears.
+          Once it's streaming, its own "Thinking" block + cursor convey
+          progress — the loader below it would be a redundant second avatar
+          (the post-reasoning searching/generating phases re-raise isLoading
+          while the message already exists). */}
+      {isLoading && !(isStreaming && lastMessage?.role === "assistant") && (
+        <ChatLoading />
+      )}
       <div ref={bottomRef} />
 
       {showScrollButton && (

--- a/frontend/components/dashboard/explore/ui/ProcessTimeline.tsx
+++ b/frontend/components/dashboard/explore/ui/ProcessTimeline.tsx
@@ -1,0 +1,324 @@
+"use client";
+
+import {
+  Check,
+  ChevronDown,
+  Clock,
+  FileText,
+  Search,
+  Sparkles,
+} from "lucide-react";
+import { motion } from "motion/react";
+import { type ReactNode, useEffect, useMemo, useRef, useState } from "react";
+import type { TimelineStep, ToolStepOutput } from "@/lib/chat/chat-context";
+import { cn } from "@/lib/utils";
+import { getFileInfo } from "./file-info";
+
+// Claude-research-style "process timeline": a collapsible summary header over a
+// left rail whose icons mark each step — clock for reasoning, a tool glyph per
+// tool call, a check for "Done". Driven by the ordered TimelineStep[] streamed
+// onto an assistant turn (reasoning interleaved with tool calls). Ephemeral:
+// steps are not persisted, so the timeline appears on live turns only.
+
+const partTransition = { duration: 0.2, ease: "easeOut" } as const;
+
+const TOOL_LABELS: Record<string, string> = {
+  search_documents: "Searched documents",
+  search_sbi_knowledge: "Searched SBI knowledge",
+  get_reports: "Fetched reports",
+  get_finance_summary: "Fetched finances",
+  get_lifecycle_status: "Checked project status",
+};
+
+function toolLabel(toolName: string): string {
+  return TOOL_LABELS[toolName] ?? toolName;
+}
+
+// Search-style tools get the magnifier; record/report fetches get the document.
+function isFetchTool(toolName: string): boolean {
+  return (
+    toolName === "get_reports" ||
+    toolName === "get_finance_summary" ||
+    toolName === "get_lifecycle_status"
+  );
+}
+
+interface ToolCardProps {
+  toolName: string;
+  done: boolean;
+  output?: ToolStepOutput;
+}
+
+// Tool card — echoes the Sources panel row language (numbered green badge, file
+// icon, filename · page) but lighter than the answer, so the timeline reads
+// thinking → tool card → answer. The rail already carries the tool glyph, so the
+// card header has no leading icon (avoids a double-glyph stutter).
+function ToolCard({ toolName, done, output }: ToolCardProps) {
+  const label = toolLabel(toolName);
+  const sources = output?.sources ?? [];
+
+  return (
+    <div className="overflow-hidden rounded-xl border border-sbi-dark-border bg-sbi-dark-card/40">
+      <div className="flex items-center gap-2.5 px-3 py-2">
+        <span className="text-[13px] font-light text-white/90">{label}</span>
+        {!done ? (
+          <span className="ml-auto flex items-center gap-1.5 text-xs font-light text-sbi-muted">
+            <span className="size-3 animate-spin rounded-full border border-sbi-green/40 border-t-sbi-green/90" />
+            Running…
+          </span>
+        ) : sources.length > 0 ? (
+          <span className="ml-auto rounded-md border border-sbi-green/30 bg-sbi-green/10 px-1.5 py-0.5 text-[11px] font-medium text-sbi-green/90">
+            {sources.length} result{sources.length === 1 ? "" : "s"}
+          </span>
+        ) : !output?.text ? (
+          <span className="ml-auto rounded-md border border-sbi-dark-border bg-sbi-dark-card px-1.5 py-0.5 text-[11px] font-medium text-sbi-muted">
+            No results
+          </span>
+        ) : null}
+      </div>
+
+      {done && sources.length > 0 && (
+        <div className="space-y-0.5 border-t border-sbi-dark-border px-2 py-1.5">
+          {sources.map((s, i) => {
+            const filename = s.filename ?? "Untitled";
+            const fileInfo = getFileInfo(filename);
+            const name = filename.replace(/\.[^/.]+$/, "");
+            return (
+              <div
+                key={`${filename}-${s.page_number ?? ""}-${i}`}
+                className="flex items-center gap-2.5 px-2 py-1.5"
+              >
+                <span className="inline-flex h-5 min-w-[1.25rem] shrink-0 items-center justify-center rounded-md border border-sbi-green/30 bg-sbi-green/10 px-1 text-[11px] font-medium text-sbi-green/90">
+                  {i + 1}
+                </span>
+                {fileInfo.icon}
+                <span className="truncate text-[13px] text-white/90">
+                  {name}
+                  {typeof s.page_number === "number" && (
+                    <span className="text-sbi-muted-dark">
+                      {" "}
+                      · p. {s.page_number}
+                    </span>
+                  )}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {done && sources.length === 0 && output?.text && (
+        <div className="border-t border-sbi-dark-border px-3 py-2 text-[13px] font-light leading-snug text-sbi-muted">
+          {output.text.slice(0, 300)}
+          {output.text.length > 300 ? "…" : ""}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// The icon that sits on the timeline rail for a given step.
+function StepIcon({ step }: { step: TimelineStep }) {
+  if (step.kind === "tool") {
+    return isFetchTool(step.toolName) ? (
+      <FileText className="size-3.5 text-sbi-green/80" strokeWidth={1.5} />
+    ) : (
+      <Search className="size-3.5 text-sbi-green/80" strokeWidth={1.5} />
+    );
+  }
+  return <Clock className="size-3.5 text-sbi-muted" strokeWidth={1.5} />;
+}
+
+// Reasoning text — compact and de-emphasized, clamped to a few lines once the
+// turn settles (with a Show more/less toggle). While the turn is still streaming
+// it stays fully expanded so the user can watch it think.
+function ReasoningText({
+  text,
+  streaming,
+}: {
+  text: string;
+  streaming: boolean;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const [overflows, setOverflows] = useState(false);
+  const ref = useRef<HTMLParagraphElement>(null);
+  // Collapse the model's generous blank-line gaps so the rail stays tight.
+  const normalized = useMemo(
+    () => text.replace(/\n{2,}/g, "\n").trim(),
+    [text],
+  );
+  const clamped = !streaming && !expanded;
+
+  // `normalized` is an intentional re-measure trigger (re-check overflow as the
+  // reasoning text grows mid-stream), not read in the body.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: re-measure on text growth
+  useEffect(() => {
+    if (!clamped) return;
+    const el = ref.current;
+    if (el) setOverflows(el.scrollHeight > el.clientHeight + 1);
+  }, [normalized, clamped]);
+
+  return (
+    <div>
+      <p
+        ref={ref}
+        className={cn(
+          "whitespace-pre-wrap break-words text-[13px] font-light leading-snug text-sbi-muted",
+          clamped && "line-clamp-3",
+        )}
+      >
+        {normalized}
+      </p>
+      {!streaming && (overflows || expanded) && (
+        <button
+          type="button"
+          onClick={() => setExpanded((v) => !v)}
+          className="mt-1 text-[12px] font-light text-sbi-green/80 transition-colors hover:text-sbi-green"
+        >
+          {expanded ? "Show less" : "Show more"}
+        </button>
+      )}
+    </div>
+  );
+}
+
+interface ProcessTimelineProps {
+  steps: TimelineStep[];
+  streaming: boolean;
+  done: boolean;
+  title?: string | null;
+}
+
+export function ProcessTimeline({
+  steps,
+  streaming,
+  done,
+  title,
+}: ProcessTimelineProps) {
+  // Open while the turn is live; auto-collapse once it settles so a long
+  // transcript doesn't keep every past turn's reasoning expanded. The user can
+  // still re-open any card (the effect only fires on the settle transition).
+  const [open, setOpen] = useState(streaming);
+  useEffect(() => {
+    if (done && !streaming) setOpen(false);
+  }, [done, streaming]);
+
+  const headerLabel =
+    title ?? (streaming && !done ? "Working through it…" : "Worked through it");
+
+  // Build a uniform row list (steps + a trailing "Done") so the rail connector
+  // can be drawn per-row and simply omitted after the last row — this is what
+  // makes the line terminate at the check instead of running through it.
+  const rows: {
+    key: string;
+    kind: "reasoning" | "tool" | "done";
+    icon: ReactNode;
+    content: ReactNode;
+    // Key by array index — steps are append-only and never reordered, so the
+    // index is stable AND unique even if a tool id collides (see backend
+    // fallback id). The kind/id suffix is just for readability in the DOM.
+  }[] = steps.map((step, i) => ({
+    key: `${i}-${step.kind === "tool" ? step.toolCallId : "reasoning"}`,
+    kind: step.kind,
+    icon: <StepIcon step={step} />,
+    content:
+      step.kind === "reasoning" ? (
+        <ReasoningText text={step.text} streaming={streaming} />
+      ) : (
+        <ToolCard
+          toolName={step.toolName}
+          done={step.state === "done"}
+          output={step.output}
+        />
+      ),
+  }));
+  if (done) {
+    rows.push({
+      key: "done",
+      kind: "done",
+      icon: <Check className="size-3.5 text-sbi-green" strokeWidth={2} />,
+      content: <span className="text-sm font-light text-sbi-green">Done</span>,
+    });
+  }
+
+  return (
+    <div className="rounded-xl border border-sbi-dark-border bg-sbi-dark-card/30">
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        aria-expanded={open}
+        className="flex w-full items-center gap-2 px-3 py-2 text-left"
+      >
+        {streaming && !done ? (
+          <span className="size-3.5 shrink-0 animate-spin rounded-full border border-sbi-green/40 border-t-sbi-green/90" />
+        ) : (
+          // Neutral glyph (not a check) — the rail's "Done" step is the sole
+          // completion cue, so the header doesn't double up on checkmarks.
+          <Sparkles
+            className="size-3.5 shrink-0 text-sbi-green/70"
+            strokeWidth={1.5}
+          />
+        )}
+        <span className="min-w-0 flex-1 truncate text-[13px] font-light text-white/90">
+          {headerLabel}
+        </span>
+        <ChevronDown
+          className={cn(
+            "size-4 shrink-0 text-sbi-muted transition-transform duration-200",
+            open && "rotate-180",
+          )}
+          strokeWidth={1.5}
+        />
+      </button>
+
+      {open && (
+        <div className="border-t border-sbi-dark-border px-3 py-3">
+          {rows.map((row, idx) => {
+            const isLast = idx === rows.length - 1;
+            return (
+              <motion.div
+                key={row.key}
+                initial={{ opacity: 0, y: 6 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={partTransition}
+                className="flex gap-3"
+              >
+                {/* Icon + downward connector. The connector flex-fills to the
+                    bottom of the row (incl. the content's pb) so it meets the
+                    next icon; the last row omits it, capping the rail. */}
+                <div className="flex flex-col items-center self-stretch">
+                  <div
+                    className={cn(
+                      "flex size-[21px] shrink-0 items-center justify-center rounded-full border",
+                      row.kind === "done"
+                        ? "border-sbi-green/30 bg-sbi-green/10"
+                        : "border-sbi-dark-border bg-sbi-dark",
+                    )}
+                  >
+                    {row.icon}
+                  </div>
+                  {!isLast && (
+                    <div className="mt-1 w-px flex-1 bg-sbi-dark-border" />
+                  )}
+                </div>
+                <div
+                  className={cn(
+                    "min-w-0 flex-1",
+                    // The single-line "Done" row centers against its check;
+                    // multi-line step content top-aligns with its icon.
+                    row.kind === "done"
+                      ? "flex min-h-[21px] items-center"
+                      : "pt-0.5",
+                    !isLast && "pb-3",
+                  )}
+                >
+                  {row.content}
+                </div>
+              </motion.div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/lib/api/chat.ts
+++ b/frontend/lib/api/chat.ts
@@ -47,6 +47,18 @@ export interface ChatResponse {
   session_id: number | null;
 }
 
+// A tool lifecycle event streamed mid-turn by the agent: `tool_call` when a tool
+// is invoked, `tool_result` when it returns. Used to build the live process
+// timeline; ephemeral (never persisted).
+export type ToolEvent =
+  | { type: "tool_call"; id: string; name: string; input?: unknown }
+  | {
+      type: "tool_result";
+      id: string;
+      name: string;
+      output?: { sources?: unknown[]; text?: string };
+    };
+
 /**
  * Send a chat message via SSE streaming.
  * - onPhase fires on backend phase changes (thinking/planning/searching/generating).
@@ -55,6 +67,8 @@ export interface ChatResponse {
  *   only); interleaved before the answer deltas. Ephemeral — shown live, never
  *   persisted.
  * - onSession fires once when the server route confirms (or creates) the session.
+ * - onTool fires on tool lifecycle events (tool_call / tool_result), used to
+ *   build the live process timeline. Ephemeral — never persisted.
  */
 export async function sendChatMessage(
   request: ChatRequest,
@@ -63,6 +77,7 @@ export async function sendChatMessage(
   onDelta?: (text: string) => void,
   onSession?: (sessionId: number) => void,
   onReasoning?: (text: string) => void,
+  onTool?: (event: ToolEvent) => void,
 ): Promise<ChatResponse> {
   const response = await fetch("/api/chat/", {
     method: "POST",
@@ -95,6 +110,11 @@ export async function sendChatMessage(
   let buffer = "";
   let result: ChatResponse | null = null;
   let sessionId: number | null = null;
+  // Accumulate streamed answer text as a fallback: if the backend ends the
+  // stream without a final `result` event (e.g. it crashes after emitting some
+  // deltas), we still surface what was generated instead of throwing away a
+  // perfectly good partial answer.
+  let accumulatedAnswer = "";
 
   while (true) {
     const { done, value } = await reader.read();
@@ -119,10 +139,25 @@ export async function sendChatMessage(
           onSession?.(event.session_id);
         } else if (event.type === "phase" && onPhase) {
           onPhase(event.phase);
-        } else if (event.type === "delta" && onDelta) {
-          onDelta(event.text || "");
+        } else if (event.type === "delta") {
+          accumulatedAnswer += event.text || "";
+          onDelta?.(event.text || "");
         } else if (event.type === "reasoning" && onReasoning) {
           onReasoning(event.text || "");
+        } else if (event.type === "tool_call" && onTool) {
+          onTool({
+            type: "tool_call",
+            id: String(event.id ?? ""),
+            name: String(event.name ?? ""),
+            input: event.input,
+          });
+        } else if (event.type === "tool_result" && onTool) {
+          onTool({
+            type: "tool_result",
+            id: String(event.id ?? ""),
+            name: String(event.name ?? ""),
+            output: event.output,
+          });
         } else if (event.type === "result") {
           result = {
             answer: event.answer || "",
@@ -140,8 +175,18 @@ export async function sendChatMessage(
     }
   }
 
-  if (!result) throw new Error("No result received from server");
-  return result;
+  if (result) return result;
+  // No `result` event arrived. If text streamed, surface it as the answer rather
+  // than discarding the turn; only error out when nothing at all was received.
+  if (accumulatedAnswer.trim()) {
+    return {
+      answer: accumulatedAnswer,
+      sources: [],
+      timestamp: new Date().toISOString(),
+      session_id: sessionId,
+    };
+  }
+  throw new Error("No result received from server");
 }
 
 /**

--- a/frontend/lib/chat/chat-context.tsx
+++ b/frontend/lib/chat/chat-context.tsx
@@ -15,6 +15,7 @@ import {
   extractFileText,
   type SourceDocument,
   sendChatMessage,
+  type ToolEvent,
 } from "@/lib/api/chat";
 import { useProject } from "@/lib/project/project-context";
 import { createClient } from "@/lib/supabase/client";
@@ -35,6 +36,32 @@ export interface MessageAttachment {
   content: string;
 }
 
+// A source row carried by a tool result (filename + optional page).
+export interface ToolStepSource {
+  filename?: string | null;
+  page_number?: number | null;
+}
+
+// The output of a completed tool call: cited sources and/or a text summary.
+export interface ToolStepOutput {
+  sources?: ToolStepSource[];
+  text?: string;
+}
+
+// One ordered step in an assistant turn's "process timeline" — either a chunk of
+// streamed reasoning or a tool call. Reasoning chunks are coalesced into the
+// trailing reasoning step so reasoning → tool → reasoning interleaves in order.
+// Ephemeral: never persisted, so the timeline shows on live turns only.
+export type TimelineStep =
+  | { kind: "reasoning"; text: string }
+  | {
+      kind: "tool";
+      toolCallId: string;
+      toolName: string;
+      state: "running" | "done";
+      output?: ToolStepOutput;
+    };
+
 export interface DisplayMessage {
   id: string;
   role: "user" | "assistant";
@@ -47,6 +74,10 @@ export interface DisplayMessage {
   // Reasoning/thinking tokens streamed before the answer on thinking-model
   // turns. Ephemeral — shown live in a collapsible section, never persisted.
   reasoning?: string;
+  // Ordered process timeline (reasoning chunks interleaved with tool calls)
+  // streamed during the turn. Drives the ProcessTimeline UI. Ephemeral — built
+  // live from the stream, never persisted (absent on reloaded turns).
+  steps?: TimelineStep[];
   // Branch navigation, set only on messages backed by a persisted DB row whose
   // parent has sibling branches (created by edit/regenerate). `dbId` is the row id
   // (used to switch branches); `branchIndex`/`branchCount` drive the ‹ i/n › picker.
@@ -373,9 +404,10 @@ export function ChatProvider({ children }: { children: ReactNode }) {
       setLoadingPhase("thinking");
       setIsStreaming(true);
 
+      // Hoisted above the try so the catch can settle the streaming message it
+      // created (stop the timeline spinner / resolve in-flight tool steps).
+      let assistantId: string | null = null;
       try {
-        let assistantId: string | null = null;
-
         // Brand-new conversation: mint the chat's uuid client-side so the URL is
         // correct before the first response (the API route creates the session
         // with it). syncPublicId reconciles from the DB afterwards as a safety net.
@@ -438,8 +470,10 @@ export function ChatProvider({ children }: { children: ReactNode }) {
           (reasoning) => {
             if (cancelledRef.current || !reasoning) return;
             // Reasoning can arrive before the first answer delta — create the
-            // streaming assistant message so the "Thinking" section renders
-            // live, then extend it (mirrors the content-delta handler).
+            // streaming assistant message so the timeline renders live, then
+            // extend it (mirrors the content-delta handler). Each chunk is also
+            // coalesced into the trailing `steps` reasoning entry so reasoning ⇄
+            // tool interleaving stays in stream order.
             if (assistantId === null) {
               const id = `assistant-${Date.now()}`;
               assistantId = id;
@@ -451,6 +485,7 @@ export function ChatProvider({ children }: { children: ReactNode }) {
                   role: "assistant",
                   content: "",
                   reasoning,
+                  steps: [{ kind: "reasoning", text: reasoning }],
                   timestamp: new Date(),
                   isStreaming: true,
                 },
@@ -458,11 +493,94 @@ export function ChatProvider({ children }: { children: ReactNode }) {
             } else {
               const id = assistantId;
               setMessages((prev) =>
-                prev.map((m) =>
-                  m.id === id
-                    ? { ...m, reasoning: (m.reasoning ?? "") + reasoning }
-                    : m,
-                ),
+                prev.map((m) => {
+                  if (m.id !== id) return m;
+                  const steps = m.steps ? [...m.steps] : [];
+                  const last = steps[steps.length - 1];
+                  if (last && last.kind === "reasoning") {
+                    steps[steps.length - 1] = {
+                      ...last,
+                      text: last.text + reasoning,
+                    };
+                  } else {
+                    steps.push({ kind: "reasoning", text: reasoning });
+                  }
+                  return {
+                    ...m,
+                    reasoning: (m.reasoning ?? "") + reasoning,
+                    steps,
+                  };
+                }),
+              );
+            }
+          },
+          (toolEvent: ToolEvent) => {
+            if (cancelledRef.current) return;
+            // A tool call/result mid-turn. Ensure the streaming assistant message
+            // exists (a tool can fire before any reasoning/answer), then push the
+            // tool step or mark it done. Deliberately does NOT clear the loader —
+            // a tool call means the turn is still working (searching phase).
+            if (assistantId === null) {
+              const id = `assistant-${Date.now()}`;
+              assistantId = id;
+              setMessages((prev) => [
+                ...prev,
+                {
+                  id,
+                  role: "assistant",
+                  content: "",
+                  steps: [],
+                  timestamp: new Date(),
+                  isStreaming: true,
+                },
+              ]);
+            }
+            const id = assistantId;
+            if (toolEvent.type === "tool_call") {
+              setMessages((prev) =>
+                prev.map((m) => {
+                  if (m.id !== id) return m;
+                  const steps = m.steps ? [...m.steps] : [];
+                  steps.push({
+                    kind: "tool",
+                    toolCallId: toolEvent.id,
+                    toolName: toolEvent.name,
+                    state: "running",
+                  });
+                  return { ...m, steps };
+                }),
+              );
+            } else {
+              // tool_result — mark the matching step done and attach its output.
+              const output: ToolStepOutput = {
+                sources: Array.isArray(toolEvent.output?.sources)
+                  ? (toolEvent.output?.sources as ToolStepSource[])
+                  : undefined,
+                text:
+                  typeof toolEvent.output?.text === "string"
+                    ? toolEvent.output.text
+                    : undefined,
+              };
+              setMessages((prev) =>
+                prev.map((m) => {
+                  if (m.id !== id) return m;
+                  const steps = m.steps ? [...m.steps] : [];
+                  // Resolve the most recent STILL-RUNNING tool step with this id.
+                  // The running guard means a duplicate/colliding id can never
+                  // re-mark an already-completed card (defense for backend ids).
+                  for (let i = steps.length - 1; i >= 0; i--) {
+                    const s = steps[i];
+                    if (
+                      s.kind === "tool" &&
+                      s.toolCallId === toolEvent.id &&
+                      s.state === "running"
+                    ) {
+                      steps[i] = { ...s, state: "done", output };
+                      break;
+                    }
+                  }
+                  return { ...m, steps };
+                }),
               );
             }
           },
@@ -518,6 +636,27 @@ export function ChatProvider({ children }: { children: ReactNode }) {
         }
         setLoadingPhase("error");
         setError(err instanceof Error ? err.message : "Failed to send message");
+        // Settle the partially-streamed assistant message (if one was created)
+        // so its timeline stops streaming and any in-flight tool step resolves —
+        // otherwise the header spinner / tool card would hang after the error.
+        if (assistantId !== null) {
+          const id = assistantId;
+          setMessages((prev) =>
+            prev.map((m) =>
+              m.id === id
+                ? {
+                    ...m,
+                    isStreaming: false,
+                    steps: m.steps?.map((s) =>
+                      s.kind === "tool" && s.state === "running"
+                        ? { ...s, state: "done" }
+                        : s,
+                    ),
+                  }
+                : m,
+            ),
+          );
+        }
         setTimeout(() => setLoadingPhase("idle"), 3000);
         return false;
       } finally {
@@ -659,7 +798,20 @@ export function ChatProvider({ children }: { children: ReactNode }) {
       const hasStreaming = prev.some((m) => m.isStreaming);
       if (hasStreaming) {
         return prev.map((m) =>
-          m.isStreaming ? { ...m, isStreaming: false, isCancelled: true } : m,
+          m.isStreaming
+            ? {
+                ...m,
+                isStreaming: false,
+                isCancelled: true,
+                // Resolve any in-flight tool step so its card doesn't hang on
+                // "Running…" forever once the turn is torn down.
+                steps: m.steps?.map((s) =>
+                  s.kind === "tool" && s.state === "running"
+                    ? { ...s, state: "done" }
+                    : s,
+                ),
+              }
+            : m,
         );
       }
       return [


### PR DESCRIPTION
## Summary

Renders reasoning + tool calls as a collapsible **process timeline** on each assistant turn (clock = reasoning, tool glyph = tool card, check = Done), driven by an ordered, ephemeral `TimelineStep[]` streamed onto the turn. Auto-opens while live, auto-collapses on settle.

This is the production port of the throwaway `explore-spike`. The spike (`explore-spike` page, `/api/chat/spike` route) and the AI-SDK deps (`ai`, `@ai-sdk/react`) it pulled in are **intentionally excluded** — the production Explore keeps its hand-rolled SSE + branching data layer.

## Changes
- **`ProcessTimeline.tsx`** (new): reusable timeline — `ToolCard`, `StepIcon`, `ReasoningText`; per-row rail connector that terminates at the Done check.
- **`chat-context.tsx`**: `TimelineStep` model + `onTool` handler; reasoning coalesced into steps; running tool steps resolved on cancel/error.
- **`lib/api/chat.ts`**: forward `tool_call`/`tool_result` SSE events; **synthesize a result from accumulated deltas** if the stream ends without a `result` event (defensive — no more discarded partial answers).
- **`ChatMessage.tsx`**: render the timeline, drop the old reasoning section, allowlist link schemes (`https`/`mailto`) in the markdown renderer.
- **`graph.py`** (backend): per-iteration unique tool-call ids (`call_{iteration}_{i}`) — fixes id collisions across tool iterations.
- **`.github/pull_request_template.md`** (new): repo PR template.

## Architecture notes
- Tool steps are **ephemeral** (not persisted), exactly like reasoning. The existing parent/child branching tree, persistence, and session list are untouched — the production `/api/chat` route already forwards upstream tool bytes transparently, so no route change was needed.
- Decided against a full `useChat` migration: `useChat` manages a flat message array and can't model the branching tree the production stack relies on.

## Audit
Independent review run; triaged findings:
- **Fixed**: unique tool ids + running-guard on `tool_result` + collision-proof timeline keys; running tool steps settled on cancel/error; markdown link-scheme allowlist; stream-without-`result` fallback.
- **Verified non-issues**: RLS on `client_chat_sessions`/`client_chat_messages` (ownership policies confirmed against the live DB); `project_id` membership — the backend re-verifies via `scoped_project_ids` on every live-data tool, so a forged id returns zero data (scope hint, not a capability).

## Verification
- `bun run build` → ✓ Compiled successfully
- Biome: all new/changed files clean (the 4 `ChatMessage.tsx` findings are pre-existing on `dev`, unrelated to this change)
- `python -m py_compile graph.py` → OK

> Note: lint is a non-blocking build-only gate; no test framework configured.